### PR TITLE
Remove width rule making flag overflow

### DIFF
--- a/site/gatsby-site/src/components/cite/SimilarIncidents.js
+++ b/site/gatsby-site/src/components/cite/SimilarIncidents.js
@@ -47,7 +47,6 @@ const IncidentCardImage = styled(Image)`
 
 const CardFooter = styled.div`
   display: flex;
-  width: 100%;
   flex-direction: row;
   align-items: center;
   font-weight: 500;


### PR DESCRIPTION
Fixes the issue in #917 where the flag button on similar incidents was not visible.