### PR TITLE
Discover ux hit actions

### DIFF
--- a/site/gatsby-site/src/components/discover/Filters.js
+++ b/site/gatsby-site/src/components/discover/Filters.js
@@ -2,10 +2,7 @@ import React from 'react';
 import REFINEMENT_LISTS from 'components/discover/REFINEMENT_LISTS';
 import { Row, Col } from 'react-bootstrap';
 import Filter from './Filter';
-import Stats from './Stats';
 import styled from 'styled-components';
-import ClearFilters from './ClearFilters';
-import DisplayModeSwitch from './DisplayModeSwitch';
 
 const StyledFilter = styled(Filter)`
   .dropdown-toggle {
@@ -22,15 +19,6 @@ function Filters() {
             <StyledFilter type={list.type} {...list} />
           </Col>
         ))}
-      </Row>
-      <Row className="d-none d-md-flex">
-        <Col className="d-flex align-items-center">
-          <Stats />
-          <DisplayModeSwitch />
-        </Col>
-        <Col className="d-flex justify-content-end">
-          <ClearFilters>Clear Filters</ClearFilters>
-        </Col>
       </Row>
     </>
   );

--- a/site/gatsby-site/src/components/discover/Hits.js
+++ b/site/gatsby-site/src/components/discover/Hits.js
@@ -85,7 +85,7 @@ const Hits = ({
   const [display] = useQueryParam('display', DisplayModeEnumParam);
 
   return (
-    <HitsContainer className={`container-xl mt-4 ${display}`}>
+    <HitsContainer className={`container-xl ${display}`}>
       {hits.map((hit) => (
         <Hit
           key={hit.objectID}

--- a/site/gatsby-site/src/components/discover/hitTypes/Compact.js
+++ b/site/gatsby-site/src/components/discover/hitTypes/Compact.js
@@ -1,47 +1,26 @@
 import React from 'react';
 import { Card } from 'react-bootstrap';
-import { Highlight, Snippet } from 'react-instantsearch-dom';
 import { Image } from 'utils/cloudinary';
 import styled from 'styled-components';
 import { fill } from '@cloudinary/base/actions/resize';
 import md5 from 'md5';
-import { Link } from 'gatsby';
 import Actions from '../Actions';
+import { HeaderTitle, SourceDomainSubtitle } from './shared';
 
-const BlockQuote = styled.blockquote`
-  color: var(--bs-gray-400);
-  .ais-Snippet-highlighted {
-    background: rgba(237, 74, 0, 0.98);
+const StyledCard = styled(Card)`
+  height: 240px;
+  overflow: hidden;
+
+  :hover {
+    background: #00000000;
   }
-`;
 
-const TitleHighlight = styled(Highlight)`
-  font-weight: bold;
-`;
-
-const IncidentCardImage = styled(Image)`
-  object-fit: cover;
-  position: absolute;
-  z-index: 0;
-  width: 100%;
-  height: 100%;
-  bottom: 0;
-  left: 0;
+  animation: all 0s;
 `;
 
 const StyledCardBody = styled(Card.Body)`
   position: relative;
   padding: 0;
-`;
-
-const StyledSubTitle = styled(Card.Subtitle)`
-  color: var(--bs-gray-400);
-`;
-
-const StyledCardTitle = styled(Card.Title)`
-  a {
-    color: #fff;
-  }
 `;
 
 const Contents = styled.div`
@@ -55,15 +34,37 @@ const Contents = styled.div`
   min-height: 40%;
 `;
 
-const StyledCard = styled(Card)`
-  height: 240px;
-  overflow: hidden;
+const IncidentCardImage = styled(Image)`
+  object-fit: cover;
+  position: absolute;
+  z-index: 0;
+  width: 100%;
+  height: 100%;
+  bottom: 0;
+  left: 0;
+`;
 
-  :hover {
-    background: #00000000;
+const StyledHeaderTitle = styled(HeaderTitle)`
+  a {
+    color: white !important;
   }
+  a:hover {
+    opacity: 0.9;
+  }
+  font-size: 1rem;
+  * {
+    font-size: 1rem;
+  }
+`;
 
-  animation: all 0s;
+const StyledSubTitle = styled(SourceDomainSubtitle)`
+  color: var(--bs-gray-400);
+  :hover {
+    opacity: 0.9;
+  }
+  a:hover {
+    color: var(--bs-gray-400);
+  }
 `;
 
 export default function Compact({
@@ -77,36 +78,8 @@ export default function Compact({
     <StyledCard>
       <StyledCardBody className="d-flex flex-column ">
         <Contents className="ps-4 pe-4 pt-3">
-          {item._snippetResult.text.matchLevel === 'full' ? (
-            <>
-              <StyledCardTitle>
-                <Link
-                  to={`/cite/${item.incident_id}#r${item.mongodb_id}`}
-                  className="text-decoration-none"
-                >
-                  <TitleHighlight hit={item} attribute="title" className="h6" />
-                </Link>
-              </StyledCardTitle>
-              <BlockQuote className="mt-4 small">
-                <Snippet attribute="text" hit={item} />
-              </BlockQuote>
-            </>
-          ) : (
-            <>
-              <StyledCardTitle>
-                <Link
-                  to={`/cite/${item.incident_id}#${item.mongodb_id}`}
-                  className="text-decoration-none"
-                >
-                  <TitleHighlight hit={item} attribute="title" className="h6" />
-                </Link>
-              </StyledCardTitle>
-              <StyledSubTitle className="my-2 small">
-                {item.source_domain} &middot;{' '}
-                {item.date_published ? item.date_published.substring(0, 4) : 'Needs publish date'}
-              </StyledSubTitle>
-            </>
-          )}
+          <StyledHeaderTitle item={item} />
+          <StyledSubTitle item={item} className="my-2 small" />
         </Contents>
 
         <IncidentCardImage

--- a/site/gatsby-site/src/components/discover/hitTypes/Details.js
+++ b/site/gatsby-site/src/components/discover/hitTypes/Details.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Card } from 'react-bootstrap';
-import { Highlight, Snippet } from 'react-instantsearch-dom';
 import { Image } from 'utils/cloudinary';
 import styled from 'styled-components';
 import { fill } from '@cloudinary/base/actions/resize';
@@ -8,6 +7,8 @@ import { fill } from '@cloudinary/base/actions/resize';
 import md5 from 'md5';
 import { navigate } from 'gatsby';
 import Actions from '../Actions';
+
+import { SourceDomainSubtitle, HeaderTitle } from './shared';
 
 const IncidentCardImage = styled(Image)`
   height: ${({ height }) => height};
@@ -19,10 +20,6 @@ const StyledLabel = styled.p`
   margin: 0.6em 0;
 `;
 
-const TitleHighlight = styled(Highlight)`
-  font-weight: bold;
-`;
-
 export default function Details({
   item,
   authorsModal,
@@ -30,30 +27,22 @@ export default function Details({
   flagReportModal,
   toggleFilterByIncidentId,
 }) {
+  console.log(item);
   return (
     <Card className="h-100" data-cy={item.mongodb_id}>
-      <IncidentCardImage
-        className="card-img-top"
-        publicID={item.cloudinary_id ? item.cloudinary_id : `legacy/${md5(item.image_url)}`}
-        alt={item.title}
-        height="240px"
-        transformation={fill().height(480)}
-      />
+      <a href={'/cite/' + item.incident_id + '#r' + item.objectID}>
+        <IncidentCardImage
+          className="card-img-top"
+          publicID={item.cloudinary_id ? item.cloudinary_id : `legacy/${md5(item.image_url)}`}
+          alt={item.title}
+          height="240px"
+          transformation={fill().height(480)}
+        />
+      </a>
       <Card.Body className="d-flex flex-column ">
-        <Card.Title>
-          <TitleHighlight hit={item} attribute="title" />
-        </Card.Title>
+        <HeaderTitle item={item} />
 
-        <Card.Subtitle className="mb-2 text-muted">
-          {item.source_domain} &middot;{' '}
-          {item.date_published ? item.date_published.substring(0, 4) : 'Needs publish date'}
-        </Card.Subtitle>
-
-        {item._snippetResult.text.matchLevel === 'full' && (
-          <blockquote className="mt-4">
-            <Snippet attribute="text" hit={item} />
-          </blockquote>
-        )}
+        <SourceDomainSubtitle item={item} className="mb-2 text-muted" />
 
         <Card.Text className="flex-fill">{item.text.substr(0, 400) + '...'}</Card.Text>
 
@@ -63,7 +52,7 @@ export default function Details({
               type="button"
               className="btn btn-secondary btn-sm w-100"
               onClick={() => {
-                navigate(`/cite/${item.incident_id}#r${item.mongodb_id}`);
+                navigate(`/cite/${item.incident_id}`);
               }}
             >
               <StyledLabel>Show Details on Incident #{item.incident_id}</StyledLabel>

--- a/site/gatsby-site/src/components/discover/hitTypes/List.js
+++ b/site/gatsby-site/src/components/discover/hitTypes/List.js
@@ -1,21 +1,15 @@
 import React, { useState } from 'react';
 import { Card, Button } from 'react-bootstrap';
-import { Highlight, Snippet } from 'react-instantsearch-dom';
 import { Image } from 'utils/cloudinary';
 import styled from 'styled-components';
 import { fill } from '@cloudinary/base/actions/resize';
-import md5 from 'md5';
 import Actions from '../Actions';
 import { getParagraphs } from 'utils/typography';
+import { HeaderTitle, SourceDomainSubtitle } from './shared';
+import md5 from 'md5';
 
-const IncidentCardImage = styled(Image)`
-  width: 120px;
-  height: 80px;
-  object-fit: cover;
-`;
-
-const TitleHighlight = styled(Highlight)`
-  font-weight: bold;
+const StyledCard = styled(Card)`
+  overflow: hidden;
 `;
 
 const StyledCardBody = styled(Card.Body)``;
@@ -24,8 +18,10 @@ const Contents = styled.div`
   display: flex;
 `;
 
-const StyledCard = styled(Card)`
-  overflow: hidden;
+const IncidentCardImage = styled(Image)`
+  width: 120px;
+  height: 80px !important;
+  object-fit: cover;
 `;
 
 const Text = styled.div``;
@@ -52,20 +48,9 @@ export default function Details({
             transformation={fill().height(320)}
           />
           <Text>
-            <Card.Title>
-              <TitleHighlight hit={item} attribute="title" />
-            </Card.Title>
+            <HeaderTitle item={item} />
 
-            <Card.Subtitle className="mb-2 text-muted">
-              {item.source_domain} &middot;{' '}
-              {item.date_published ? item.date_published.substring(0, 4) : 'Needs publish date'}
-            </Card.Subtitle>
-
-            {item._snippetResult.text.matchLevel === 'full' && (
-              <blockquote className="mt-4">
-                <Snippet attribute="text" hit={item} />
-              </blockquote>
-            )}
+            <SourceDomainSubtitle item={item} className="mb-2 text-muted" />
 
             <ActionsContainer className="d-flex justify-content-start gap-4">
               <Actions

--- a/site/gatsby-site/src/components/discover/hitTypes/shared.js
+++ b/site/gatsby-site/src/components/discover/hitTypes/shared.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Card } from 'react-bootstrap';
+import { Highlight } from 'react-instantsearch-dom';
+import styled from 'styled-components';
+
+const linkHoverHighlight = `
+  a:not(:hover) { color: inherit; }
+  @supports not selector(:not) {
+    a { color: inherit }
+  }
+`;
+
+const HeaderCard = styled(Card.Title)`
+  a {
+    font-weight: bold;
+  }
+  ${linkHoverHighlight}
+`;
+
+const SubdomainCard = styled(Card.Subtitle)`
+  ${linkHoverHighlight}
+`;
+
+export function citationReportUrl(item) {
+  return '/cite/' + item.incident_id + '#r' + item.objectID;
+}
+
+export function HeaderTitle({ item, ...props }) {
+  return (
+    <HeaderCard {...props}>
+      <a href={citationReportUrl(item)}>
+        <Highlight hit={item} attribute="title" />
+      </a>
+    </HeaderCard>
+  );
+}
+
+export function SourceDomainSubtitle({ item, ...props }) {
+  return (
+    <SubdomainCard {...props}>
+      <a href={item.url}>
+        {item.source_domain} &middot;{' '}
+        {item.date_published ? item.date_published.substring(0, 4) : 'Needs publish date'}
+      </a>
+    </SubdomainCard>
+  );
+}
+
+export default {};

--- a/site/gatsby-site/src/pages/apps/discover.js
+++ b/site/gatsby-site/src/pages/apps/discover.js
@@ -271,7 +271,7 @@ function DiscoverApp(props) {
 
             <div
               className="hiddenMobile"
-              style={{ position: 'relative', minHeight: '4rem', boxSizing: 'border-box' }}
+              style={{ position: 'relative', minHeight: '4.25rem', boxSizing: 'border-box' }}
             >
               <details>
                 <summary

--- a/site/gatsby-site/src/pages/apps/discover.js
+++ b/site/gatsby-site/src/pages/apps/discover.js
@@ -18,6 +18,10 @@ import VirtualFilters from 'components/discover/VirtualFilters';
 import { Container, Row, Col } from 'react-bootstrap';
 import LanguageSwitcher from 'components/i18n/LanguageSwitcher';
 import useTranslation from 'components/i18n/useTranslation';
+import Stats from 'components/discover/Stats';
+import ClearFilters from 'components/discover/ClearFilters';
+import DisplayModeSwitch from 'components/discover/DisplayModeSwitch';
+import styled from 'styled-components';
 
 const searchClient = algoliasearch(
   config.header.search.algoliaAppId,
@@ -175,6 +179,13 @@ const getQueryFromState = (searchState) => {
   return query;
 };
 
+const ClearFiltersButton = styled(ClearFilters)`
+  height: 32px !important;
+  line-height: 32px !important;
+  padding: 0px !important;
+  background: red;
+`;
+
 function DiscoverApp(props) {
   const [query, setQuery] = useQueryParams(queryConfig);
 
@@ -257,7 +268,47 @@ function DiscoverApp(props) {
                 </Col>
               )}
             </Row>
-            <Filters />
+
+            <div
+              className="hiddenMobile"
+              style={{ position: 'relative', minHeight: '4rem', boxSizing: 'border-box' }}
+            >
+              <details>
+                <summary
+                  className="mt-3"
+                  style={{
+                    position: 'absolute',
+                    right: '0px',
+                    top: '0px',
+                    height: '38px',
+                    lineHeight: '38px',
+                  }}
+                >
+                  Filter Search
+                </summary>
+                <div style={{ paddingTop: '3rem', clear: 'both' }}>
+                  <Filters />
+                </div>
+              </details>
+              <div
+                className="mt-3"
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  position: 'absolute',
+                  top: '0px',
+                  height: '38px',
+                  width: 'calc(100% - 14ch)',
+                }}
+              >
+                <Stats />
+                <DisplayModeSwitch />
+                <div style={{ marginLeft: 'auto' }}>
+                  <ClearFiltersButton>Clear Filters</ClearFiltersButton>
+                </div>
+              </div>
+            </div>
+
             <FiltersModal />
           </Container>
 


### PR DESCRIPTION
Resolves #537. Changes:

- Makes result header images and titles into links to the report text on our site
- Make the subtitle containing the domain into a link to the original source
- Removes blockquotes from descriptions
  - These are usually redundant and take up vertical space.
  - In compact view, they also sometimes push the titles outside of the card
- Filters options are start out collapsed under a "filter search" `<summary>`.
  - This adds enough vertical space that the result titles appear above the fold.
  - On mobile, the modal filter dialogue is still used
  - If we want to highlight the filter options more, another possibility would be to put them in a sidebar
    - It might be better to de-emphasize the filters until we've solved some of the other UX issues (see #630).
    - I think that the "Classifications" filter is much more interesting than any of the others. Perhaps we could put it in the first row but hide the others behind the click?

## Before

The result titles are mostly below the fold, and they are not clickable.

https://user-images.githubusercontent.com/25443411/171270128-e700e2db-7751-4c4c-b542-2234638a4c6b.mp4

## After

Titles are above the fold, and header images, titles, and source domains are links.

https://user-images.githubusercontent.com/25443411/171270335-786d281f-282c-4cf5-85fb-7d5aaaedf0b8.mp4


