### PR TITLE
Add check for loading local.env file

### DIFF
--- a/site/gatsby-site/gatsby-config.js
+++ b/site/gatsby-site/gatsby-config.js
@@ -1,4 +1,11 @@
-require('dotenv').config();
+if (process.env.NODE_ENV === 'development') {
+  require('dotenv').config({
+    path: 'local.env',
+  });
+} else {
+  require('dotenv').config();
+}
+
 const md5 = require('md5');
 
 const path = require(`path`);


### PR DESCRIPTION
This MP is proposing a solution of loading env variables on local development.
Docs: https://www.gatsbyjs.com/docs/how-to/local-development/environment-variables/

A different approach would be to have an `env.production` and `env.development` files. The disadvantage that I see with this is that the env vars will be committed on git and I think it's a safety issue. `local.env` is not committed, it's kept only locally.

So with this PR, we need to make sure:
1. it will allow local development to continue normally
2. it will not break the production environment or change the deployment process in any way