### PR TITLE
Equalize space above and below sidebar tree ul

### DIFF
--- a/site/gatsby-site/src/components/sidebar/index.js
+++ b/site/gatsby-site/src/components/sidebar/index.js
@@ -84,7 +84,7 @@ const Divider = styled((props) => (
   </li>
 ))`
   list-style: none;
-  padding: 0.5rem 0;
+  padding: 16px 0;
 
   hr {
     margin: 0;

--- a/site/gatsby-site/src/global.css
+++ b/site/gatsby-site/src/global.css
@@ -421,7 +421,7 @@ blockquote {
 }
 
 .sideBarUL {
-  margin-top: 32px;
+  margin-top: 16px;
   padding-left: 0;
 }
 


### PR DESCRIPTION
This fixes item 3 of #617, where there was too much space above the sidebar tree compared to below. Set to `16px`, half the height of the list items.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img height="300" src="https://user-images.githubusercontent.com/25443411/169437604-9f6da497-63c3-4aa4-b673-3bc6d24552cb.png"/></td>

<td><img height="300" src="https://user-images.githubusercontent.com/25443411/169437614-3108956f-31fc-4656-a7d8-0d43678dba22.png"/></td>
</tr>
</table>
