### PR TITLE
Include flagged reports in incidents list

### DIFF
--- a/site/gatsby-site/src/pages/summaries/incidents.js
+++ b/site/gatsby-site/src/pages/summaries/incidents.js
@@ -86,7 +86,7 @@ export const pageQuery = graphql`
       }
     }
 
-    allMongodbAiidprodReports(filter: { flag: { eq: null } }) {
+    allMongodbAiidprodReports {
       nodes {
         id
         report_number


### PR DESCRIPTION
Resolves #887 (may need migration in #878 as well, not sure). The "missing" reports were in fact those that have `flagged: true`. I think the best solution is to just show them – flagged reports are visible elsewhere, so I don't see why we should hide them here. The discover app has a filter for flagged reports, but I now don't think it works.