### PR TITLE
Set 'Anonymous' as submitter when not provided

### DIFF
--- a/site/gatsby-site/src/components/forms/SubmitForm.js
+++ b/site/gatsby-site/src/components/forms/SubmitForm.js
@@ -92,7 +92,11 @@ const SubmitForm = () => {
         date_modified: date_submitted,
         description: values.text.substring(0, 200),
         authors: isString(values.authors) ? values.authors.split(',') : values.authors,
-        submitters: isString(values.submitters) ? values.submitters.split(',') : values.submitters,
+        submitters: values.submitters
+          ? isString(values.submitters)
+            ? values.submitters.split(',')
+            : values.submitters
+          : ['Anonymous'],
         language: 'en',
       };
 

--- a/site/gatsby-site/src/components/submissions/SubmissionForm.js
+++ b/site/gatsby-site/src/components/submissions/SubmissionForm.js
@@ -46,8 +46,7 @@ export const schema = Yup.object().shape({
     .required('*Author is required. Anonymous or the publication can be entered.'),
   submitters: Yup.string()
     .min(3, '*Submitter must have at least 3 characters')
-    .max(200, "*Submitter list can't be longer than 200 characters")
-    .required('*Submitter is required. Anonymous can be entered.'),
+    .max(200, "*Submitter list can't be longer than 200 characters"),
   text: Yup.string()
     .min(80, '*Text must have at least 80 characters')
     .max(50000, "*Text can't be longer than 50000 characters")


### PR DESCRIPTION
Resolves #643, making the submitters field in the report submission form optional, with "Anonymous" as the value when left blank.