### PR TITLE
Improve api-side error handling

### DIFF
--- a/site/gatsby-site/src/components/SemanticallyRelatedIncidents.js
+++ b/site/gatsby-site/src/components/SemanticallyRelatedIncidents.js
@@ -28,6 +28,7 @@ const semanticallyRelated = async (text) => {
   });
 
   if (!response?.ok) {
+    console.error('/api/semanticallyRelated', response);
     throw new Error('Semantic relation error');
   }
   const json = await response.json();


### PR DESCRIPTION
I've tested this on what I believe was a cold start of the lambda API, and it worked correctly this time.