### PR TITLE
Prevent submitted app from crashing when no incident is found

### DIFF
--- a/site/gatsby-site/src/components/submissions/SubmissionReview.js
+++ b/site/gatsby-site/src/components/submissions/SubmissionReview.js
@@ -188,7 +188,7 @@ const SubmissionReview = ({ submission }) => {
             {submission['title']}
             <br />
             <Badge bg="secondary">
-              Inc: {submission.incident_date || incidentData?.incident.date}
+              Inc: {submission.incident_date || incidentData?.incident?.date}
             </Badge>{' '}
             <Badge bg="secondary">Pub: {submission.date_published}</Badge>{' '}
             <Badge bg="secondary">Sub: {submission.date_submitted}</Badge>{' '}


### PR DESCRIPTION
Right now, staging crashes when expanding some submission reviews.