### PR TITLE
Add type="date" to date fields on IncidentReportForm.js

### DIFF
--- a/site/gatsby-site/src/components/forms/IncidentReportForm.js
+++ b/site/gatsby-site/src/components/forms/IncidentReportForm.js
@@ -257,6 +257,7 @@ const IncidentReportForm = ({ incident, onUpdate, onSubmit, onDelete = null }) =
       <TextInputGroup
         name="incident_date"
         label="Incident Date"
+        type="date"
         placeholder="YYYY-MM-DD"
         className="mt-3"
         {...TextInputGroupProps}
@@ -264,6 +265,7 @@ const IncidentReportForm = ({ incident, onUpdate, onSubmit, onDelete = null }) =
       <TextInputGroup
         name="date_published"
         label="Date Published"
+        type="date"
         placeholder="YYYY-MM-DD"
         className="mt-3"
         {...TextInputGroupProps}
@@ -271,6 +273,7 @@ const IncidentReportForm = ({ incident, onUpdate, onSubmit, onDelete = null }) =
       <TextInputGroup
         name="date_downloaded"
         label="Date Downloaded"
+        type="date"
         placeholder="YYYY-MM-DD"
         className="mt-3"
         {...TextInputGroupProps}


### PR DESCRIPTION
Per #627, adds the browser's default date picker (as used in IncidentForm.js) to text fields on the submission form.