### PR TITLE
Fix Taxonomy Classifications section's titles that breaks on mobile

### DIFF
--- a/site/gatsby-site/cypress/support/commands.js
+++ b/site/gatsby-site/cypress/support/commands.js
@@ -42,7 +42,7 @@ Cypress.Commands.add(
 Cypress.Commands.add('query', ({ query, variables }) => {
   const client = getApolloClient();
 
-  return cy.wrap(client.query({ query, variables }), { timeout: 8000, log: true });
+  return cy.wrap(client.query({ query, variables }), { timeout: 15000, log: true });
 });
 
 Cypress.Commands.add('clickOutside', () => {

--- a/site/gatsby-site/src/components/taxa/Taxonomy.js
+++ b/site/gatsby-site/src/components/taxa/Taxonomy.js
@@ -26,8 +26,14 @@ const Field = styled.div`
   width: 20%;
   border-right: 2.5px solid #d9deee;
   margin-right: 1em;
+  padding-right: 0.5em;
   color: grey;
   font-weight: 700;
+
+  @media only screen and (max-width: 767px) {
+    width: 50%;
+    min-width: 40%;
+  }
 `;
 
 const Value = styled(Markdown)`


### PR DESCRIPTION
### This PR

Fix the line breaks on the Taxonomy Classifications section's titles on mobile.
Check issue #787 for more information.

### Testing steps

1- Go to the preview [link](https://fix-classifications-titles--pablo-staging-aiid.netlify.app/cite/10)
2- Check Taxonomy Classification section on Desktop and mobile

Closes #787 