### PR TITLE
Add a11y skip-to-content link

### DIFF
--- a/site/gatsby-site/src/components/Layout.js
+++ b/site/gatsby-site/src/components/Layout.js
@@ -77,7 +77,7 @@ const Layout = ({ children, collapse, className, location }) => (
           dangerouslySetInnerHTML={{ __html: config.sidebar.title }}
         />
       )}
-      <Content className="mb-5">
+      <Content id="content" className="mb-5">
         <MaxWidth className={className}>{children}</MaxWidth>
       </Content>
       <RightSideBarWidth className={'hiddenMobile'}>

--- a/site/gatsby-site/src/components/LayoutHideSidebar.js
+++ b/site/gatsby-site/src/components/LayoutHideSidebar.js
@@ -111,7 +111,7 @@ const LayoutHideSidebar = ({ children, location, menuCollapseCallback }) => {
           dangerouslySetInnerHTML={{ __html: config.sidebar.title }}
         />
       ) : null}
-      <Content>
+      <Content id="content">
         <SidebarToggleButton onClick={() => toggleMenu()} collapse={collapse.toString()}>
           MENU
         </SidebarToggleButton>

--- a/site/gatsby-site/src/components/ui/Header.js
+++ b/site/gatsby-site/src/components/ui/Header.js
@@ -13,15 +13,21 @@ import Sidebar from '../sidebar';
 const SkipToContent = styled.a`
   color: white;
   background-color: #001934;
-  display: block;
   position: relative;
-  height: 0px;
+  order: 1;
+  margin-left: auto;
   opacity: 0;
-  z-index: 10000;
+  width: 0px;
+  height: 0px;
+  overflow: hidden;
   :focus {
     opacity: 1;
-    height: unset;
     padding: 0ch 1ch;
+    width: unset;
+    height: unset;
+  }
+  @media (max-width: 767px) {
+    font-size: 12px !important;
   }
 `;
 
@@ -29,7 +35,20 @@ const NavBarHeaderContainer = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  align-items: center;
   width: 100%;
+  .navbarHeader {
+    order: 0;
+  }
+  .divider {
+    width: 1px;
+  }
+  .navBarBrand > * {
+    flex-shrink: 0;
+  }
+  .navBarBrand > .headerTitle {
+    flex-shrink: 1;
+  }
 `;
 
 const HeaderIconsContainer = styled.div`
@@ -37,7 +56,7 @@ const HeaderIconsContainer = styled.div`
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-
+  order: 2;
   .paddingAround {
     padding-right: 10px;
   }
@@ -124,9 +143,9 @@ const Header = () => {
 
         return (
           <div>
-            <SkipToContent href="#content">Skip to Content</SkipToContent>
             <nav className={'navBarDefault'}>
               <NavBarHeaderContainer>
+                <SkipToContent href="#content">Skip to Content</SkipToContent>
                 <div className={'navBarHeader'}>
                   <Link to={finalLogoLink} className={'navBarBrand'}>
                     <img

--- a/site/gatsby-site/src/components/ui/Header.js
+++ b/site/gatsby-site/src/components/ui/Header.js
@@ -10,6 +10,21 @@ import config from '../../../config.js';
 
 import Sidebar from '../sidebar';
 
+const SkipToContent = styled.a`
+  color: white;
+  background-color: #001934;
+  display: block;
+  position: relative;
+  height: 0px;
+  opacity: 0;
+  z-index: 10000;
+  :focus {
+    opacity: 1;
+    height: unset;
+    padding: 0ch 1ch;
+  }
+`;
+
 const NavBarHeaderContainer = styled.div`
   display: flex;
   flex-direction: row;
@@ -109,6 +124,7 @@ const Header = () => {
 
         return (
           <div>
+            <SkipToContent href="#content">Skip to Content</SkipToContent>
             <nav className={'navBarDefault'}>
               <NavBarHeaderContainer>
                 <div className={'navBarHeader'}>


### PR DESCRIPTION
Solves #645

I had to add `id="content"` to the main element in `Layout.js` and `LayoutHideSidebar.js`, so any future layouts would need it as well. It would be nice to somehow enforce that, but I'm not sure of the best way. I tried writing a test that would iterate through every page and test that a `#content` element exists, but it was slow and failed on `/apps/classifications` even though it does have a `#content`, probably because it takes some time to load.

**Edit**: Moved link to navbar, still hidden by default but visible on focus – potentially looks more natural not pushing the rest of the content down.

https://user-images.githubusercontent.com/25443411/171862700-ad61fb5e-0921-438d-b46a-ed07c322c0ec.mp4

Works ok on narrow viewports:


https://user-images.githubusercontent.com/25443411/171862781-956a5920-0fa2-4078-94ed-84311e1d4927.mp4


