### PR TITLE
Make `WebArchiveLink`s split buttons with original and archive urls

### DIFF
--- a/site/gatsby-site/cypress/e2e/discover.cy.js
+++ b/site/gatsby-site/cypress/e2e/discover.cy.js
@@ -101,4 +101,27 @@ describe('The Discover app', () => {
 
     cy.get('@modal').should('not.exist');
   });
+
+  it('Opens an archive link', () => {
+    cy.visit(url, {
+      onBeforeLoad: (win) => {
+        cy.stub(win, 'open', () => {}).as('windowOpen');
+      },
+    });
+
+    cy.get('[data-cy="web-archive-link"] .dropdown-toggle').first().click();
+
+    cy.get('[data-cy="original"]')
+      .first()
+      .should('be.visible')
+      .should('have.attr', 'target', '_blank')
+      .invoke('attr', 'href')
+      .then((href) => {
+        expect(href).to.not.contain('web.archive.org');
+      });
+
+    cy.get('[data-cy="wayback-machine"]').first().should('be.visible').click();
+
+    cy.get('@windowOpen').should('be.called');
+  });
 });

--- a/site/gatsby-site/src/components/cite/IncidentCard.js
+++ b/site/gatsby-site/src/components/cite/IncidentCard.js
@@ -6,6 +6,7 @@ import { fill } from '@cloudinary/base/actions/resize';
 import { useUserContext } from 'contexts/userContext';
 import Actions from 'components/discover/Actions';
 import ReportText from 'components/reports/ReportText';
+import WebArchiveLink from 'components/ui/WebArchiveLink';
 
 const IncidentCardContainer = styled.div`
   border: 1.5px solid #d9deee;
@@ -14,8 +15,11 @@ const IncidentCardContainer = styled.div`
   display: flex;
   flex-direction: column;
   .subhead {
+    color: var(--bs-gray-600);
+    a:not(:hover) {
+      color: inherit;
+    }
     margin: 0;
-    opacity: 0.4;
     padding-top: 10px;
   }
 `;
@@ -59,8 +63,10 @@ const IncidentCard = ({ item, authorsModal, submittersModal, flagReportModal }) 
           )}
         </div>
         <p className="subhead">
-          {item.source_domain} &middot;{' '}
-          {item.date_published ? item.date_published.substring(0, 4) : 'Needs publish date'}
+          <WebArchiveLink url={item.url}>
+            {item.source_domain} &middot;{' '}
+            {item.date_published ? item.date_published.substring(0, 4) : 'Needs publish date'}
+          </WebArchiveLink>
         </p>
       </div>
       <CardBody className="card-body">

--- a/site/gatsby-site/src/components/discover/hitTypes/Compact.js
+++ b/site/gatsby-site/src/components/discover/hitTypes/Compact.js
@@ -9,7 +9,6 @@ import { HeaderTitle, SourceDomainSubtitle } from './shared';
 
 const StyledCard = styled(Card)`
   height: 240px;
