### PR TITLE
Reduce TSNE nIter

### DIFF
--- a/site/gatsby-site/src/utils/updateTsne.js
+++ b/site/gatsby-site/src/utils/updateTsne.js
@@ -26,7 +26,7 @@ const updateTsneInDatabase = async () => {
     perplexity: 30.0,
     earlyExaggeration: 3.0,
     learningRate: 100.0,
-    nIter: 10000,
+    nIter: 1000,
     metric: 'euclidean',
   });
 


### PR DESCRIPTION
Reducing the TSNE nIter will put less strain on the build system, which might reduce crashiness. I think 1,000 works fine, I just set it to 10,000 for good measure.