### PR TITLE
Add `limit: 200` to FIND_SUBMISSIONS query

### DIFF
--- a/site/gatsby-site/src/graphql/submissions.js
+++ b/site/gatsby-site/src/graphql/submissions.js
@@ -10,7 +10,7 @@ export const DELETE_SUBMISSION = gql`
 
 export const FIND_SUBMISSIONS = gql`
   query FindSubmissions {
-    submissions {
+    submissions(limit: 200) {
       _id
       cloudinary_id
       date_downloaded


### PR DESCRIPTION
Fixes the problem of missing entries from the submission queue named in #654. For now... Eventually we will probably want to add pagination and a better table view.