### PR TITLE
Add slug id to blog postheadings

### DIFF
--- a/site/gatsby-site/src/templates/post.js
+++ b/site/gatsby-site/src/templates/post.js
@@ -2,11 +2,23 @@ import React from 'react';
 import Helmet from 'react-helmet';
 import { graphql } from 'gatsby';
 import MDXRenderer from 'gatsby-plugin-mdx/mdx-renderer';
+import { MDXProvider } from '@mdx-js/react';
 
 import Layout from 'components/Layout';
 import { StyledHeading, StyledMainWrapper, PostDate, Author } from 'components/styles/Post';
 import config from '../../config';
 import { format } from 'date-fns';
+
+const slug = (title) => title.toLowerCase().replace(/\s+/g, '');
+
+const Components = {
+  h1: ({ children }) => <h1 id={slug(children)}>{children}</h1>,
+  h2: ({ children }) => <h2 id={slug(children)}>{children}</h2>,
+  h3: ({ children }) => <h3 id={slug(children)}>{children}</h3>,
+  h4: ({ children }) => <h4 id={slug(children)}>{children}</h4>,
+  h5: ({ children }) => <h5 id={slug(children)}>{children}</h5>,
+  h6: ({ children }) => <h6 id={slug(children)}>{children}</h6>,
+};
 
 export default function Post(props) {
   const {
@@ -40,7 +52,9 @@ export default function Post(props) {
         <PostDate>{format(new Date(mdx.frontmatter.date), 'MMM d, yyyy')}</PostDate>
       </div>
       <StyledMainWrapper>
-        <MDXRenderer>{mdx.body}</MDXRenderer>
+        <MDXProvider components={Components}>
+          <MDXRenderer>{mdx.body}</MDXRenderer>
+        </MDXProvider>
         <Author>By {mdx.frontmatter.author}</Author>
       </StyledMainWrapper>
     </Layout>


### PR DESCRIPTION
Fixes problem listed in #613 where the links in the blog post tables of contents were broken because of missing ids on post headers. Adds slug IDs in `post.js` by the same method used in `docs.js`.