### PR TITLE
Use the new Atlas Service App graphQL URL format

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Create a `.env` file under `site/gatsby-site` with the following contents:
 
 ```
 GATSBY_REALM_APP_ID=aiidstitch2-vsdrv
+GATSBY_REALM_APP_GRAPHQL_URL=[to be updated in "Deploy the Realm App" section]
 MONGODB_CONNECTION_STRING=mongodb+srv://readonlyuser:gfz2JXY1SDmworgw@aiiddev.6zxh5.mongodb.net
 MONGODB_REPLICA_SET=aiiddev-shard-00-02.6zxh5.mongodb.net,aiiddev-shard-00-01.6zxh5.mongodb.net,aiiddev-shard-00-00.6zxh5.mongodb.net
 
@@ -163,9 +164,13 @@ Finally, update the previously created `.env`:
 
 ```
 GATSBY_REALM_APP_ID=aiidstitch2-<REALM_APP_ID>
+GATSBY_REALM_APP_GRAPHQL_URL=https://<REALM_APP_REGION>.aws.realm.mongodb.com/api/client/v2.0/app/aiidstitch2-<REALM_APP_ID>/graphql
 MONGODB_CONNECTION_STRING=mongodb+srv://<username>:<password>@aiiddev.<CLUSTER>.mongodb.net
 MONGODB_REPLICA_SET=aiiddev-shard-00-00.<CLUSTER>.mongodb.net,aiiddev-shard-00-01.<CLUSTER>.mongodb.net,aiiddev-shard-00-02.<CLUSTER>.mongodb.net
 ```
+
+To get the `GATSBY_REALM_APP_GRAPHQL_URL` value, go to Atlas Service App page, then select "GraphQL" on the left side of the page, and then copy the GraphQL Endpoint URL.
+
 Restart Gatsby, and your local app should fetch data from your MongoDB environment!
 
 ### Algolia environment setup
@@ -280,6 +285,7 @@ AWS_LAMBDA_JS_RUNTIME=nodejs14.x # required to run the Gatsby v4
 GATSBY_ALGOLIA_APP_ID=
 GATSBY_ALGOLIA_SEARCH_KEY=
 GATSBY_REALM_APP_ID=
+GATSBY_REALM_APP_GRAPHQL_URL=
 MONGODB_CONNECTION_STRING=
 MONGODB_REPLICA_SET=
 GATSBY_EXCLUDE_DATASTORE_FROM_BUNDLE=1 # specific to Netlify, for large sites
@@ -290,6 +296,7 @@ Two workflows take care of deploying the Realm app to both `production` and `sta
 These environments must contain the following variables:
 ```
 GATSBY_REALM_APP_ID=
+GATSBY_REALM_APP_GRAPHQL_URL=
 REALM_API_PRIVATE_KEY=
 REALM_API_PUBLIC_KEY=
 ```

--- a/site/gatsby-site/config.js
+++ b/site/gatsby-site/config.js
@@ -16,6 +16,7 @@ const config = {
       db_service: 'mongodb-atlas',
       db_name: 'aiidprod',
       db_collection: 'incidents',
+      realm_app_graphql_url: process.env.GATSBY_REALM_APP_GRAPHQL_URL,
     },
     graphqlApiKey: process.env.REALM_GRAPHQL_API_KEY,
   },

--- a/site/gatsby-site/cypress/plugins/index.js
+++ b/site/gatsby-site/cypress/plugins/index.js
@@ -21,6 +21,7 @@ module.exports = (on, config) => {
   config.env.e2eUsername = process.env.E2E_ADMIN_USERNAME;
   config.env.e2ePassword = process.env.E2E_ADMIN_PASSWORD;
   config.env.realmAppId = process.env.GATSBY_REALM_APP_ID;
+  config.env.realmAppGraphqlUrl = process.env.GATSBY_REALM_APP_GRAPHQL_URL;
 
   return config;
 };

--- a/site/gatsby-site/cypress/support/utils.js
+++ b/site/gatsby-site/cypress/support/utils.js
@@ -9,11 +9,11 @@ export const getApolloClient = () => {
 
   const password = Cypress.env('e2ePassword');
 
-  const realmAppId = Cypress.env('realmAppId');
+  const realmAppGraphqlUrl = Cypress.env('realmAppGraphqlUrl');
 
   const client = new ApolloClient({
     link: new HttpLink({
-      uri: `https://realm.mongodb.com/api/client/v2.0/app/${realmAppId}/graphql`,
+      uri: `${realmAppGraphqlUrl}`,
 
       fetch: async (uri, options) => {
         options.headers.email = email;

--- a/site/gatsby-site/src/api/graphql.js
+++ b/site/gatsby-site/src/api/graphql.js
@@ -15,16 +15,13 @@ const cors = Cors();
 async function realmExecutor({ document, variables }) {
   const query = print(document);
 
-  const fetchResult = await fetch(
-    `https://realm.mongodb.com/api/client/v2.0/app/${config.realm.production_db.realm_app_id}/graphql`,
-    {
-      method: 'POST',
-      headers: {
-        apiKey: config.realm.graphqlApiKey,
-      },
-      body: JSON.stringify({ query, variables }),
-    }
-  );
+  const fetchResult = await fetch(`${config.realm.production_db.realm_app_graphql_url}`, {
+    method: 'POST',
+    headers: {
+      apiKey: config.realm.graphqlApiKey,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
 
   return fetchResult.json();
 }

--- a/site/gatsby-site/src/contexts/userContext/UserContextProvider.js
+++ b/site/gatsby-site/src/contexts/userContext/UserContextProvider.js
@@ -11,7 +11,7 @@ import fetch from 'cross-fetch';
 const getApolloCLient = (getValidAccessToken) =>
   new ApolloClient({
     link: new HttpLink({
-      uri: `https://realm.mongodb.com/api/client/v2.0/app/${config.realm.production_db.realm_app_id}/graphql`,
+      uri: `${config.realm.production_db.realm_app_graphql_url}`,
 
       fetch: async (uri, options) => {
         const accessToken = await getValidAccessToken();


### PR DESCRIPTION
Atlas App Service has changed the GraphQL URL format for new apps from:

`https://realm.mongodb.com/api/client/v2.0/app/<REALM_APP_ID>/graphql`

to:
`https://<REALM_APP_REGION>.aws.realm.mongodb.com/api/client/v2.0/app/aiidstitch2-<REALM_APP_ID>/graphql`

So we have to change the code to use a new ENV variable `GATSBY_REALM_APP_GRAPHQL_URL` with the full URL value instead of just replacing the Realm App Id.

To get the `GATSBY_REALM_APP_GRAPHQL_URL` value, go to Atlas Service App page, then select "GraphQL" on the left side of the page, and then copy the GraphQL Endpoint URL.
