### PR TITLE
Add editor_notes to submit tests and check submitted data

### DIFF
--- a/site/gatsby-site/cypress/integration/submit.js
+++ b/site/gatsby-site/cypress/integration/submit.js
@@ -1,5 +1,4 @@
 import parseNews from '../fixtures/api/parseNews.json';
-import { maybeIt } from '../support/utils';
 
 describe('The Submit form', () => {
   const url = '/apps/submit';
@@ -184,7 +183,7 @@ describe('The Submit form', () => {
     ).should('exist');
     cy.get('[data-cy="submission"] [data-cy="review-button"]').click();
 
-    let expectedValues = {
+    const expectedValues = {
       _id: '6272f2218933c7a9b512e13b',
       text: 'Something',
       submitters: 'Something',
@@ -197,152 +196,13 @@ describe('The Submit form', () => {
       url: `https://www.arstechnica.com/gadgets/2017/11/youtube-to-crack-down-on-inappropriate-content-masked-as-kids-cartoons/`,
       source_domain: 'arstechnica.com',
       language: 'en',
+      editor_notes: 'Here are some notes',
     };
 
     for (let key in expectedValues) {
       cy.get(`[data-cy="${key}"]`).contains(expectedValues[key]).should('exist');
     }
   });
-
-  maybeIt(
-    'Should submit a new report linked to incident 1 with editor notes when logged in',
-    () => {
-      cy.login(Cypress.env('e2eUsername'), Cypress.env('e2ePassword'));
-
-      cy.intercept('GET', parserURL, parseNews).as('parseNews');
-
-      cy.visit(url);
-
-      cy.get('input[name="url"]').type(
-        `https://www.arstechnica.com/gadgets/2017/11/youtube-to-crack-down-on-inappropriate-content-masked-as-kids-cartoons/`
-      );
-
-      cy.get('button').contains('Fetch info').click();
-
-      cy.get('input[name="submitters"]').type('Something');
-
-      cy.get('[class*="Typeahead"]').type('New Tag{enter}');
-
-      cy.get('[name="editor_notes"').type('Here are some notes');
-
-      cy.conditionalIntercept(
-        '**/graphql',
-        (req) =>
-          req.body.operationName == 'FindIncident' && req.body.variables.query.incident_id == 1,
-        'findIncident',
-        {
-          data: {
-            incident: {
-              __typename: 'Incident',
-              incident_id: 1,
-              title: 'Test title',
-              date: '2016-03-13',
-            },
-          },
-        }
-      );
-
-      cy.get('[name="incident_id"]').type('1');
-
-      cy.wait('@findIncident');
-
-      cy.conditionalIntercept(
-        '**/graphql',
-        (req) => req.body.operationName == 'InsertSubmission',
-        'submitReport',
-        {
-          data: {
-            insertOneSubmission: { __typename: 'Submission', _id: '6272f2218933c7a9b512e13b' },
-          },
-        }
-      );
-
-      cy.get('button[type="submit"]').click();
-
-      cy.wait('@submitReport').then((xhr) => {
-        expect(xhr.request.body.variables.submission).to.deep.include({
-          title: 'YouTube to crack down on inappropriate content masked as kids’ cartoons',
-          submitters: ['Something'],
-          authors: ['Valentina Palladino'],
-          date_published: '2017-11-10',
-          image_url:
-            'https://cdn.arstechnica.net/wp-content/uploads/2017/11/Screen-Shot-2017-11-10-at-9.25.47-AM-760x380.png',
-          cloudinary_id:
-            'reports/cdn.arstechnica.net/wp-content/uploads/2017/11/Screen-Shot-2017-11-10-at-9.25.47-AM-760x380.png',
-          tags: ['New Tag'],
-          incident_id: 1,
-          url: `https://www.arstechnica.com/gadgets/2017/11/youtube-to-crack-down-on-inappropriate-content-masked-as-kids-cartoons/`,
-          source_domain: `arstechnica.com`,
-          editor_notes: 'Here are some notes',
-        });
-      });
-
-      cy.get('div[class^="ToastContext"]')
-        .contains('Report successfully added to review queue')
-        .should('exist');
-
-      cy.conditionalIntercept(
-        '**/graphql',
-        (req) => req.body.operationName == 'FindSubmissions',
-        'findSubmissions',
-        {
-          data: {
-            submissions: [
-              {
-                __typename: 'Submission',
-                _id: '6272f2218933c7a9b512e13b',
-                text: 'Something',
-                title: 'YouTube to crack down on inappropriate content masked as kids’ cartoons',
-                submitters: ['Something'],
-                authors: ['Valentina Palladino'],
-                incident_date: '2021-09-21',
-                date_published: '2017-11-10',
-                image_url:
-                  'https://cdn.arstechnica.net/wp-content/uploads/2017/11/Screen-Shot-2017-11-10-at-9.25.47-AM-760x380.png',
-                tags: ['New Tag'],
-                incident_id: '0',
-                url: `https://www.arstechnica.com/gadgets/2017/11/youtube-to-crack-down-on-inappropriate-content-masked-as-kids-cartoons/`,
-                source_domain: 'arstechnica.com',
-                language: 'en',
-                description: 'Something',
-                editor_notes: 'Here are some notes',
-              },
-            ],
-          },
-        }
-      );
-
-      cy.visit('/apps/submitted');
-
-      cy.wait('@findSubmissions');
-
-      cy.contains(
-        '[data-cy="submission"]',
-        'YouTube to crack down on inappropriate content masked as kids’ cartoons'
-      ).should('exist');
-      cy.get('[data-cy="submission"] [data-cy="review-button"]').click();
-
-      let expectedValues = {
-        _id: '6272f2218933c7a9b512e13b',
-        text: 'Something',
-        submitters: 'Something',
-        authors: 'Valentina Palladino',
-        incident_date: '2021-09-21',
-        date_published: '2017-11-10',
-        image_url:
-          'https://cdn.arstechnica.net/wp-content/uploads/2017/11/Screen-Shot-2017-11-10-at-9.25.47-AM-760x380.png',
-        incident_id: '0',
-        url: `https://www.arstechnica.com/gadgets/2017/11/youtube-to-crack-down-on-inappropriate-content-masked-as-kids-cartoons/`,
-        source_domain: 'arstechnica.com',
-        language: 'en',
-        editor_notes: 'Here are some notes',
-      };
-
-      for (let key in expectedValues) {
-        cy.get(`[data-cy="${key}"]`).contains(expectedValues[key]).should('exist');
-      }
-    }
-  );
 
   it('Should show a toast on error when failing to reach parsing endpoint', () => {
     cy.visit(url);

--- a/site/gatsby-site/src/components/forms/SubmitForm.js
+++ b/site/gatsby-site/src/components/forms/SubmitForm.js
@@ -39,6 +39,7 @@ const queryConfig = {
   image_url: withDefault(StringParam, ''),
   incident_id: withDefault(StringParam, ''),
   text: withDefault(StringParam, ''),
+  editor_notes: withDefault(StringParam, ''),
   tags: withDefault(ArrayParam, []),
 };
 

--- a/site/gatsby-site/src/components/submissions/SubmissionReview.js
+++ b/site/gatsby-site/src/components/submissions/SubmissionReview.js
@@ -179,6 +179,7 @@ const SubmissionReview = ({ submission }) => {
               onClick={() => setOpen(!open)}
               aria-controls="collapse-incident-submission"
               aria-expanded={open}
+              data-cy="review-button"
             >
               review &gt;
             </Button>
@@ -207,7 +208,7 @@ const SubmissionReview = ({ submission }) => {
           <ListedGroup className="mt-2 mx-3" item={submission} keysToRender={urls} />
           <ListedGroup className="mt-2 mx-3" item={submission} keysToRender={otherDetails} />
 
-          <Card className="m-3">
+          <Card className="m-3" data-cy="text">
             <Card.Header>Text</Card.Header>
             <Card.Body>
               <ReadMoreText text={submission.text} visibility={open} />
@@ -215,7 +216,7 @@ const SubmissionReview = ({ submission }) => {
           </Card>
 
           {submission.editor_notes && isSubmitter ? (
-            <Card className="m-3">
+            <Card className="m-3" data-cy="editor_notes">
               <Card.Header>Editor Notes</Card.Header>
               <Card.Body>
                 <ReadMoreText text={submission.editor_notes} visibility={open} />

--- a/site/gatsby-site/src/components/submissions/SubmissionReview.js
+++ b/site/gatsby-site/src/components/submissions/SubmissionReview.js
@@ -215,15 +215,13 @@ const SubmissionReview = ({ submission }) => {
             </Card.Body>
           </Card>
 
-          {submission.editor_notes && isSubmitter ? (
+          {submission.editor_notes && (
             <Card className="m-3" data-cy="editor_notes">
               <Card.Header>Editor Notes</Card.Header>
               <Card.Body>
                 <ReadMoreText text={submission.editor_notes} visibility={open} />
               </Card.Body>
             </Card>
-          ) : (
-            ''
           )}
 
           {open && (


### PR DESCRIPTION
Resolves  #715.

- Adds `editor_notes` field to existing tests where missing
  - This would have caught the submission failure referred to in #715.
- Expands the "Should submit a new report linked to incident 1" to not just check that the submitted item appears in the submission queue, but that the data in it matches what was submitted
  - ~~When login credentials are available, includes `editor_notes` with the above~~
    - Now displays editor_notes to all users