### PR TITLE
Update OpenGraph meta tags to use incident title and description

### DIFF
--- a/site/gatsby-site/cypress/e2e/cite.cy.js
+++ b/site/gatsby-site/cypress/e2e/cite.cy.js
@@ -283,7 +283,7 @@ describe('Cite pages', () => {
     }).then(({ data: { incidents } }) => {
       const incident = incidents[0];
 
-      const title = incident.title;
+      const title = `Incident ${incidentId}: ${incident.title}`;
 
       const description = incident.description;
 

--- a/site/gatsby-site/cypress/e2e/cite.cy.js
+++ b/site/gatsby-site/cypress/e2e/cite.cy.js
@@ -281,11 +281,13 @@ describe('Cite pages', () => {
         }
       `,
     }).then(({ data: { incidents } }) => {
-      const title = `Incident ${incidentId}`;
+      const incident = incidents[0];
 
-      const description = `Citation record for Incident ${incidentId}`;
+      const title = incident.title;
 
-      const imageUrl = [...incidents[0].reports].sort((a, b) =>
+      const description = incident.description;
+
+      const imageUrl = [...incident.reports].sort((a, b) =>
         a.date_published >= b.date_published ? 1 : -1
       )[0].image_url;
 

--- a/site/gatsby-site/page-creators/createCitationPages.js
+++ b/site/gatsby-site/page-creators/createCitationPages.js
@@ -64,6 +64,8 @@ const createCitationPages = async (graphql, createPage) => {
         allMongodbAiidprodIncidents {
           nodes {
             incident_id
+            title
+            description
             date
             reports
             editors

--- a/site/gatsby-site/src/components/AiidHelmet.js
+++ b/site/gatsby-site/src/components/AiidHelmet.js
@@ -8,7 +8,7 @@ const AiidHelmet = ({
   metaDescription,
   canonicalUrl,
   metaImage,
-  metaType,
+  metaType = 'website',
 }) => {
   const twitter = config.siteMetadata.twitterAccount;
 
@@ -26,7 +26,7 @@ const AiidHelmet = ({
       {metaImage && <meta property="twitter:image" content={metaImage} />}
       {metaImage && <meta property="og:image" content={metaImage} />}
 
-      <meta property="og:type" content={metaType || 'website'} />
+      <meta property="og:type" content={metaType} />
 
       {twitter && <meta name="twitter:site" content={twitter} />}
       {twitter && <meta name="twitter:creator" content={twitter} />}

--- a/site/gatsby-site/src/templates/cite.js
+++ b/site/gatsby-site/src/templates/cite.js
@@ -17,6 +17,7 @@ import Taxonomy from 'components/taxa/Taxonomy';
 import { useUserContext } from 'contexts/userContext';
 import SimilarIncidents from 'components/cite/SimilarIncidents';
 import { Trans, useTranslation } from 'react-i18next';
+import { useLocalization } from 'gatsby-theme-i18n';
 
 const CardContainer = styled.div`
   border: 1.5px solid #d9deee;
@@ -73,11 +74,17 @@ function CitePage(props) {
 
   const { t } = useTranslation();
 
+  const { locale } = useLocalization();
+
   // meta tags
 
-  const metaTitle = t('Incident {{id}}', { id: incident.incident_id });
+  const defaultIncidentTitle = t('Citation record for Incident {{id}}', {
+    id: incident.incident_id,
+  });
 
-  const metaDescription = t('Citation record for Incident {{id}}', { id: incident.incident_id });
+  const metaTitle = incident.title;
+
+  const metaDescription = incident.description;
 
   const canonicalUrl = getCanonicalUrl(incident.incident_id);
 
@@ -125,7 +132,7 @@ function CitePage(props) {
       </AiidHelmet>
 
       <div className={'titleWrapper'}>
-        <StyledHeading>{metaDescription}</StyledHeading>
+        <StyledHeading>{locale == 'en' ? metaTitle : defaultIncidentTitle}</StyledHeading>
       </div>
 
       <Container>

--- a/site/gatsby-site/src/templates/cite.js
+++ b/site/gatsby-site/src/templates/cite.js
@@ -82,7 +82,7 @@ function CitePage(props) {
     id: incident.incident_id,
   });
 
-  const metaTitle = incident.title;
+  const metaTitle = `Incident ${incident.incident_id}: ${incident.title}`;
 
   const metaDescription = incident.description;
 


### PR DESCRIPTION
- On `cite.js`, change the `metaTitle` and `metaDescription` to start using the title and description from the incident itself.
- If the language is `en` use the actual incident title on the incident page:

### Before:

![image](https://user-images.githubusercontent.com/6564809/181630873-b02a0a7c-1723-4124-bc5e-239bc612977b.png)

### After:

![image](https://user-images.githubusercontent.com/6564809/181837458-9b354c83-5791-4871-8b7c-fb774c777620.png)

 

Closes #871 