### PR TITLE
Add headerTitle to link

### DIFF
--- a/site/gatsby-site/src/components/ui/Header.js
+++ b/site/gatsby-site/src/components/ui/Header.js
@@ -130,12 +130,12 @@ const Header = () => {
                         alt={'logo'}
                       />
                     </HideOnDesktop>
+                    <div className="divider hiddenMobile"></div>
+                    <div
+                      className={'headerTitle displayInline'}
+                      dangerouslySetInnerHTML={{ __html: headerTitle }}
+                    />
                   </Link>
-                  <li className="divider hiddenMobile"></li>
-                  <div
-                    className={'headerTitle displayInline'}
-                    dangerouslySetInnerHTML={{ __html: headerTitle }}
-                  />
                 </div>
                 <HeaderIconsContainer>
                   <li className="divider hiddenMobile"></li>


### PR DESCRIPTION
This fixes the first item of [#613](https://github.com/responsible-ai-collaborative/aiid/issues/613) where the site title in the header was not a link to the homepage.

The divider is changed from a `<li>` to a `<div>` because when inside of a `<Link>` it was displaying with a bullet to the left, and in any case it doesn't seem like a list item semantically.