### PR TITLE
Disable default submit behavior

### DIFF
--- a/site/gatsby-site/src/components/forms/IncidentReportForm.js
+++ b/site/gatsby-site/src/components/forms/IncidentReportForm.js
@@ -204,7 +204,13 @@ const IncidentReportForm = ({ incident, onUpdate, onSubmit, onDelete = null }) =
   };
 
   return (
-    <Form onSubmit={handleSubmit} className="mx-auto" data-cy="report">
+    <Form
+      onSubmit={(event) => {
+        event.preventDefault();
+      }}
+      className="mx-auto"
+      data-cy="report"
+    >
       <TextInputGroup
         name="url"
         label="Report Address"
@@ -332,7 +338,7 @@ const IncidentReportForm = ({ incident, onUpdate, onSubmit, onDelete = null }) =
           into the database after enough incidents are pending.
         </p>
       )}
-      <Button className="mt-3" variant="primary" type="submit" disabled={isSubmitting}>
+      <Button className="mt-3" variant="primary" onClick={handleSubmit} disabled={isSubmitting}>
         Submit
       </Button>
       {onDelete && (


### PR DESCRIPTION
This solves #624. The submit button semantically ceases to be of `type="submit"`, which is somewhat inelegant. However the alternative, as far as I can tell, would be to add event overrides for every form input type, which seems more error-prone. You can still submit using the keyboard alone by tabbing to focus the submit button and then pressing enter.