### PR TITLE
Always select incident #1 rather than the top match in submit test

### DIFF
--- a/site/gatsby-site/cypress/e2e/submit.cy.js
+++ b/site/gatsby-site/cypress/e2e/submit.cy.js
@@ -110,7 +110,10 @@ describe('The Submit form', () => {
     );
 
     // Set the ID from the button in the list of semantically similar incidents
-    cy.get('[data-cy=related-byText] [data-cy=result] [data-cy=set-id]').first().click();
+    cy.get('[data-cy=related-byText] [data-cy=result] [data-cy=set-id]')
+      .contains('#1')
+      .first()
+      .click();
 
     cy.get(
       '[data-cy=related-byText] [data-cy=result] [data-cy="similar-selector"] [data-cy="similar"]'


### PR DESCRIPTION
For some reason, incident 55 is now (sometimes?) appearing ahead of incident 1 in the list of semantically related incidents in this test. In such case, this prevents the test from failing.