### PR TITLE
Create 404 images Migration

### DIFF
--- a/site/gatsby-site/migrations/2022.07.26T17.46.22.fix-404-report-images.js
+++ b/site/gatsby-site/migrations/2022.07.26T17.46.22.fix-404-report-images.js
@@ -1,0 +1,24 @@
+const config = require('../config');
+
+/**
+ * @type {import('umzug').MigrationFn<any>}
+ * @param {{context: {client: import('mongodb').MongoClient}}} context
+ */
+exports.up = async ({ context: { client } }) => {
+  const collection = client.db(config.realm.production_db.db_name).collection('reports');
+
+  await collection.updateOne(
+    { report_number: 1173 },
+    {
+      $set: {
+        cloudinary_id:
+          'reports/images.khaleejtimes.com/storyimage/KT/20170804/ARTICLE/170809597/AR/0/AR-170809597.jpg',
+      },
+    }
+  );
+
+  await collection.updateOne(
+    { report_number: 1175 },
+    { $set: { cloudinary_id: 'reports/s2.reutersmedia.net' } }
+  );
+};


### PR DESCRIPTION
Replaces PR #795 

Fix
This fix has a migration that fixes the URLs of both broken 404 images on incident 66.
A more important fix or troubleshooting should be done in the future to discover the root of the problem. UPDATE: @lmcnulty is working on it.