### PR TITLE
Add submitter e2e test

### DIFF
--- a/site/gatsby-site/cypress/e2e/submitter.cy.js
+++ b/site/gatsby-site/cypress/e2e/submitter.cy.js
@@ -1,0 +1,27 @@
+describe('Submitter Selection', () => {
+  const url = '/';
+
+  it('Should successfully load home page', () => {
+    cy.visit(url);
+  });
+
+  it('Should sroll to Incident Report Submission Leaderboards', () => {
+    cy.contains('Incident Report Submission Leaderboards').scrollIntoView();
+  });
+
+  it('Should select the first submitter if there is one', () => {
+    cy.get('div[class^="Leaderboard__StyledItem"] a').its('length').should('be.gt', 1);
+
+    cy.get('div[class^="Leaderboard__StyledItem"] a').first().click();
+  });
+
+  it('Should load the discover page with a pre-selected submitter in the URL', () => {
+    cy.url().should('include', 'submitters=');
+  });
+
+  it('Should have the submitter pre-selected on the dropdown', () => {
+    cy.contains('Submitters').find('span.badge').first().click();
+
+    cy.contains('Submitters').find('span.badge').first().should('contain.text', '1');
+  });
+});

--- a/site/gatsby-site/cypress/e2e/submitter.cy.js
+++ b/site/gatsby-site/cypress/e2e/submitter.cy.js
@@ -1,27 +1,25 @@
 describe('Submitter Selection', () => {
-  const url = '/';
+  let url = '/';
 
-  it('Should successfully load home page', () => {
+  it('Should select the first submitter if there is one and load the discover page with a pre-selected submitter in the URL', () => {
     cy.visit(url);
-  });
 
-  it('Should scroll to Incident Report Submission Leaderboards', () => {
     cy.contains('Incident Report Submission Leaderboards').scrollIntoView();
-  });
 
-  it('Should select the first submitter if there is one', () => {
     cy.get('div[class^="Leaderboard__StyledItem"] a').its('length').should('be.gt', 1);
 
     cy.get('div[class^="Leaderboard__StyledItem"] a').first().click();
-  });
 
-  it('Should load the discover page with a pre-selected submitter in the URL', () => {
     cy.url().should('include', 'submitters=');
   });
 
   it('Should have the submitter pre-selected on the dropdown', () => {
+    url = '/apps/discover?submitters=Anonymous';
+
+    cy.visit(url);
+
     cy.contains('Submitters').find('span.badge').first().click();
 
-    cy.contains('Submitters').find('span.badge').first().should('contain.text', '1');
+    cy.get('.shadow-lg.card').find('.list-group-item.active').should('contain.text', 'Anonymous');
   });
 });

--- a/site/gatsby-site/cypress/e2e/submitter.cy.js
+++ b/site/gatsby-site/cypress/e2e/submitter.cy.js
@@ -5,7 +5,7 @@ describe('Submitter Selection', () => {
     cy.visit(url);
   });
 
-  it('Should sroll to Incident Report Submission Leaderboards', () => {
+  it('Should scroll to Incident Report Submission Leaderboards', () => {
     cy.contains('Incident Report Submission Leaderboards').scrollIntoView();
   });
 


### PR DESCRIPTION
### Description
New Cypress e2e test that checks that a selected leaderboard submitter is correctly redirected to the **Discover Page** with the value auto-selected.

Name of the test: submitter.cy.js

### Steps of test
1. Should successfully load home page
2. Should scroll to Incident Report Submission Leaderboards
3. Should select the first submitter if there is one
4. Should load the discover page with a pre-selected submitter in the URL
5. Should have the submitter pre-selected on the dropdown