### PR TITLE
Remove submitters as required field in submission form

### DIFF
--- a/site/gatsby-site/src/components/forms/SubmitForm.js
+++ b/site/gatsby-site/src/components/forms/SubmitForm.js
@@ -13,6 +13,7 @@ import isString from 'lodash/isString';
 import SubmissionForm, { schema } from 'components/submissions/SubmissionForm';
 import { Formik } from 'formik';
 import { stripMarkdown } from 'utils/typography';
+import isArray from 'lodash/isArray';
 
 const CustomDateParam = {
   encode: encodeDate,
@@ -92,8 +93,8 @@ const SubmitForm = () => {
         description: values.text.substring(0, 200),
         authors: isString(values.authors) ? values.authors.split(',') : values.authors,
         submitters: values.submitters
-          ? isString(values.submitters)
-            ? values.submitters.split(',')
+          ? !isArray(values.submitters)
+            ? values.submitters.split(',').map((s) => s.trim())
             : values.submitters
           : ['Anonymous'],
         language: 'en',

--- a/site/gatsby-site/src/components/submissions/SubmissionEditModal.js
+++ b/site/gatsby-site/src/components/submissions/SubmissionEditModal.js
@@ -36,9 +36,11 @@ export default function SubmissionEditModal({ show, onHide, submissionId }) {
             authors: !isArray(values.authors)
               ? values.authors.split(',').map((s) => s.trim())
               : values.authors,
-            submitters: !isArray(values.submitters)
-              ? values.submitters.split(',').map((s) => s.trim())
-              : values.submitters,
+            submitters: values.submitters
+              ? !isArray(values.submitters)
+                ? values.submitters.split(',').map((s) => s.trim())
+                : values.submitters
+              : ['Anonymous'],
             plain_text: await stripMarkdown(update.text),
           },
         },

--- a/site/gatsby-site/src/components/submissions/SubmissionForm.js
+++ b/site/gatsby-site/src/components/submissions/SubmissionForm.js
@@ -52,8 +52,7 @@ export const schema = yup.object().shape({
   submitters: yup
     .string()
     .min(3, '*Submitter must have at least 3 characters')
-    .max(200, "*Submitter list can't be longer than 200 characters")
-    .required('*Submitter is required. Anonymous can be entered.'),
+    .max(200, "*Submitter list can't be longer than 200 characters"),
   text: yup
     .string()
     .min(80, '*Text must have at least 80 characters')


### PR DESCRIPTION
Resolves #716.

This was correct in [the original commit](https://github.com/responsible-ai-collaborative/aiid/commit/30c17875eefe2ef8eb199a63cdd7b8a80f132077#diff-28b1e7830a22d95e1d771867c56ae054f99275acc97a13d1ef4382b40c071fd8) but got undone in further revisions to the submission form.

I've harmonized submit handling for the `submitters` field in `SubmitForm.js` and `SubmissionEditModal.js`.

I've left the report edit form as it is – it still requires an explicit value for `submitters`, since it will start out with a value, and if the editor removes it without a replacement, that's probably a mistake.