### PR TITLE
Make id input non-scrollable

### DIFF
--- a/site/gatsby-site/src/components/incidents/IncidentIdField.js
+++ b/site/gatsby-site/src/components/incidents/IncidentIdField.js
@@ -34,6 +34,7 @@ export default function IncidentIdField({ name, placeHolder = '', className = ''
         value={value}
         onChange={onChange}
         onBlur={onBlur}
+        onWheel={(event) => event.currentTarget.blur()}
         isInvalid={!!error}
         placeholder={placeHolder}
       />


### PR DESCRIPTION
This solves #633. An "id" input type is added for non-scrolling numeric inputs. The "number" input type is left alone, as the default browser behavior is potentially desirable when the values represent quantities rather than IDs.