### PR TITLE
Increase number of retries for semanticallyRelated

### DIFF
--- a/site/gatsby-site/src/api/semanticallyRelated.js
+++ b/site/gatsby-site/src/api/semanticallyRelated.js
@@ -22,7 +22,7 @@ export default async function handler(req, res) {
 
   let error = null;
 
-  while (tries < (max_retries || 3) && (response?.status !== 200 || error)) {
+  while (tries < (max_retries || 6) && (response?.status !== 200 || error)) {
     try {
       response = await axios({
         url,

--- a/site/gatsby-site/src/components/SemanticallyRelatedIncidents.js
+++ b/site/gatsby-site/src/components/SemanticallyRelatedIncidents.js
@@ -22,7 +22,7 @@ const semanticallyRelated = async (text) => {
 
   let controller = new AbortController();
 
-  setTimeout(() => controller.abort(), 33000);
+  setTimeout(() => controller.abort(), 66000);
   const response = await fetch(url, {
     method: 'POST',
     body: JSON.stringify({ text }),


### PR DESCRIPTION
The semanticallyRelated api usually fails on a cold start. I added retries to try to address this, but it may not have been aggressive enough. This PR increases the retries and wait time. It will be taken out of draft when I'm satisfied that the numbers appropriate.