### PR TITLE
Revert tailwind’s `ol, ul { list-style: none }`

### DIFF
--- a/site/gatsby-site/src/tailwind.css
+++ b/site/gatsby-site/src/tailwind.css
@@ -3,9 +3,12 @@
 @tailwind utilities;
 
 @layer base {
-
     h2 {
         font-size: 2rem;
+    }
+
+    ul, ol {
+      list-style: revert;
     }
 
     .tw-layout {


### PR DESCRIPTION
Resolves #1015, restoring default list-styles:

---

![image](https://user-images.githubusercontent.com/25443411/186753564-9da818a6-435f-4214-9e4c-6cd2d9a532ce.png)

---

I didn't find anything that this broke, but I think it will require a change to #979 since I made the lists in the taxonomies field display inline, and those will look weird when they have bullets again.