### PR TITLE
Raise z-index of header to prevent covered language switcher menu

### DIFF
--- a/site/gatsby-site/src/global.css
+++ b/site/gatsby-site/src/global.css
@@ -272,7 +272,7 @@ a:hover {
   -webkit-box-shadow: -1px 0px 4px 1px rgba(175, 158, 232, 0.4);
   -moz-box-shadow: -1px 0px 4px 1px rgba(175, 158, 232, 0.8);
   -o-box-shadow: -1px 0px 4px 1px rgba(175, 158, 232, 0.4);
-  z-index: 1;
+  z-index: 2;
   padding: 15px;
   position: relative;
   height: 80px;


### PR DESCRIPTION
#783 increased the z-index of the main element, so it would cover the menu of the language switcher. This increases the navigation z-index to prevent it.