### PR TITLE
Render jsx in popovers, click to toggle visibility

### DIFF
--- a/site/gatsby-site/src/components/forms/Label.js
+++ b/site/gatsby-site/src/components/forms/Label.js
@@ -1,21 +1,29 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { OverlayTrigger, Form } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
 import PropTypes from 'prop-types';
 
 const Label = ({ popover, placement, trigger, label }) => {
+  const [show, setShow] = useState(false);
+
   if (!popover) {
     return <Form.Label>{label} :</Form.Label>;
   }
   return (
-    <OverlayTrigger trigger={trigger} placement={placement} overlay={popover}>
+    <OverlayTrigger
+      trigger={trigger}
+      placement={placement}
+      overlay={popover}
+      {...(show ? { show } : {})}
+    >
       <Form.Label>
         {label}{' '}
         <FontAwesomeIcon
           icon={faQuestionCircle}
           style={{ color: 'rgb(210, 210, 210)' }}
           className="far fa-question-circle"
+          onClick={() => setShow(!show)}
         />{' '}
         :
       </Form.Label>

--- a/site/gatsby-site/src/components/forms/Label.js
+++ b/site/gatsby-site/src/components/forms/Label.js
@@ -21,7 +21,7 @@ const Label = ({ popover, placement, trigger, label }) => {
         {label}{' '}
         <FontAwesomeIcon
           icon={faQuestionCircle}
-          style={{ color: 'rgb(210, 210, 210)' }}
+          style={{ color: 'rgb(210, 210, 210)', cursor: 'pointer' }}
           className="far fa-question-circle"
           onClick={() => setShow(!show)}
         />{' '}

--- a/site/gatsby-site/src/components/submissions/SubmissionForm.js
+++ b/site/gatsby-site/src/components/submissions/SubmissionForm.js
@@ -293,7 +293,7 @@ const SubmissionForm = () => {
         </Form.Group>
 
         <Form.Group className="mt-3">
-          <Label popover={POP_OVERS['language']} label={t('Tags')} />
+          <Label popover={POP_OVERS['tags']} label={t('Tags')} />
           <TagsControl name={'tags'} />
         </Form.Group>
 

--- a/site/gatsby-site/src/components/ui/PopOvers.js
+++ b/site/gatsby-site/src/components/ui/PopOvers.js
@@ -26,7 +26,7 @@ export const submitters = Popover({
 
 export const incident_date = Popover({
   title: 'When did the incident first occur?',
-  text: `Many AI incidents are not discrete events ({i.e., they happen over a period of time}).
+  text: `Many AI incidents are not discrete events (i.e. they happen over a period of time).
   Further, it is often difficult to know when the incident first occured when the first
   public report follows some period of time after the first occurence. In this field
   you should enter either the date of the first report of the incident, or

--- a/site/gatsby-site/src/components/ui/PopOvers.js
+++ b/site/gatsby-site/src/components/ui/PopOvers.js
@@ -1,96 +1,101 @@
+import React from 'react';
 import Popover from 'components/ui/Popover';
 
 // These tooltip messages are displayed on the form elements explaining what is expected to be input.
-export const title = Popover(
-  'Headline',
-  `Most works have a title that should be entered here verbatim.
+export const title = Popover({
+  title: 'Headline',
+  text: `Most works have a title that should be entered here verbatim.
   In the event the work has no title, attempt to summarize the contents in a few words without editorializing.
-  This text is featured prominently in incident records.`
-);
+  This text is featured prominently in incident records.`,
+});
 
-export const authors = Popover(
-  'Creator of the Linked Content',
-  `Enter the names of the creators of the linked content.
+export const authors = Popover({
+  title: 'Creator of the Linked Content',
+  text: `Enter the names of the creators of the linked content.
   You should enter all persons contributing to the written work as a single
-  row of a CSV.`
-);
+  row of a CSV.`,
+});
 
-export const submitters = Popover(
-  'This is you!',
-  `Enter your name here. If more than one person contributed to collecting the incident,
+export const submitters = Popover({
+  title: 'This is you!',
+  text: `Enter your name here. If more than one person contributed to collecting the incident,
   you can enter multiple people separated with commas. Alternatively, you can enter
   "Anonymous" as submitter if you do not want to be attributed in the database.
-  Entries in this field will be added to the public leaderboard.`
-);
+  Entries in this field will be added to the public leaderboard.`,
+});
 
-export const incident_date = Popover(
-  'When did the incident first occur?',
-  `Many AI incidents are not discrete events (i.e., they happen over a period of time).
+export const incident_date = Popover({
+  title: 'When did the incident first occur?',
+  text: `Many AI incidents are not discrete events ({i.e., they happen over a period of time}).
   Further, it is often difficult to know when the incident first occured when the first
   public report follows some period of time after the first occurence. In this field
   you should enter either the date of the first report of the incident, or
   an educated guess of when the incident likely first occured. For instance, if
   the incident is pertaining to a search engine feature that launched in January
   and the first public incident report is in February, you should assign an
-  incident date in January.`
-);
+  incident date in January.`,
+});
 
-export const date_published = Popover(
-  'When did the report become available?',
-  `Reports often have a publication date at the URL, but even when it does not,
-  you can visit the <a href="https://archive.org/web/">Wayback Machine</a>
-  to find when the report URL was first indexed.`
-);
+export const date_published = Popover({
+  title: 'When did the report become available?',
+  text: (
+    <>
+      Reports often have a publication date at the URL, but even when it does not, you can visit the{' '}
+      <a href="https://archive.org/web/">Wayback Machine</a> to find when the report URL was first
+      indexed.text:
+    </>
+  ),
+});
 
-export const date_downloaded = Popover(
-  'When did you copy the contents of the report into this form?',
-  `Reports are often updated through time by news organizations. This
+export const date_downloaded = Popover({
+  title: 'When did you copy the contents of the report into this form?',
+  text: `Reports are often updated through time by news organizations. This
   date helps determine whether the contents could potentially be stale. Typically
-  you will put today's date here.`
-);
+  you will put todaytitle: 's date here.`,
+});
 
-export const url = Popover(
-  'Link to the publicly available report',
-  `This address will be linked to within many incident database UIs.`
-);
+export const url = Popover({
+  title: 'Link to the publicly available report',
+  text: `This address will be linked to within many incident database UIs.`,
+});
 
-export const image_url = Popover(
-  'An image used to preview the incident report',
-  `This should be a URL for an image that will be indexed and displayed next to the report.
+export const image_url = Popover({
+  title: 'An image used to preview the incident report',
+  text: `This should be a URL for an image that will be indexed and displayed next to the report.
   Most publications now have headline images you can grab a URL from by right-clicking.
-  You can also link figure images here instead.`
-);
+  You can also link figure images here instead.`,
+});
 
-export const incident_id = Popover(
-  'Is this an existing incident?',
-  `Very often reports are written about incidents that are already in the incident database.
+export const incident_id = Popover({
+  title: 'Is this an existing incident?',
+  text: `Very often reports are written about incidents that are already in the incident database.
   Before submitting, you should check whether the incident is in the database already by
   visiting the "Discover" application and searching for incidents of a similar nature
   to the incident report you are now submitting. If an incident exists for your report, but
   the report has never been submitted, please enter the corresponding incident identifier
   number here. If the incident report already exists,
-  please do not resubmit.`
-);
+  please do not resubmit.`,
+});
 