-  overflow: hidden;
 
   :hover {
     background: #00000000;
@@ -55,6 +54,8 @@ const StyledHeaderTitle = styled(HeaderTitle)`
   * {
     font-size: 1rem;
   }
+  max-height: 5em;
+  overflow: hidden;
 `;
 
 const StyledSubTitle = styled(SourceDomainSubtitle)`

--- a/site/gatsby-site/src/components/discover/hitTypes/shared.js
+++ b/site/gatsby-site/src/components/discover/hitTypes/shared.js
@@ -4,9 +4,12 @@ import React from 'react';
 import { Card } from 'react-bootstrap';
 import { Highlight } from 'react-instantsearch-dom';
 import styled from 'styled-components';
+import WebArchiveLink from '../../../components/ui/WebArchiveLink';
 
 const linkHoverHighlight = `
-  a:not(:hover) { color: inherit; }
+  a:not(:hover) {
+    color: inherit;
+  }
 `;
 
 const HeaderCard = styled(Card.Title)`
@@ -27,7 +30,11 @@ export function citationReportUrl(item) {
 export function HeaderTitle({ item, ...props }) {
   return (
     <HeaderCard {...props}>
-      <LocalizedLink to={citationReportUrl(item)} className="text-decoration-none">
+      <LocalizedLink
+        to={citationReportUrl(item)}
+        className="text-decoration-none"
+        title={item.title}
+      >
         <Highlight hit={item} attribute="title" />
       </LocalizedLink>
     </HeaderCard>
@@ -37,9 +44,9 @@ export function HeaderTitle({ item, ...props }) {
 export function SourceDomainSubtitle({ item, ...props }) {
   return (
     <SubdomainCard {...props}>
-      <a href={item.url}>
+      <WebArchiveLink url={item.url} date={item.date_submitted}>
         {item.source_domain} &middot; {format(fromUnixTime(item.epoch_date_published), 'yyyy')}
-      </a>
+      </WebArchiveLink>
     </SubdomainCard>
   );
 }

--- a/site/gatsby-site/src/components/ui/WebArchiveLink.js
+++ b/site/gatsby-site/src/components/ui/WebArchiveLink.js
@@ -1,4 +1,24 @@
 import React from 'react';
+import { Dropdown, SplitButton } from 'react-bootstrap';
+import styled from 'styled-components';
+
+const ArchiveOriginalSplit = styled(SplitButton)`
+  > *.dropdown-toggle {
+    padding: 0px !important;
+    margin: 0px !important;
+    margin-left: 2px !important;
+    width: 2ch;
+    color: inherit;
+  }
+  > *:not(.dropdown-toggle) {
+    padding: 0px !important;
+    margin: 0px !important;
+  }
+  a {
+    text-decoration: none;
+    font-weight: inherit;
+  }
+`;
 
 async function getSnapshotURL(url, date) {
   const timestamp = date ? date.replace('-', '') : '';
@@ -10,7 +30,7 @@ async function getSnapshotURL(url, date) {
   return response.archived_snapshots.closest.url.replace('http:', 'https:');
 }
 
-export default function WebArchiveLink({ url, date, children, className, title }) {
+export default function WebArchiveLink({ url, date, children, className }) {
   const onClick = async (e) => {
     e.preventDefault();
     const win = window.open('', '_blank');
@@ -25,15 +45,20 @@ export default function WebArchiveLink({ url, date, children, className, title }
   };
 
   return (
-    <a
-      title={title}
-      className={className}
-      onClick={onClick}
+    <ArchiveOriginalSplit
+      variant="link"
+      title={children}
       href={url}
       target="_blank"
       rel="noopener noreferrer"
+      className={className}
     >
-      {children}
-    </a>
+      <Dropdown.Item eventKey="1" href={url} target="_blank" rel="noopener noreferrer">
+        View the page at its original source
+      </Dropdown.Item>
+      <Dropdown.Item eventKey="2" onClick={onClick} target="_blank" rel="noopener noreferrer">
+        View the page archived by the Wayback Machine
+      </Dropdown.Item>
+    </ArchiveOriginalSplit>
   );
 }

--- a/site/gatsby-site/src/components/ui/WebArchiveLink.js
+++ b/site/gatsby-site/src/components/ui/WebArchiveLink.js
@@ -53,11 +53,24 @@ export default function WebArchiveLink({ url, date, children, className }) {
       target="_blank"
       rel="noopener noreferrer"
       className={className}
+      data-cy="web-archive-link"
     >
-      <Dropdown.Item eventKey="1" href={url} target="_blank" rel="noopener noreferrer">
+      <Dropdown.Item
+        eventKey="1"
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        data-cy="original"
+      >
         <Trans>View the page at its original source</Trans>
       </Dropdown.Item>
-      <Dropdown.Item eventKey="2" onClick={onClick} target="_blank" rel="noopener noreferrer">
+      <Dropdown.Item
+        eventKey="2"
+        onClick={onClick}
+        target="_blank"
+        rel="noopener noreferrer"
+        data-cy="wayback-machine"
+      >
         <Trans>View the page archived by the Wayback Machine</Trans>
       </Dropdown.Item>
     </ArchiveOriginalSplit>

--- a/site/gatsby-site/src/components/ui/WebArchiveLink.js
+++ b/site/gatsby-site/src/components/ui/WebArchiveLink.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Dropdown, SplitButton } from 'react-bootstrap';
 import styled from 'styled-components';
+import { Trans } from 'react-i18next';
 
 const ArchiveOriginalSplit = styled(SplitButton)`
   > *.dropdown-toggle {
@@ -54,10 +55,10 @@ export default function WebArchiveLink({ url, date, children, className }) {
       className={className}
     >
       <Dropdown.Item eventKey="1" href={url} target="_blank" rel="noopener noreferrer">
-        View the page at its original source
+        <Trans>View the page at its original source</Trans>
       </Dropdown.Item>
       <Dropdown.Item eventKey="2" onClick={onClick} target="_blank" rel="noopener noreferrer">
-        View the page archived by the Wayback Machine
+        <Trans>View the page archived by the Wayback Machine</Trans>
       </Dropdown.Item>
     </ArchiveOriginalSplit>
   );


### PR DESCRIPTION
Implements [suggestion](https://github.com/responsible-ai-collaborative/aiid/issues/61#issuecomment-1185726082) in #61, adding dropdown to choose between original or archive.org url.

<img src="https://user-images.githubusercontent.com/25443411/179607160-c62ee7ef-a6bd-418f-9099-1bf12bc45f52.png" width="500"/>
