### PR TITLE
Switch quicksearch placeholder text determination from js to css

### DIFF
--- a/site/gatsby-site/src/components/forms/SearchInput.js
+++ b/site/gatsby-site/src/components/forms/SearchInput.js
@@ -26,11 +26,6 @@ const SearchFormControl = styled(FormControl)`
   border-bottom-right-radius: 0.3rem !important;
 `;
 
-const SearchInputGroup = styled(InputGroup)`
-  max-width: 640px;
-  margin: auto;
-`;
-
 export default withTranslation()(function SearchInput({
   value,
   onChange,
@@ -41,7 +36,7 @@ export default withTranslation()(function SearchInput({
   placeHolder = t('Type Here'),
 }) {
   return (
-    <SearchInputGroup className="position-relative">
+    <InputGroup className="position-relative">
       <SearchFormControl
         size={size}
         placeholder={placeHolder}
@@ -59,6 +54,6 @@ export default withTranslation()(function SearchInput({
           <FontAwesomeIcon opacity={0.5} icon={faSearch} className="pointer" />
         )}
       </SearchStatus>
-    </SearchInputGroup>
+    </InputGroup>
   );
 });

--- a/site/gatsby-site/src/components/landing/QuickSearch.js
+++ b/site/gatsby-site/src/components/landing/QuickSearch.js
@@ -1,8 +1,42 @@
 import SearchInput from 'components/forms/SearchInput';
 import { navigate } from 'gatsby';
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Button, Card, Col, Form, Row } from 'react-bootstrap';
 import { Trans, useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+
+const SearchInputWrapper = styled.div`
+  position: relative;
+  max-width: 640px;
+  margin: auto;
+  :after {
+    color: var(--bs-gray-600);
+    font-size: 1.25rem;
+    position: absolute;
+    left: 1em;
+    top: 50%;
+    padding-top: -50%;
+    transform: translateY(-50%);
+    z-index: 3;
+    pointer-events: none;
+
+    content: '${(props) => props.t('Search reports')}';
+    @media (min-width: 350px) {
+      content: '${(props) => props.t('Search 1600+ reports')}';
+    }
+    @media (min-width: 450px) {
+      content: '${(props) => props.t('Search 1600+ AI harm reports')}';
+    }
+    @media (min-width: 500px) {
+      content: '${(props) => props.t('Search over 1600 reports of AI harms')}';
+    }
+  }
+  &.has-input {
+    :after {
+      content: '' !important;
+    }
+  }
+`;
 
 export default function QuickSearch({ className }) {
   const [searchTerm, setSearchTerm] = useState('');
@@ -17,28 +51,6 @@ export default function QuickSearch({ className }) {
     navigate(`/apps/discover`);
   };
 
-  const [placeHolderText, setPlaceHolderText] = useState('Search 1600+ reports');
-
-  useEffect(() => {
-    const updatePlaceHolder = () => {
-      if (document) {
-        const w = document.body.scrollWidth;
-
-        if (w > 500) setPlaceHolderText('Search over 1600 reports of AI harms');
-        else if (w > 450) setPlaceHolderText('Search 1600+ AI harm reports');
-        else if (w > 350) setPlaceHolderText('Search 1600+ reports');
-        else setPlaceHolderText('Search reports');
-      }
-    };
-
-    updatePlaceHolder();
-
-    if (window) {
-      window.addEventListener('resize', updatePlaceHolder);
-      return () => window.removeEventListener('resize', updatePlaceHolder);
-    }
-  }, []);
-
   const { t } = useTranslation(['translation', 'landing', 'actions']);
 
   return (
@@ -46,16 +58,18 @@ export default function QuickSearch({ className }) {
       <Card className={className}>
         <Card.Body>
           <Form onSubmit={submit} id="quickSearch">
-            <SearchInput
-              size="lg"
-              value={searchTerm}
-              onChange={setSearchTerm}
-              onClear={() => setSearchTerm('')}
-              placeHolder={t(placeHolderText, { ns: 'landing' })}
-              onKeyPress={(e) => {
-                e.key === 'Enter' && submit(e);
-              }}
-            />
+            <SearchInputWrapper t={t} className={searchTerm == '' ? '' : 'has-input'}>
+              <SearchInput
+                size="lg"
+                value={searchTerm}
+                onChange={setSearchTerm}
+                onClear={() => setSearchTerm('')}
+                placeHolder=""
+                onKeyPress={(e) => {
+                  e.key === 'Enter' && submit(e);
+                }}
+              />
+            </SearchInputWrapper>
             <Row>
               <Col className="d-flex gap-2 justify-content-center">
                 <Button size="lg" variant="primary" className="mt-4" type="submit">


### PR DESCRIPTION
This fixes the issue from #847 where

>The width of the page on initial render jumps between widths. I believe it is rendering a default, then updating to whatever the screen size is. This is particularly clear when it comes to the search box text, which changes between "Search over 1600 reports of AI harms" and "Search 1600+ reports".

The text is now set with css, meaning that the browser can render the initial html appropriately for the screen size without having to wait for React to re-render the component. Unfortunately, css doesn't provide a way to set placeholder text, so it we have to simulate it with an `:after` styled to look like a placeholder.