### PR TITLE
Connect to Cypress dashboard

### DIFF
--- a/site/gatsby-site/cypress.config.js
+++ b/site/gatsby-site/cypress.config.js
@@ -1,7 +1,7 @@
 const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
-  video: false,
+  video: true,
   chromeWebSecurity: false,
   defaultCommandTimeout: 30000,
   requestTimeout: 15000,

--- a/site/gatsby-site/netlify.toml
+++ b/site/gatsby-site/netlify.toml
@@ -11,5 +11,6 @@ TERM = "xterm"
     enable = false
   [plugins.inputs.postBuild]
     enable = true
+    record = true
     spa = true
     start = 'gatsby serve -p 8080'


### PR DESCRIPTION
The Cypress Dashboard **might** help to find flaky tests, so let's enable it.

Instructions:

- Create a new Cypress project https://dashboard.cypress.io

 - On Netilfy, create the following env variables:

```
CYPRESS_PROJECT_ID=<assigned by Cypress>
CYPRESS_RECORD_KEY=<from Cypress too>
```

Once ready, the dashboard should list test runs:

![image](https://user-images.githubusercontent.com/1172479/179072920-e62e1743-bb4f-44e4-b17b-64ab5364311d.png)


 