### PR TITLE
Remove float: right from sidebar external link icon

### DIFF
--- a/site/gatsby-site/src/components/sidebar/index.js
+++ b/site/gatsby-site/src/components/sidebar/index.js
@@ -39,8 +39,8 @@ const ListItem = styled(({ className, active, level, ...props }) => {
       background-color: #fff;
     `} // external link icon
     svg {
-      float: right;
-      margin-right: 1rem;
+      margin-left: 1ch;
+      vertical-align: top;
     }
   }
 `;


### PR DESCRIPTION
Solves item 4 of #617.

<table>
  <tr><th>Before</th><th>After</th>
  <tr>
    <td><img width="200" src="https://user-images.githubusercontent.com/25443411/170309881-cdde70b7-4375-4a89-9085-f29b426d50db.png"></td>
    <td><img width="200" src="https://user-images.githubusercontent.com/25443411/170309969-6d9b5474-2f1d-4bd6-bde9-2173a4288d92.png"></td>
  </tr>
</table>





