### PR TITLE
Ladder 4 editors field

### DIFF
--- a/mongo.md
+++ b/mongo.md
@@ -43,6 +43,7 @@ People
 
 * `submitters`: Array(string) # People that submitted the incident report
 * `authors`: Array(string) # People that wrote the incident report
+* `editors`: Array(string) # The editors of the incident. Editors are listed in the incident citation and can promote user-submitted records to incident reports.
 
 Text
 

--- a/site/gatsby-site/cypress/fixtures/incidents/incident.json
+++ b/site/gatsby-site/cypress/fixtures/incidents/incident.json
@@ -11,7 +11,7 @@
             "__typename": "Incident",
             "date": "2015-05-19",
             "description": "YouTube’s content filtering and recommendation algorithms exposed children to disturbing and inappropriate videos.",
-            "editors": "Sean McGregor",
+            "editors": ["Sean McGregor"],
             "incident_id": 1,
             "reports": [
                 {

--- a/site/gatsby-site/cypress/fixtures/incidents/incident.json
+++ b/site/gatsby-site/cypress/fixtures/incidents/incident.json
@@ -11,6 +11,7 @@
             "__typename": "Incident",
             "date": "2015-05-19",
             "description": "YouTube’s content filtering and recommendation algorithms exposed children to disturbing and inappropriate videos.",
+            "editors": "Sean McGregor",
             "incident_id": 1,
             "reports": [
                 {

--- a/site/gatsby-site/cypress/integration/cite.js
+++ b/site/gatsby-site/cypress/integration/cite.js
@@ -50,6 +50,19 @@ describe('Cite pages', () => {
       });
   });
 
+  it('Should show the incident stats table', () => {
+    cy.visit(url);
+    cy.get('[data-cy=incident-stats]').should('exist');
+  });
+
+  it('Should show editors in the stats table', () => {
+    cy.visit(url);
+    cy.get('[data-cy=incident-stats] > * > *')
+      .contains('Editors')
+      .parents('*')
+      .contains('Sean McGregor');
+  });
+
   maybeIt('Should show an edit link to users with the appropriate role', {}, () => {
     cy.login(Cypress.env('e2eUsername'), Cypress.env('e2ePassword'));
 

--- a/site/gatsby-site/cypress/integration/incidents.js
+++ b/site/gatsby-site/cypress/integration/incidents.js
@@ -36,6 +36,8 @@ describe('Incidents', () => {
       .find('[type="text"]')
       .type('Test Deployer{enter}');
 
+    cy.contains('label', 'Editors').next().find('[type="text"]').type('Test Editor{enter}');
+
     cy.conditionalIntercept(
       '**/graphql',
       (req) => req.body.operationName == 'UpdateIncident',
@@ -57,6 +59,7 @@ describe('Incidents', () => {
       ]);
       expect(xhr.request.body.variables.set.AllegedDeveloperOfAISystem).to.deep.eq(['YouTube']);
       expect(xhr.request.body.variables.set.AllegedHarmedOrNearlyHarmedParties).to.deep.eq([]);
+      expect(xhr.request.body.variables.set.editors).to.deep.eq(['Sean McGregor', 'Test Editor']);
     });
 
     cy.get('div[class^="ToastContext"]')

--- a/site/gatsby-site/migrations/2022.05.19T14.38.40.set-sean-as-editor.js
+++ b/site/gatsby-site/migrations/2022.05.19T14.38.40.set-sean-as-editor.js
@@ -1,0 +1,24 @@
+const config = require('../config');
+
+/**
+ * @type {import('umzug').MigrationFn<any>}
+ * @param {{context: {client: import('mongodb').MongoClient}}} context
+ */
+exports.up = async ({ context: { client } }) => {
+  const collection = client.db(config.realm.production_db.db_name).collection('incidents');
+
+  await collection.updateMany(
+    { editors: { $exists: false } },
+    { $set: { editors: ['Sean McGregor'] } }
+  );
+};
+
+/**
+ * @type {import('umzug').MigrationFn<any>}
+ * @param {{context: {client: import('mongodb').MongoClient}}} context
+ */
+exports.down = async ({ context: { client } }) => {
+  const collection = client.db(config.realm.production_db.db_name).collection('incidents');
+
+  await collection.updateMany({ editors: ['Sean McGregor'] }, { $unset: { editors: [] } });
+};

--- a/site/gatsby-site/page-creators/createCitiationPages.js
+++ b/site/gatsby-site/page-creators/createCitiationPages.js
@@ -60,6 +60,7 @@ const createCitiationPages = async (graphql, createPage) => {
             incident_id
             date
             reports
+            editors
           }
         }
 

--- a/site/gatsby-site/src/components/BibTex.js
+++ b/site/gatsby-site/src/components/BibTex.js
@@ -3,7 +3,7 @@ import { Button, Modal } from 'react-bootstrap';
 import { getFormattedName } from '../utils/typography';
 import { format } from 'date-fns';
 
-const BibTex = ({ nodes, incidentDate, incident_id }) => {
+const BibTex = ({ nodes, incidentDate, incident_id, editors }) => {
   const [show, setShow] = useState(false);
 
   const handleClose = () => setShow(false);
@@ -22,6 +22,14 @@ const BibTex = ({ nodes, incidentDate, incident_id }) => {
   // Only return the earliest submitter
   let submitterCite = getFormattedName(docs[0]['submitters'][0]);
 
+  const firstEditor = editors[0];
+
+  const nameFragments = firstEditor.split(' ');
+
+  const editorLastName = nameFragments[nameFragments.length - 1];
+
+  const editorFirstName = nameFragments[0];
+
   const jsx = (
     <code>
       @article &#123;
@@ -30,7 +38,7 @@ const BibTex = ({ nodes, incidentDate, incident_id }) => {
       <br />
       &nbsp; &nbsp; &nbsp; &nbsp; author = &#123;{submitterCite}&#125;,
       <br />
-      &nbsp; &nbsp; &nbsp; &nbsp; editor = &#123;McGregor, Sean&#125;,
+      &nbsp; &nbsp; &nbsp; &nbsp; editor = &#123;{editorLastName}, {editorFirstName}&#125;,
       <br />
       &nbsp; &nbsp; &nbsp; &nbsp; journal = &#123;AI Incident Database&#125;,
       <br />

--- a/site/gatsby-site/src/components/BibTex.js
+++ b/site/gatsby-site/src/components/BibTex.js
@@ -22,12 +22,13 @@ const BibTex = ({ nodes, incidentDate, incident_id, editors }) => {
   // Only return the earliest submitter
   let submitterCite = getFormattedName(docs[0]['submitters'][0]);
 
-  /* eslint-disable padding-line-between-statements */
   const firstEditor = editors[0];
+
   const nameFragments = firstEditor.split(' ');
+
   const editorLastName = nameFragments[nameFragments.length - 1];
+
   const editorFirstName = nameFragments[0];
-  /* eslint-enable padding-line-between-statements */
 
   const jsx = (
     <code>

--- a/site/gatsby-site/src/components/BibTex.js
+++ b/site/gatsby-site/src/components/BibTex.js
@@ -22,13 +22,12 @@ const BibTex = ({ nodes, incidentDate, incident_id, editors }) => {
   // Only return the earliest submitter
   let submitterCite = getFormattedName(docs[0]['submitters'][0]);
 
+  /* eslint-disable padding-line-between-statements */
   const firstEditor = editors[0];
-
   const nameFragments = firstEditor.split(' ');
-
   const editorLastName = nameFragments[nameFragments.length - 1];
-
   const editorFirstName = nameFragments[0];
+  /* eslint-enable padding-line-between-statements */
 
   const jsx = (
     <code>

--- a/site/gatsby-site/src/components/cite/Citation.js
+++ b/site/gatsby-site/src/components/cite/Citation.js
@@ -2,7 +2,7 @@ import { format } from 'date-fns';
 import React, { useEffect, useState } from 'react';
 import { getFormattedName } from '../../utils/typography';
 
-const Citation = ({ nodes, incidentDate, incident_id }) => {
+const Citation = ({ nodes, incidentDate, incident_id, editors }) => {
   let docs = [];
 
   nodes.forEach(({ node }) => docs.push(node));
@@ -32,10 +32,19 @@ const Citation = ({ nodes, incidentDate, incident_id }) => {
     setRetrievalString(text);
   }, []);
 
+  const firstEditor = editors[0];
+
+  const nameFragments = firstEditor.split(' ');
+
+  const editorLastName = nameFragments[nameFragments.length - 1];
+
+  const editorFirstNameInitial = nameFragments[0][0] + '.';
+
   return (
     <>
-      {submitterCite}. ({incidentDate}) Incident Number {docs[0]['incident_id']}. in McGregor, S.
-      (ed.) <em>Artificial Intelligence Incident Database.</em> Responsible AI Collaborative.{' '}
+      {submitterCite}. ({incidentDate}) Incident Number {docs[0]['incident_id']}. in{' '}
+      {editorLastName}, {editorFirstNameInitial} (ed.){' '}
+      <em>Artificial Intelligence Incident Database.</em> Responsible AI Collaborative.{' '}
       {retrievalString}
     </>
   );

--- a/site/gatsby-site/src/components/cite/IncidentStatsCard.js
+++ b/site/gatsby-site/src/components/cite/IncidentStatsCard.js
@@ -21,7 +21,7 @@ const IncidentCardContainer = styled.div`
   }
 `;
 
-const IncidentStatsCard = ({ incidentId, reportCount, incidentDate }) => {
+const IncidentStatsCard = ({ incidentId, reportCount, incidentDate, editors }) => {
   const STATS = [
     {
       key: 'incidentId',
@@ -35,6 +35,10 @@ const IncidentStatsCard = ({ incidentId, reportCount, incidentDate }) => {
       key: 'incidentDate',
       label: 'Incident Date',
     },
+    {
+      key: 'editors',
+      label: 'Editors',
+    },
   ];
 
   if (reportCount === 0) {
@@ -45,6 +49,7 @@ const IncidentStatsCard = ({ incidentId, reportCount, incidentDate }) => {
     incidentId,
     reportCount,
     incidentDate,
+    editors,
   };
 
   return (

--- a/site/gatsby-site/src/components/incidents/IncidentForm.js
+++ b/site/gatsby-site/src/components/incidents/IncidentForm.js
@@ -24,7 +24,7 @@ function IncidentForm() {
         <Form.Control.Feedback type="invalid">{errors.title}</Form.Control.Feedback>
       </Form.Group>
 
-      <Form.Group>
+      <Form.Group className="mt-3">
         <Form.Label>Description</Form.Label>
         <Form.Control
           type="text"
@@ -54,6 +54,10 @@ function IncidentForm() {
       <Form.Group className="mt-3">
         <Form.Label>Alleged Harmed or Nearly Harmed Parties</Form.Label>
         <TagsControl name="AllegedHarmedOrNearlyHarmedParties" />
+      </Form.Group>
+      <Form.Group className="mt-3">
+        <Form.Label>Editors</Form.Label>
+        <TagsControl name="editors" />
       </Form.Group>
     </FormikForm>
   );

--- a/site/gatsby-site/src/graphql/incidents.js
+++ b/site/gatsby-site/src/graphql/incidents.js
@@ -6,6 +6,7 @@ export const FIND_INCIDENT = gql`
       incident_id
       title
       description
+      editors
       date
       AllegedDeployerOfAISystem
       AllegedDeveloperOfAISystem
@@ -23,6 +24,7 @@ export const FIND_INCIDENTS = gql`
       incident_id
       title
       description
+      editors
       date
       AllegedDeployerOfAISystem
       AllegedDeveloperOfAISystem
@@ -40,6 +42,7 @@ export const UPDATE_INCIDENT = gql`
       incident_id
       title
       description
+      editors
       date
       AllegedDeployerOfAISystem
       AllegedDeveloperOfAISystem

--- a/site/gatsby-site/src/templates/cite.js
+++ b/site/gatsby-site/src/templates/cite.js
@@ -118,6 +118,7 @@ function CitePage(props) {
                   nodes={incidentReports}
                   incidentDate={incident.date}
                   incident_id={incident.incident_id}
+                  editors={incident.editors}
                 />
               </div>
             </CardContainer>
@@ -191,6 +192,7 @@ function CitePage(props) {
                   nodes={incidentReports}
                   incidentDate={incident.date}
                   incident_id={incident.incident_id}
+                  editors={incident.editors}
                 />
               </div>
             </CardContainer>

--- a/site/gatsby-site/src/templates/cite.js
+++ b/site/gatsby-site/src/templates/cite.js
@@ -127,7 +127,7 @@ function CitePage(props) {
 
         <Row className="mt-4">
           <Col>
-            <StatsContainer>
+            <StatsContainer data-cy={'incident-stats'}>
               <IncidentStatsCard
                 {...{
                   incidentId: incident.incident_id,

--- a/site/gatsby-site/src/templates/cite.js
+++ b/site/gatsby-site/src/templates/cite.js
@@ -132,6 +132,7 @@ function CitePage(props) {
                   incidentId: incident.incident_id,
                   reportCount: incidentReports.length,
                   incidentDate: incident.date,
+                  editors: incident.editors.join(', '),
                 }}
               />
             </StatsContainer>

--- a/site/realm/data_sources/mongodb-atlas/aiidprod/incidents/schema.json
+++ b/site/realm/data_sources/mongodb-atlas/aiidprod/incidents/schema.json
@@ -27,6 +27,12 @@
         "description": {
             "bsonType": "string"
         },
+        "editors": {
+            "bsonType": "array",
+            "items": {
+                "bsonType": "string"
+            }
+        },
         "incident_id": {
             "bsonType": "int"
         },

--- a/site/realm/data_sources/mongodb-atlas/aiidprod/incidents/schema.json
+++ b/site/realm/data_sources/mongodb-atlas/aiidprod/incidents/schema.json
@@ -46,5 +46,11 @@
             "bsonType": "string"
         }
     },
+    "required": [
+      "_id",
+      "incident_id",
+      "editors", 
+      "reports"
+    ],
     "title": "incident"
 }

--- a/site/realm/data_sources/mongodb-atlas/aiidprod/incidents/schema.json
+++ b/site/realm/data_sources/mongodb-atlas/aiidprod/incidents/schema.json
@@ -47,7 +47,6 @@
         }
     },
     "required": [
-      "_id",
       "incident_id",
       "editors", 
       "reports"

--- a/site/realm/functions/promoteSubmissionToReport.js
+++ b/site/realm/functions/promoteSubmissionToReport.js
@@ -18,6 +18,7 @@ exports = async (input) => {
       title: submission.title,
       incident_id: lastIncident.incident_id + 1,
       reports: [],
+      editors: ["Sean McGregor"],
       date: submission.incident_date,
     }
     


### PR DESCRIPTION
Per #620,

- Adds an `editors` field to the `incidents` collection scheme
- Updates the MongoDB doc to include the new field
- Adds the field to those GraphQL queries and mutations in incidents.js that included every field.
- Adds a migration making Sean the editor for all incidents where one is not set.
- Adds the editor to the incidents table in `/cite` and replaces Sean in the citations with whoever the first editor is.
- In the incidents edit form, adds a field for editors
- Adds a test for the editor appearing in the incidents table.