### PR TITLE
Prevent <main> from overflowing viewport horizontally

### DIFF
--- a/site/gatsby-site/src/components/Layout.js
+++ b/site/gatsby-site/src/components/Layout.js
@@ -38,6 +38,14 @@ const Content = styled('main')`
     background: ${({ theme }) => theme.colors.background};
   }
 
+  @media only screen and (min-width: 767px) {
+    /* Subtract the sidebar and margin width */
+    width: calc(100% - 298px - 66px);
+    > * {
+      max-width: 100%;
+    }
+  }
+
   @media only screen and (max-width: 1123px) {
     padding-left: 0;
     margin: 0 10px;
@@ -59,6 +67,7 @@ const LeftSideBarWidth = styled.div`
 
 const RightSideBarWidth = styled.div`
   width: 224px;
+  margin-left: -24px;
 
   @media (max-width: 965px) {
     display: none;


### PR DESCRIPTION
This solves #718 by setting an explicit width for the `<main>` element. Honestly, I'm not sure why it isn't already constrained to fit its parent flexbox. Setting `flex-shrink` doesn't help. There may be a more principled solution, but this works as a quick fix.

<table>
  <tr><th>Before</th><th>After</th>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/25443411/174322908-cf777725-6936-4731-a28d-88dc15afaba7.png"></td>
    <td><img src="https://user-images.githubusercontent.com/25443411/174323065-8648ede4-45ce-4879-88eb-ae23ebbe80f3.png"></td>
  </tr>
</table>


## Other sizes

https://user-images.githubusercontent.com/25443411/174323589-b2d75ee1-2f64-45fc-afe4-e9641fae8f1c.mp4



