### PR TITLE
This plugin is installed automatically now.

### DIFF
--- a/site/gatsby-site/netlify.toml
+++ b/site/gatsby-site/netlify.toml
@@ -7,9 +7,6 @@ CYPRESS_CACHE_FOLDER = "./node_modules/CypressBinary"
 TERM = "xterm"
 
 [[plugins]]
-package = "@netlify/plugin-gatsby"
-
-[[plugins]]
   package = "netlify-plugin-cypress"
   [plugins.inputs.postBuild]
     enable = true


### PR DESCRIPTION
Part of upgrading to the new plugin is removing it from `netlify.toml`:

<img width="917" alt="image" src="https://user-images.githubusercontent.com/1172479/164879521-b42fe3dd-51fa-4f7f-9d8f-4a0f15841b94.png">
