### PR TITLE
Classification column filters

### DIFF
--- a/site/gatsby-site/migrations/2022.08.15T19.33.01.remove-commas-in-classifications.js
+++ b/site/gatsby-site/migrations/2022.08.15T19.33.01.remove-commas-in-classifications.js
@@ -13,6 +13,24 @@ exports.up = async ({ context: { client } }) => {
       continue;
     }
 
+    if (classification.incident_id == 76) {
+      classificationsCollection.updateOne(
+        { incident_id: 76 },
+        {
+          $set: {
+            classifications: {
+              ...classification.classifications,
+              'Data Inputs': [
+                'photo IDs, names birthdays, and national IDs of people suspected of crimes',
+                'camera feed',
+              ],
+            },
+          },
+        }
+      );
+      continue;
+    }
+
     for (const category of Object.keys(classification.classifications).filter(
       (category) =>
         ![
@@ -27,11 +45,14 @@ exports.up = async ({ context: { client } }) => {
 
       if (Array.isArray(value)) {
         for (let string of value) {
-          if (string.includes('The Equal Credit Opportunity Act')) {
+          if (
+            string.includes('The Equal Credit Opportunity Act') ||
+            string.includes('user content (textposts, images, videos)')
+          ) {
             continue;
           }
           if (string.includes(',')) {
-            const updatedClassifications = {};
+            const updatedClassifications = classification.classifications;
 
             updatedClassifications[category] = string.split(',').map((s) => s.trim());
             await classificationsCollection.updateOne(
@@ -43,19 +64,6 @@ exports.up = async ({ context: { client } }) => {
       }
     }
   }
-  classificationsCollection.updateOne(
-    { incident_id: 76 },
-    {
-      $set: {
-        classifications: {
-          'Data Inputs': [
-            'photo IDs, names birthdays, and national IDs of people suspected of crimes',
-            'camera feed',
-          ],
-        },
-      },
-    }
-  );
 };
 
 /** @type {import('umzug').MigrationFn<any>} */

--- a/site/gatsby-site/migrations/2022.08.15T19.33.01.remove-commas-in-classifications.js
+++ b/site/gatsby-site/migrations/2022.08.15T19.33.01.remove-commas-in-classifications.js
@@ -1,0 +1,46 @@
+/** @type {import('umzug').MigrationFn<any>} */
+exports.up = async ({ context: { client } }) => {
+  await client.connect();
+
+  const classificationsCollection = client.db('aiidprod').collection('classifications');
+
+  const classifications = await classificationsCollection.find({});
+
+  while (await classifications.hasNext()) {
+    const classification = await classifications.next();
+
+    for (const category of Object.keys(classification.classifications).filter(
+      (category) =>
+        ![
+          'Full Description',
+          'Short Description',
+          'AI System Description',
+          'Location',
+          'Sector of Deployment',
+          'notes',
+        ].includes(category)
+    )) {
+      const value = classification.classifications[category];
+
+      if (Array.isArray(value)) {
+        for (let string of value) {
+          if (string.includes('The Equal Credit Opportunity Act')) {
+            continue;
+          }
+          if (string.includes(',')) {
+            const updatedClassifications = {};
+
+            updatedClassifications[category] = string.split(',').map((s) => s.trim());
+            await classificationsCollection.updateOne(
+              { incident_id: classification.incident_id },
+              { $set: { classifications: updatedClassifications } }
+            );
+          }
+        }
+      }
+    }
+  }
+};
+
+/** @type {import('umzug').MigrationFn<any>} */
+exports.down = async () => {};

--- a/site/gatsby-site/migrations/2022.08.15T19.33.01.remove-commas-in-classifications.js
+++ b/site/gatsby-site/migrations/2022.08.15T19.33.01.remove-commas-in-classifications.js
@@ -55,28 +55,33 @@ exports.up = async ({ context: { client } }) => {
     )) {
       const value = classification.classifications[category];
 
-      if (Array.isArray(value)) {
-        for (let string of value) {
-          if (
-            string.includes('The Equal Credit Opportunity Act') ||
-            string.includes('user content (textposts, images, videos)')
-          ) {
-            continue;
-          }
-          if (string.includes(',')) {
-            const newValue = string.split(',').map((s) => s.trim());
+      if (Array.isArray(value) && value.length == 1) {
+        const string = value[0];
 
-            updatedClassifications[category] = newValue;
+        if (
+          string.includes('The Equal Credit Opportunity Act') ||
+          string.includes('user content (textposts, images, videos)')
+        ) {
+          continue;
+        }
 
-            console.log(
-              '#' + classification.incident_id,
-              category,
-              ':',
-              classification.classifications[category],
-              '→',
-              newValue
-            );
-          }
+        const semicolon = string.includes(';');
+
+        const comma = string.includes(',');
+
+        if (semicolon || comma) {
+          const newValue = string.split(semicolon ? ';' : ',').map((s) => s.trim());
+
+          updatedClassifications[category] = newValue;
+
+          console.log(
+            '#' + classification.incident_id,
+            category,
+            ':',
+            classification.classifications[category],
+            '→',
+            newValue
+          );
         }
       }
     }

--- a/site/gatsby-site/migrations/2022.08.15T19.33.01.remove-commas-in-classifications.js
+++ b/site/gatsby-site/migrations/2022.08.15T19.33.01.remove-commas-in-classifications.js
@@ -14,22 +14,34 @@ exports.up = async ({ context: { client } }) => {
     }
 
     if (classification.incident_id == 76) {
+      const newDataInputs = [
+        'photo IDs, names birthdays, and national IDs of people suspected of crimes',
+        'camera feed',
+      ];
+
+      console.log(
+        '#' + classification.incident_id,
+        'Data Inputs :',
+        classification.classifications['Data Inputs'],
+        '→',
+        newDataInputs
+      );
+
       classificationsCollection.updateOne(
         { incident_id: 76 },
         {
           $set: {
             classifications: {
               ...classification.classifications,
-              'Data Inputs': [
-                'photo IDs, names birthdays, and national IDs of people suspected of crimes',
-                'camera feed',
-              ],
+              'Data Inputs': newDataInputs,
             },
           },
         }
       );
       continue;
     }
+
+    const updatedClassifications = {};
 
     for (const category of Object.keys(classification.classifications).filter(
       (category) =>
@@ -52,17 +64,34 @@ exports.up = async ({ context: { client } }) => {
             continue;
           }
           if (string.includes(',')) {
-            const updatedClassifications = classification.classifications;
+            const newValue = string.split(',').map((s) => s.trim());
 
-            updatedClassifications[category] = string.split(',').map((s) => s.trim());
-            await classificationsCollection.updateOne(
-              { incident_id: classification.incident_id },
-              { $set: { classifications: updatedClassifications } }
+            updatedClassifications[category] = newValue;
+
+            console.log(
+              '#' + classification.incident_id,
+              category,
+              ':',
+              classification.classifications[category],
+              '→',
+              newValue
             );
           }
         }
       }
     }
+
+    await classificationsCollection.updateOne(
+      { incident_id: classification.incident_id },
+      {
+        $set: {
+          classifications: {
+            ...classification.classifications,
+            ...updatedClassifications,
+          },
+        },
+      }
+    );
   }
 };
 

--- a/site/gatsby-site/migrations/2022.08.15T19.33.01.remove-commas-in-classifications.js
+++ b/site/gatsby-site/migrations/2022.08.15T19.33.01.remove-commas-in-classifications.js
@@ -9,13 +9,16 @@ exports.up = async ({ context: { client } }) => {
   while (await classifications.hasNext()) {
     const classification = await classifications.next();
 
+    if (classification.incident_id == 40) {
+      continue;
+    }
+
     for (const category of Object.keys(classification.classifications).filter(
       (category) =>
         ![
           'Full Description',
           'Short Description',
           'AI System Description',
-          'Location',
           'Sector of Deployment',
           'notes',
         ].includes(category)
@@ -40,6 +43,19 @@ exports.up = async ({ context: { client } }) => {
       }
     }
   }
+  classificationsCollection.updateOne(
+    { incident_id: 76 },
+    {
+      $set: {
+        classifications: {
+          'Data Inputs': [
+            'photo IDs, names birthdays, and national IDs of people suspected of crimes',
+            'camera feed',
+          ],
+        },
+      },
+    }
+  );
 };
 
 /** @type {import('umzug').MigrationFn<any>} */

--- a/site/gatsby-site/migrations/2022.08.15T19.33.01.remove-commas-in-classifications.js
+++ b/site/gatsby-site/migrations/2022.08.15T19.33.01.remove-commas-in-classifications.js
@@ -43,15 +43,15 @@ exports.up = async ({ context: { client } }) => {
 
     const updatedClassifications = {};
 
-    for (const category of Object.keys(classification.classifications).filter(
-      (category) =>
-        ![
-          'Full Description',
-          'Short Description',
-          'AI System Description',
-          'Sector of Deployment',
-          'notes',
-        ].includes(category)
+    for (const category of Object.keys(classification.classifications).filter((category) =>
+      [
+        'AI Applications',
+        'AI Techniques',
+        'Data Inputs',
+        'Harm Distribution Basis',
+        'Laws Implicated',
+        'Named Entities',
+      ].includes(category)
     )) {
       const value = classification.classifications[category];
 


### PR DESCRIPTION
Resolves #739. A few items still have commas, but that's because they're incorrectly stored in MongoDB as strings. They should be replaced with arrays.

![image](https://user-images.githubusercontent.com/25443411/178519905-50c845f9-2383-4a18-8938-70ad1f54301e.png)
