### PR TITLE
Add epoch fields to edit report forms

### DIFF
--- a/site/gatsby-site/cypress/integration/citeEdit.js
+++ b/site/gatsby-site/cypress/integration/citeEdit.js
@@ -70,7 +70,28 @@ describe('Edit report', () => {
 
     cy.contains('button', 'Submit').click();
 
-    cy.wait('@updateReport');
+    cy.wait('@updateReport').then((xhr) => {
+      expect(xhr.request.body.variables.set.authors).deep.eq(['Test Author']);
+      expect(xhr.request.body.variables.set.cloudinary_id).eq('reports/test.com/test.jpg');
+      expect(xhr.request.body.variables.set.date_downloaded).eq('2022-01-01');
+      expect(xhr.request.body.variables.set.date_modified).eq('2022-04-22');
+      expect(xhr.request.body.variables.set.date_published).eq('2022-02-02');
+      expect(xhr.request.body.variables.set.epoch_date_downloaded).eq(1640995200);
+      expect(xhr.request.body.variables.set.epoch_date_modified).eq(1650585600);
+      expect(xhr.request.body.variables.set.epoch_date_published).eq(1643760000);
+      expect(xhr.request.body.variables.set.flag).eq(null);
+      expect(xhr.request.body.variables.set.image_url).eq('https://test.com/test.jpg');
+      expect(xhr.request.body.variables.set.incident_date).eq('2022-03-03');
+      expect(xhr.request.body.variables.set.incident_id).eq(1);
+      expect(xhr.request.body.variables.set.report_number).eq(10);
+      expect(xhr.request.body.variables.set.submitters).deep.eq(['Test Submitter']);
+      expect(xhr.request.body.variables.set.tags).deep.eq(['New Tag']);
+      expect(xhr.request.body.variables.set.text).eq(
+        'Sit quo accusantium quia assumenda. Quod delectus similique labore optio quaease'
+      );
+      expect(xhr.request.body.variables.set.title).eq('Test Title');
+      expect(xhr.request.body.variables.set.url).eq('https://www.test.com/test');
+    });
 
     cy.get('div[class^="ToastContext"]')
       .contains('Incident report 10 updated successfully.')

--- a/site/gatsby-site/cypress/integration/citeEdit.js
+++ b/site/gatsby-site/cypress/integration/citeEdit.js
@@ -2,6 +2,8 @@ import { maybeIt } from '../support/utils';
 
 import updateOneIncident from '../fixtures/reports/updateOneIncident.json';
 
+import { format, getUnixTime } from 'date-fns';
+
 describe('Edit report', () => {
   const url = '/cite/edit?reportNumber=10';
 
@@ -39,8 +41,6 @@ describe('Edit report', () => {
   maybeIt('Should submit new values', () => {
     cy.login(Cypress.env('e2eUsername'), Cypress.env('e2ePassword'));
 
-    cy.clock(Date.UTC(2022, 3, 23), ['Date']);
-
     cy.visit(url);
 
     const values = {
@@ -73,13 +73,17 @@ describe('Edit report', () => {
     cy.contains('button', 'Submit').click();
 
     cy.wait('@updateReport').then((xhr) => {
+      const date_modified = format(new Date(), 'yyyy-MM-dd');
+
+      const epoch_date_modified = getUnixTime(new Date(date_modified));
+
       expect(xhr.request.body.variables.set.authors).deep.eq(['Test Author']);
       expect(xhr.request.body.variables.set.cloudinary_id).eq('reports/test.com/test.jpg');
       expect(xhr.request.body.variables.set.date_downloaded).eq('2022-01-01');
-      expect(xhr.request.body.variables.set.date_modified).eq('2022-04-22');
+      expect(xhr.request.body.variables.set.date_modified).eq(date_modified);
       expect(xhr.request.body.variables.set.date_published).eq('2022-02-02');
       expect(xhr.request.body.variables.set.epoch_date_downloaded).eq(1640995200);
-      expect(xhr.request.body.variables.set.epoch_date_modified).eq(1650585600);
+      expect(xhr.request.body.variables.set.epoch_date_modified).eq(epoch_date_modified);
       expect(xhr.request.body.variables.set.epoch_date_published).eq(1643760000);
       expect(xhr.request.body.variables.set.flag).eq(null);
       expect(xhr.request.body.variables.set.image_url).eq('https://test.com/test.jpg');

--- a/site/gatsby-site/cypress/integration/citeEdit.js
+++ b/site/gatsby-site/cypress/integration/citeEdit.js
@@ -39,6 +39,8 @@ describe('Edit report', () => {
   maybeIt('Should submit new values', () => {
     cy.login(Cypress.env('e2eUsername'), Cypress.env('e2ePassword'));
 
+    cy.clock(Date.UTC(2022, 3, 23), ['Date']);
+
     cy.visit(url);
 
     const values = {

--- a/site/gatsby-site/cypress/integration/submitted.js
+++ b/site/gatsby-site/cypress/integration/submitted.js
@@ -38,7 +38,7 @@ describe('Cite pages', () => {
     });
   });
 
-  maybeIt('Promotes a report and links it to a new incident', () => {
+  it('Promotes a report and links it to a new incident', () => {
     cy.login(Cypress.env('e2eUsername'), Cypress.env('e2ePassword'));
 
     cy.conditionalIntercept(
@@ -131,6 +131,9 @@ describe('Cite pages', () => {
         expect(report.report_number).to.eq(1545);
         expect(report.incident_id).to.eq(172);
         expect(report.ref_number).eq(1);
+        expect(report.epoch_date_downloaded).eq(1604016000);
+        expect(report.epoch_date_modified).eq(1604016000);
+        expect(report.epoch_date_published).eq(1493769600);
       });
 
     cy.wait('@relatedIncidents')

--- a/site/gatsby-site/cypress/integration/submitted.js
+++ b/site/gatsby-site/cypress/integration/submitted.js
@@ -1,5 +1,6 @@
 import { maybeIt } from '../support/utils';
 import submittedReports from '../fixtures/submissions/submitted.json';
+import { format, getUnixTime } from 'date-fns';
 
 describe('Submitted reports', () => {
   const url = '/apps/submitted';
@@ -128,12 +129,23 @@ describe('Submitted reports', () => {
     cy.wait('@insertReport')
       .its('request.body.variables.report')
       .then((report) => {
+        const date_modified = format(new Date(), 'yyyy-MM-dd');
+
+        const epoch_date_modified = getUnixTime(new Date(date_modified));
+
         expect(report.report_number).to.eq(1545);
         expect(report.incident_id).to.eq(172);
         expect(report.ref_number).eq(1);
+
+        expect(report.date_modified).eq(date_modified);
+        expect(report.date_downloaded).eq('2020-10-30');
+        expect(report.date_published).eq('2017-05-03');
+        expect(report.date_submitted).eq('2020-10-30');
+
+        expect(report.epoch_date_modified).eq(epoch_date_modified);
         expect(report.epoch_date_downloaded).eq(1604016000);
-        expect(report.epoch_date_modified).eq(1604016000);
         expect(report.epoch_date_published).eq(1493769600);
+        expect(report.epoch_date_submitted).eq(1604016000);
       });
 
     cy.wait('@relatedIncidents')

--- a/site/gatsby-site/cypress/integration/submitted.js
+++ b/site/gatsby-site/cypress/integration/submitted.js
@@ -38,7 +38,7 @@ describe('Cite pages', () => {
     });
   });
 
-  it('Promotes a report and links it to a new incident', () => {
+  maybeIt('Promotes a report and links it to a new incident', () => {
     cy.login(Cypress.env('e2eUsername'), Cypress.env('e2ePassword'));
 
     cy.conditionalIntercept(

--- a/site/gatsby-site/src/components/ReportedIncident.js
+++ b/site/gatsby-site/src/components/ReportedIncident.js
@@ -138,9 +138,10 @@ const ReportedIncident = ({ incident: report }) => {
 
     newReport.date_modified = format(new Date(), 'yyyy-MM-dd');
 
+    newReport.epoch_date_modified = getUnixTime(new Date(newReport.date_modified));
     newReport.epoch_date_published = getUnixTime(new Date(newReport.date_published));
     newReport.epoch_date_downloaded = getUnixTime(new Date(newReport.date_downloaded));
-    newReport.epoch_date_modified = getUnixTime(new Date(newReport.date_modified));
+    newReport.epoch_date_submitted = getUnixTime(new Date(newReport.date_submitted));
 
     await insertReport({ variables: { report: newReport } });
 

--- a/site/gatsby-site/src/components/ReportedIncident.js
+++ b/site/gatsby-site/src/components/ReportedIncident.js
@@ -21,6 +21,7 @@ import { gql, useLazyQuery, useMutation } from '@apollo/client';
 import { INSERT_INCIDENT } from '../graphql/incidents';
 import { DELETE_SUBMISSION } from '../graphql/submissions';
 import useToastContext, { SEVERITY } from 'hooks/useToast';
+import { format, getUnixTime } from 'date-fns';
 
 const ListedGroup = ({ item, keysToRender }) => {
   return (
@@ -134,6 +135,12 @@ const ReportedIncident = ({ incident: report }) => {
     }
 
     newReport.ref_number = lastRefNumber + 1;
+
+    newReport.date_modified = format(new Date(), 'yyyy-MM-dd');
+
+    newReport.epoch_date_published = getUnixTime(new Date(newReport.date_published));
+    newReport.epoch_date_downloaded = getUnixTime(new Date(newReport.date_downloaded));
+    newReport.epoch_date_modified = getUnixTime(new Date(newReport.date_modified));
 
     await insertReport({ variables: { report: newReport } });
 

--- a/site/gatsby-site/src/graphql/reports.js
+++ b/site/gatsby-site/src/graphql/reports.js
@@ -29,10 +29,10 @@ export const UPDATE_REPORT = gql`
       submitters
       date_published
       date_downloaded
-      epoch_date_downloaded
-      epoch_date_modified
       date_modified
       epoch_date_published
+      epoch_date_downloaded
+      epoch_date_modified
       image_url
       incident_id
       text

--- a/site/gatsby-site/src/pages/cite/edit.js
+++ b/site/gatsby-site/src/pages/cite/edit.js
@@ -12,14 +12,7 @@ import {
 } from '../../graphql/reports';
 import { FIND_INCIDENT } from '../../graphql/incidents';
 import { useMutation, useQuery } from '@apollo/client/react/hooks';
-
-function stringToEpoch(dateString) {
-  let someDate = new Date(dateString);
-
-  let epoch = Math.floor(someDate.getTime() / 1000);
-
-  return epoch;
-}
+import { format, getUnixTime } from 'date-fns';
 
 function EditCitePage(props) {
   const [report, setReport] = useState();
@@ -65,20 +58,12 @@ function EditCitePage(props) {
       if (typeof values.submitters === 'string') {
         values.submitters = values.submitters.split(',').map((s) => s.trim());
       }
-      values.epoch_date_downloaded = stringToEpoch(values.date_downloaded);
-      const today = new Date();
 
-      const dd = String(today.getDate()).padStart(2, '0');
+      values.date_modified = format(new Date(), 'yyyy-MM-dd');
 
-      const mm = String(today.getMonth() + 1).padStart(2, '0'); //January is 0!
-
-      const yyyy = today.getFullYear();
-
-      const todayStr = yyyy + '-' + mm + '-' + dd;
-
-      values.epoch_date_modified = stringToEpoch(todayStr);
-      values.date_modified = todayStr;
-      values.epoch_date_published = stringToEpoch(values.date_published);
+      values.epoch_date_downloaded = getUnixTime(new Date(values.date_downloaded));
+      values.epoch_date_published = getUnixTime(new Date(values.date_published));
+      values.epoch_date_modified = getUnixTime(new Date(values.date_modified));
 
       const updated = { ...values, __typename: undefined };
 


### PR DESCRIPTION
This makes sure that `date_*` and `epoch_date_*` fields are handled properly. 

Especially when promoting reports that the `epoch_date_*` fields were missing.