### PR TITLE
Stop extra requests on typing image urls, show errors

### DIFF
--- a/site/gatsby-site/cypress/integration/submit.js
+++ b/site/gatsby-site/cypress/integration/submit.js
@@ -504,8 +504,11 @@ describe('The Submit form', () => {
       suffix;
 
     cy.visit(url);
-    cy.get('input[name=image_url]').type(newImageUrl);
-    cy.get('[data-cy=image-preview-figure] img').should('have.attr', 'src', cloudinaryImageUrl);
+    cy.get('input[name=image_url]').scrollIntoView().type(newImageUrl);
+    cy.wait(3000);
+    cy.get('[data-cy=image-preview-figure] img')
+      .scrollIntoView()
+      .should('have.attr', 'src', cloudinaryImageUrl);
   });
 
   it("Should disable Submit button when linking to an Incident that doesn't exist", () => {

--- a/site/gatsby-site/cypress/integration/submit.js
+++ b/site/gatsby-site/cypress/integration/submit.js
@@ -505,8 +505,7 @@ describe('The Submit form', () => {
 
     cy.visit(url);
     cy.get('input[name=image_url]').scrollIntoView().type(newImageUrl);
-    cy.wait(3000);
-    cy.get('[data-cy=image-preview-figure] img')
+    cy.get('[data-cy=image-preview-figure] img', { timeout: 30000 })
       .scrollIntoView()
       .should('have.attr', 'src', cloudinaryImageUrl);
   });

--- a/site/gatsby-site/src/utils/cloudinary.js
+++ b/site/gatsby-site/src/utils/cloudinary.js
@@ -7,6 +7,8 @@ import { auto as qAuto } from '@cloudinary/base/qualifiers/quality';
 import styled from 'styled-components';
 import config from '../../config';
 import TextInputGroup from 'components/forms/TextInputGroup';
+import { Spinner } from 'react-bootstrap';
+import { isWebUri } from 'valid-url';
 
 const getCloudinaryPublicID = (url) => {
   // https://cloudinary.com/documentation/fetch_remote_images#auto_upload_remote_files
@@ -58,27 +60,59 @@ const PreviewImageInputGroup = ({
 }) => {
   const [cloudinaryID, setCloudinaryID] = useState(cloudinary_id);
 
+  // Track whether the image is waiting to update so we can show a spinner.
+  const [updatingImage, setUpdatingImage] = useState(false);
+
+  const [imageReferenceError, setImageReferenceError] = useState(false);
+
   const timeoutID = useRef(null);
 
-  const updateImage = (e) => {
-    clearTimeout(timeoutID.current);
-    timeoutID.current = setTimeout(() => {
-      try {
-        const url = new URL(e.target.value);
+  const imageUrl = useRef(values.image_url);
 
-        if (url.pathname.length < 8) {
-          throw 'InvalidURL';
-        }
-        const cloudinary_id = getCloudinaryPublicID(e.target.value, 'pai', 'reports');
+  const updateCloudinaryID = () => {
+    if (isWebUri(values.image_url)) {
+      // We want to show an error if the given url does not point to an image.
+      // We can do this by attempting to load the image ourselves
+      // before passing it to Cloudinary, which loads a fallback on error.
+      const img = document.createElement('img');
 
-        setCloudinaryID(cloudinary_id);
-      } catch (error) {
-        console.log('invalid image URL');
-        console.log(error);
-        setCloudinaryID('fallback.jpg');
-      }
-    }, 2000);
+      img.src = values.image_url;
+      img.onload = () => {
+        setImageReferenceError(false);
+        setCloudinaryID(getCloudinaryPublicID(values.image_url));
+      };
+      img.onerror = () => {
+        setCloudinaryID();
+        setImageReferenceError(true);
+      };
+    } else {
+      setCloudinaryID();
+    }
+    setUpdatingImage(false);
   };
+
+  // When the form value changes, wait two seconds,
+  // and if it hasn't changed again by then, update the cloudinaryID.
+  // This prevents repeated requests for partially-typed URLs.
+  if (values.image_url != imageUrl.current) {
+    imageUrl.current = values.image_url;
+    setUpdatingImage(true);
+    clearTimeout(timeoutID.current);
+    timeoutID.current = setTimeout(updateCloudinaryID, 2000);
+  }
+
+  // Default to fallback so we don't have to hit cloudinary API
+  // when we know there will be no match
+  if (!cloudinaryID || cloudinaryID == 'reports/') {
+    setCloudinaryID('fallback.jpg');
+  }
+
+  const childErrors = { ...errors };
+
+  touched.image_url = values.image_url.length > 0;
+  if (imageReferenceError) {
+    childErrors.image_url ||= '*Url must point to a valid image';
+  }
 
   return (
     <>
@@ -87,24 +121,27 @@ const PreviewImageInputGroup = ({
         label={label}
         placeholder={placeholder}
         values={values}
-        errors={errors}
+        errors={childErrors}
         touched={touched}
-        handleChange={(e) => {
-          updateImage(e);
-          handleChange(e);
-        }}
+        handleChange={handleChange}
         className={className}
         handleBlur={handleBlur}
       />
-      <PreviewFigure data-cy="image-preview-figure">
-        <PreviewImage
-          className={'mt-3'}
-          publicID={
-            cloudinaryID ||
-            (values?.cloudinary_id === 'reports/' ? null : values?.cloudinary_id) ||
-            'fallback.jpg'
-          }
-        />
+      <PreviewFigure data-cy="image-preview-figure" id="image-preview-figure">
+        <div
+          style={{
+            height: '50vh',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          {updatingImage ? (
+            <Spinner as="span" animation="border" size="lg" role="status" aria-hidden="true" />
+          ) : (
+            <PreviewImage className={'mt-3'} publicID={cloudinaryID} />
+          )}
+        </div>
         <figcaption>Selected Image</figcaption>
       </PreviewFigure>
     </>

--- a/site/gatsby-site/src/utils/cloudinary.js
+++ b/site/gatsby-site/src/utils/cloudinary.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { AdvancedImage, lazyload } from '@cloudinary/react';
 import { CloudinaryImage } from '@cloudinary/base';
 import { defaultImage, format, quality } from '@cloudinary/base/actions/delivery';
@@ -58,21 +58,26 @@ const PreviewImageInputGroup = ({
 }) => {
   const [cloudinaryID, setCloudinaryID] = useState(cloudinary_id);
 
+  const timeoutID = useRef(null);
+
   const updateImage = (e) => {
-    try {
-      const url = new URL(e.target.value);
+    clearTimeout(timeoutID.current);
+    timeoutID.current = setTimeout(() => {
+      try {
+        const url = new URL(e.target.value);
 
-      if (url.pathname.length < 8) {
-        throw 'InvalidURL';
+        if (url.pathname.length < 8) {
+          throw 'InvalidURL';
+        }
+        const cloudinary_id = getCloudinaryPublicID(e.target.value, 'pai', 'reports');
+
+        setCloudinaryID(cloudinary_id);
+      } catch (error) {
+        console.log('invalid image URL');
+        console.log(error);
+        setCloudinaryID('fallback.jpg');
       }
-      const cloudinary_id = getCloudinaryPublicID(e.target.value, 'pai', 'reports');
-
-      setCloudinaryID(cloudinary_id);
-    } catch (error) {
-      console.log('invalid image URL');
-      console.log(error);
-      setCloudinaryID('fallback.jpg');
-    }
+    }, 2000);
   };
 
   return (
@@ -89,10 +94,7 @@ const PreviewImageInputGroup = ({
           handleChange(e);
         }}
         className={className}
-        handleBlur={(e) => {
-          updateImage(e);
-          handleBlur(e);
-        }}
+        handleBlur={handleBlur}
       />
       <PreviewFigure data-cy="image-preview-figure">
         <PreviewImage

--- a/site/gatsby-site/src/utils/cloudinary.js
+++ b/site/gatsby-site/src/utils/cloudinary.js
@@ -37,6 +37,13 @@ const Image = ({ publicID, className, alt, transformation = null, plugins = [laz
   return <AdvancedImage alt={alt} className={className} cldImg={image} plugins={plugins} />;
 };
 
+const PreviewImageContainer = styled.div`
+  height: 50vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
 const PreviewImage = styled(Image)`
   margin: -1rem auto 1rem;
   max-height: 50vh;
@@ -128,20 +135,13 @@ const PreviewImageInputGroup = ({
         handleBlur={handleBlur}
       />
       <PreviewFigure data-cy="image-preview-figure" id="image-preview-figure">
-        <div
-          style={{
-            height: '50vh',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
-        >
+        <PreviewImageContainer>
           {updatingImage ? (
             <Spinner as="span" animation="border" size="lg" role="status" aria-hidden="true" />
           ) : (
             <PreviewImage className={'mt-3'} publicID={cloudinaryID} />
           )}
-        </div>
+        </PreviewImageContainer>
         <figcaption>Selected Image</figcaption>
       </PreviewFigure>
     </>


### PR DESCRIPTION
Solves #659

- The image preview is now updated only after the image_url has not changed for two seconds, preventing excessive network requests
  - ~~Since there's now delay, the test really does need a `wait()`.~~
    - Instead of wait(), now gives cy.get() a timeout of 30 seconds.
- The image preview now renders based on the `values` prop rather than `onChange`, which makes it update on programmatic changes.
- If the entered URL is not valid or an image, an error is shown.
  - Since Cloudinary shows a fallback image without an error, before passing the url to Cloudinary, I attempt to load it directly in an offscreen <img> element -- if it succeeds, then it gets passed to Cloudinary. Otherwise, it shows an error to the user. It seems like there should be a better way to determine whether the image shown is the fallback, but I couldn't find one.