-export const text = Popover(
-  'Text of the article or transcript of the rich media',
-  `Copy, paste, and validate the textual contents of the incident report
+export const text = Popover({
+  title: 'Text of the article or transcript of the rich media',
+  text: `Copy, paste, and validate the textual contents of the incident report
   match the contents of the URL linked above. Please scrub it of all advertisements
   and other media that should not be indexed and searched when users are discovering
-  incidents in the database.`
-);
+  incidents in the database.`,
+});
 
-export const reportAddress = Popover(
-  'Link to the publicly available report',
-  `This address will be linked to within many incident database UIs.`
-);
+export const reportAddress = Popover({
+  title: 'Link to the publicly available report',
+  text: `This address will be linked to within many incident database UIs.`,
+});
 
-export const tags = Popover(
-  'Tag the type of incident report',
-  `The purpose of report tags is to support sorting reports on the citation page for the incident. When in doubt, you can leave this field blank and a database editor will select appropriate tags at ingestion time.`
-);
+export const tags = Popover({
+  title: 'Tag the type of incident report',
+  text: `The purpose of report tags is to support sorting reports on the citation page for the incident. When in doubt, you can leave this field blank and a database editor will select appropriate tags at ingestion time.`,
+});
 
-export const language = Popover(
-  'Language of the incident report',
-  `This is the written language of the text found in the report, not the language of the people or countries involved in the report. The reports will be translated to supported languages when we ingest the text.`
-);
+export const language = Popover({
+  title: 'Language of the incident report',
+  text: `This is the written language of the text found in the report, not the language of the people or countries involved in the report. The reports will be translated to supported languages when we ingest the text.`,
+});

--- a/site/gatsby-site/src/components/ui/Popover.js
+++ b/site/gatsby-site/src/components/ui/Popover.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Popover as BSPopOver } from 'react-bootstrap';
 
-const Popover = (title, text) => (
+const Popover = ({ title, text }) => (
   <BSPopOver id="popover-basic">
     <BSPopOver.Header as="h3">{title}</BSPopOver.Header>
     <BSPopOver.Body>{text}</BSPopOver.Body>


### PR DESCRIPTION
Resolves #843.

<img src="https://user-images.githubusercontent.com/25443411/180825453-df7aa0d7-0867-4d52-9d11-f75e21286ee5.png" height="300"/>

There was previously no way to actually use the link when rendered, because the popover would disappear as soon as you moved your mouse toward it. This PR makes it so that clicking the (?) icon will cause the popover to remain visible until it's clicked again, allowing interaction with elements inside the popover.