### PR TITLE
Use request body instead of query parameters for semanticallyRelated

### DIFF
--- a/site/gatsby-site/src/api/semanticallyRelated.js
+++ b/site/gatsby-site/src/api/semanticallyRelated.js
@@ -1,7 +1,8 @@
 const axios = require('axios');
 
 export default async function handler(req, res) {
-  const { text, max_retries, num } = req.query;
+  console.log('req.body', req.body);
+  const { text, max_retries, num } = JSON.parse(req.body);
 
   // Example result
   // {
@@ -14,12 +15,7 @@ export default async function handler(req, res) {
   //      "msg": "[(0.9972602725028992, 10), (0.996686577796936, 73), (0.9966337084770203, 134)]",
   //      "best_url": "https://incidentdatabase.ai/apps/discover?display=details&incident_id=10"
   //  }}
-  const url =
-    'https://q3z6vr2qvj.execute-api.us-west-2.amazonaws.com/text-to-db-similar?' +
-    'num=' +
-    String(num || 3) +
-    '&text=' +
-    encodeURIComponent(text);
+  const url = 'https://q3z6vr2qvj.execute-api.us-west-2.amazonaws.com/text-to-db-similar';
 
   let response;
 
@@ -29,7 +25,14 @@ export default async function handler(req, res) {
 
   while (tries < (max_retries || 3) && (response?.status !== 200 || error)) {
     try {
-      response = await axios.get(url);
+      response = await axios({
+        url,
+        method: 'POST',
+        data: {
+          num: String(num || 3),
+          text: text,
+        },
+      });
       if (response?.status === 200) {
         res.status(200).json({
           // See: https://github.com/responsible-ai-collaborative/nlp-lambdas/issues/9

--- a/site/gatsby-site/src/api/semanticallyRelated.js
+++ b/site/gatsby-site/src/api/semanticallyRelated.js
@@ -1,7 +1,6 @@
 const axios = require('axios');
 
 export default async function handler(req, res) {
-  console.log('req.body', req.body);
   const { text, max_retries, num } = JSON.parse(req.body);
 
   // Example result

--- a/site/gatsby-site/src/components/SemanticallyRelatedIncidents.js
+++ b/site/gatsby-site/src/components/SemanticallyRelatedIncidents.js
@@ -18,12 +18,14 @@ const relatedIncidentIdsQuery = gql`
 `;
 
 const semanticallyRelated = async (text) => {
-  const url = `/api/semanticallyRelated?text=${text}`;
+  const url = `/api/semanticallyRelated`;
 
   let controller = new AbortController();
 
   setTimeout(() => controller.abort(), 33000);
   const response = await fetch(url, {
+    method: 'POST',
+    body: JSON.stringify({ text }),
     signal: controller.signal,
   });
 


### PR DESCRIPTION
This prevents failure on long input texts. May help with the reliability issues mentioned in #847.