### PR TITLE
Make 1st report only switch persist refresh

### DIFF
--- a/site/gatsby-site/src/components/discover/Controls.js
+++ b/site/gatsby-site/src/components/discover/Controls.js
@@ -11,7 +11,7 @@ import { Trans } from 'react-i18next';
 import Row from 'elements/Row';
 import Col from 'elements/Col';
 
-const Controls = ({ query, setHideDuplicates, hideDuplicates }) => {
+const Controls = ({ query, searchState, setSearchState }) => {
   const [expandFilters, setExpandFilters] = useState(false);
 
   useEffect(() => setExpandFilters(REFINEMENT_LISTS.some((r) => query[r.attribute])), []);
@@ -29,9 +29,15 @@ const Controls = ({ query, setHideDuplicates, hideDuplicates }) => {
           <Form.Check
             type="switch"
             id="hide-duplicates"
-            checked={hideDuplicates}
+            checked={searchState.refinementList.hideDuplicates}
             onClick={(event) => {
-              setHideDuplicates(event.target.checked);
+              setSearchState({
+                ...searchState,
+                refinementList: {
+                  ...searchState.refinementList,
+                  hideDuplicates: event.target.checked,
+                },
+              });
             }}
             className="tw-switch"
           />

--- a/site/gatsby-site/src/components/discover/Hits.js
+++ b/site/gatsby-site/src/components/discover/Hits.js
@@ -5,14 +5,7 @@ import { Spinner } from 'react-bootstrap';
 import { DisplayModeEnumParam } from './queryParams';
 import { useQueryParam } from 'use-query-params';
 
-const Hits = ({
-  hits,
-  toggleFilterByIncidentId,
-  authorsModal,
-  submittersModal,
-  flagReportModal,
-  isSearchStalled,
-}) => {
+const Hits = ({ hits, authorsModal, submittersModal, flagReportModal, isSearchStalled }) => {
   if (isSearchStalled) {
     return (
       <div className="tw-no-results">
@@ -43,7 +36,6 @@ const Hits = ({
           authorsModal={authorsModal}
           submittersModal={submittersModal}
           flagReportModal={flagReportModal}
-          toggleFilterByIncidentId={toggleFilterByIncidentId}
         />
       ))}
     </div>

--- a/site/gatsby-site/src/components/discover/Hits.js
+++ b/site/gatsby-site/src/components/discover/Hits.js
@@ -5,7 +5,14 @@ import { Spinner } from 'react-bootstrap';
 import { DisplayModeEnumParam } from './queryParams';
 import { useQueryParam } from 'use-query-params';
 
-const Hits = ({ hits, authorsModal, submittersModal, flagReportModal, isSearchStalled }) => {
+const Hits = ({
+  hits,
+  authorsModal,
+  submittersModal,
+  flagReportModal,
+  isSearchStalled,
+  toggleFilterByIncidentId,
+}) => {
   if (isSearchStalled) {
     return (
       <div className="tw-no-results">
@@ -36,6 +43,7 @@ const Hits = ({ hits, authorsModal, submittersModal, flagReportModal, isSearchSt
           authorsModal={authorsModal}
           submittersModal={submittersModal}
           flagReportModal={flagReportModal}
+          toggleFilterByIncidentId={toggleFilterByIncidentId}
         />
       ))}
     </div>

--- a/site/gatsby-site/src/components/discover/OptionsModal.js
+++ b/site/gatsby-site/src/components/discover/OptionsModal.js
@@ -11,7 +11,7 @@ import Col from 'elements/Col';
 import Button from 'elements/Button';
 // https://www.algolia.com/doc/guides/building-search-ui/going-further/native/react/?language=react#create-a-modal
 
-function OptionsModal({ setHideDuplicates, hideDuplicates }) {
+function OptionsModal({ searchState, setSearchState }) {
   const [showModal, setShowModal] = useState(false);
 
   const handleClose = () => setShowModal(false);
@@ -43,9 +43,15 @@ function OptionsModal({ setHideDuplicates, hideDuplicates }) {
             <Form.Check
               type="switch"
               id="hide-duplicates-modal"
-              checked={hideDuplicates}
+              checked={searchState.refinementList.hideDuplicates}
               onClick={(event) => {
-                setHideDuplicates(event.target.checked);
+                setSearchState({
+                  ...searchState,
+                  refinementList: {
+                    ...searchState.refinementList,
+                    hideDuplicates: event.target.checked,
+                  },
+                });
               }}
             />
             <Form.Label for="hide-duplicates-modal">

--- a/site/gatsby-site/src/components/discover/queryParams.js
+++ b/site/gatsby-site/src/components/discover/queryParams.js
@@ -1,4 +1,10 @@
-import { StringParam, createEnumParam, withDefault, NumberParam } from 'use-query-params';
+import {
+  StringParam,
+  createEnumParam,
+  withDefault,
+  NumberParam,
+  BooleanParam,
+} from 'use-query-params';
 
 const DisplayModeEnumParam = withDefault(
   createEnumParam(['details', 'compact', 'list']),
@@ -21,6 +27,7 @@ const queryConfig = {
   epoch_date_published_max: StringParam,
   display: DisplayModeEnumParam,
   page: withDefault(NumberParam, 1),
+  hideDuplicates: BooleanParam,
 };
 
 export { queryConfig, DisplayModeEnumParam, LanguageEnumParam };

--- a/site/gatsby-site/src/pages/apps/discover.js
+++ b/site/gatsby-site/src/pages/apps/discover.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import { useQueryParams } from 'use-query-params';
 import algoliasearch from 'algoliasearch/lite';
 import { Configure, InstantSearch } from 'react-instantsearch-dom';
@@ -195,6 +195,22 @@ function DiscoverApp(props) {
     setSearchState({ ...searchState });
   };
 
+  const toggleFilterByIncidentId = useCallback(
+    (incidentId) => {
+      const newSearchState = {
+        ...searchState,
+        refinementList: {
+          ...searchState.refinementList,
+          incident_id: [incidentId],
+        },
+      };
+
+      setSearchState(newSearchState);
+      setQuery(getQueryFromState(newSearchState), 'push');
+    },
+    [searchState]
+  );
+
   useEffect(() => {
     const searchQuery = getQueryFromState(searchState);
 
@@ -247,6 +263,7 @@ function DiscoverApp(props) {
           </Container>
 
           <Hits
+            toggleFilterByIncidentId={toggleFilterByIncidentId}
             authorsModal={authorsModal}
             submittersModal={submittersModal}
             flagReportModal={flagReportModal}

--- a/site/gatsby-site/src/pages/apps/discover.js
+++ b/site/gatsby-site/src/pages/apps/discover.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useQueryParams } from 'use-query-params';
 import algoliasearch from 'algoliasearch/lite';
 import { Configure, InstantSearch } from 'react-instantsearch-dom';
@@ -45,8 +45,10 @@ const removeEmptyAttributes = (obj) => {
 
 const convertArrayToString = (obj) => {
   for (const attr in obj) {
-    if (obj[attr].length > 0) {
-      obj[attr] = obj[attr].join('||');
+    if (Array.isArray(obj[attr])) {
+      if (obj[attr].length > 0) {
+        obj[attr] = obj[attr].join('||');
+      }
     }
   }
   return { ...obj };
@@ -72,6 +74,10 @@ const convertStringToArray = (obj) => {
         newObj[attr][0] = newObj[attr][0].substr(4);
       } else {
         newObj[attr] = obj[attr].split('||');
+      }
+    } else {
+      if (obj[attr]) {
+        newObj[attr] = obj[attr];
       }
     }
   }
@@ -189,24 +195,6 @@ function DiscoverApp(props) {
     setSearchState({ ...searchState });
   };
 
-  const [hideDuplicates, setHideDuplicates] = useState(false);
-
-  const toggleFilterByIncidentId = useCallback(
-    (incidentId) => {
-      const newSearchState = {
-        ...searchState,
-        refinementList: {
-          ...searchState.refinementList,
-          incident_id: [incidentId],
-        },
-      };
-
-      setSearchState(newSearchState);
-      setQuery(getQueryFromState(newSearchState), 'push');
-    },
-    [searchState]
-  );
-
   useEffect(() => {
     const searchQuery = getQueryFromState(searchState);
 
@@ -238,7 +226,7 @@ function DiscoverApp(props) {
           searchState={searchState}
           onSearchStateChange={onSearchStateChange}
         >
-          <Configure hitsPerPage={28} distinct={hideDuplicates} />
+          <Configure hitsPerPage={28} distinct={searchState.refinementList.hideDuplicates} />
 
           <VirtualFilters />
 
@@ -249,21 +237,16 @@ function DiscoverApp(props) {
               </Col>
             </Row>
 
-            <Controls
-              query={query}
-              setHideDuplicates={setHideDuplicates}
-              hideDuplicates={hideDuplicates}
-            />
+            <Controls query={query} searchState={searchState} setSearchState={setSearchState} />
 
             <OptionsModal
               className="hiddenDesktop"
-              setHideDuplicates={setHideDuplicates}
-              hideDuplicates={hideDuplicates}
+              searchState={searchState}
+              setSearchState={setSearchState}
             />
           </Container>
 
           <Hits
-            toggleFilterByIncidentId={toggleFilterByIncidentId}
             authorsModal={authorsModal}
             submittersModal={submittersModal}
             flagReportModal={flagReportModal}


### PR DESCRIPTION
Addresses item in https://github.com/responsible-ai-collaborative/aiid/pull/1020#issuecomment-1233459530.

> When 1st report only is turned on and the page is reloaded (or the URL is shared), the setting is not sticky.