### PR TITLE
Add missing editor_notes to submissions schema

### DIFF
--- a/site/realm/data_sources/mongodb-atlas/aiidprod/submissions/schema.json
+++ b/site/realm/data_sources/mongodb-atlas/aiidprod/submissions/schema.json
@@ -27,6 +27,9 @@
         "description": {
             "bsonType": "string"
         },
+        "editor_notes": {
+            "bsonType": "string"
+        },
         "image_url": {
             "bsonType": "string"
         },


### PR DESCRIPTION
`editor_notes` was missing from the schema.

<img width="580" alt="image" src="https://user-images.githubusercontent.com/1172479/173926782-1526e365-6b80-4420-82be-36bc9f3323cb.png">
