### PR TITLE
Add Flowbite Spinner to Button element

### DIFF
--- a/site/gatsby-site/i18n/locales/es/submit.json
+++ b/site/gatsby-site/i18n/locales/es/submit.json
@@ -4,6 +4,7 @@
   "Report Address": "URL del Informe",
   "submitReviewDescription": "Los informes enviados se agregan a una <1>cola de revisión </1> para que se resuelvan en un registro de incidente nuevo o existente. Los incidentes se revisan y fusionan en la base de datos después de que haya suficientes incidentes pendientes.",
   "Fetch info": "Obtener información",
+  "Fetching...": "Obteniendo...",
   "Title": "Título",
   "Report title": "Título del Informe",
   "Author CSV": "Autor CSV",

--- a/site/gatsby-site/src/components/discover/Actions.js
+++ b/site/gatsby-site/src/components/discover/Actions.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Spinner } from 'react-bootstrap';
+import { Spinner } from 'flowbite-react';
 import WebArchiveLink from '../ui/WebArchiveLink';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
@@ -12,7 +12,7 @@ import {
 import { FIND_REPORT, UPDATE_REPORT } from '../../graphql/reports';
 import { useMutation, useQuery } from '@apollo/client';
 import { Trans, useTranslation } from 'react-i18next';
-import Button from 'elements/Button';
+import Button from '../../elements/Button';
 
 function FlagModalContent({ reportNumber }) {
   const { data } = useQuery(FIND_REPORT, {
@@ -40,7 +40,9 @@ function FlagModalContent({ reportNumber }) {
         <div dangerouslySetInnerHTML={{ __html: t('flagReport', { ns: 'actions' }) }} />
 
         {!report ? (
-          <Spinner size="sm" animation="border" />
+          <div className="flex justify-center">
+            <Spinner />
+          </div>
         ) : report.flag ? (
           <Button className="w-100" variant="danger" disabled data-cy="flag-toggle">
             <Trans>Flagged</Trans>
@@ -51,8 +53,9 @@ function FlagModalContent({ reportNumber }) {
             variant="danger"
             onClick={() => flagReport()}
             data-cy="flag-toggle"
+            loading={loading}
           >
-            <Trans>Flag Report</Trans> {loading && <Spinner size="sm" animation="border" />}
+            <Trans>Flag Report</Trans>
           </Button>
         )}
       </div>
@@ -71,12 +74,7 @@ export default function Actions({
 
   return (
     <>
-      <WebArchiveLink
-        url={item.url}
-        date={item.date_submitted}
-        className="btn btn-link px-1"
-        title={t('Authors')}
-      >
+      <WebArchiveLink url={item.url} date={item.date_submitted} className="btn btn-link px-1">
         <FontAwesomeIcon icon={faNewspaper} className="fa-newspaper" title="Read the Source" />
       </WebArchiveLink>
 

--- a/site/gatsby-site/src/components/forms/IncidentReportForm.js
+++ b/site/gatsby-site/src/components/forms/IncidentReportForm.js
@@ -1,22 +1,23 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Form, Button, Spinner } from 'react-bootstrap';
+import { Form } from 'react-bootstrap';
 import { useFormikContext } from 'formik';
 import * as yup from 'yup';
-import TextInputGroup from 'components/forms/TextInputGroup';
+import TextInputGroup from '../../components/forms/TextInputGroup';
 import useToastContext, { SEVERITY } from '../../hooks/useToast';
-import { dateRegExp } from 'utils/date';
-import { getCloudinaryPublicID, PreviewImageInputGroup } from 'utils/cloudinary';
+import { dateRegExp } from '../../utils/date';
+import { getCloudinaryPublicID, PreviewImageInputGroup } from '../../utils/cloudinary';
 import 'react-bootstrap-typeahead/css/Typeahead.css';
 import { graphql, useStaticQuery } from 'gatsby';
 import Label from './Label';
 import Typeahead from './Typeahead';
 import { Editor } from '@bytemd/react';
 import 'bytemd/dist/index.css';
-import IncidentIdField from 'components/incidents/IncidentIdField';
+import IncidentIdField from '../../components/incidents/IncidentIdField';
 import getSourceDomain from '../../utils/getSourceDomain';
-import supportedLanguages from 'components/i18n/languages.json';
+import supportedLanguages from '../../components/i18n/languages.json';
 import { useLocalization } from 'gatsby-theme-i18n';
-import { Trans } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
+import Button from '../../elements/Button';
 
 // set in form //
 // * title: "title of the report" # (string) The title of the report that is indexed.
@@ -91,6 +92,8 @@ const IncidentReportForm = () => {
     setFieldValue,
     setValues,
   } = useFormikContext();
+
+  const { t } = useTranslation(['submit']);
 
   const data = useStaticQuery(graphql`
     query IncidentReportFormQuery {
@@ -193,28 +196,19 @@ const IncidentReportForm = () => {
       >
         <TextInputGroup
           name="url"
-          label="Report Address"
-          placeholder="Report URL"
+          label={t('Report Address')}
+          placeholder={t('Report URL')}
           addOnComponent={
             <Button
-              className="outline-secondary"
+              variant="primary"
               disabled={!!errors.url || !touched.url || parsingNews}
               onClick={() => parseNewsUrl(values.url)}
+              loading={parsingNews}
             >
-              {' '}
               {!parsingNews ? (
-                <>Fetch info</>
+                <Trans ns="submit">Fetch info</Trans>
               ) : (
-                <>
-                  <Spinner
-                    as="span"
-                    animation="border"
-                    size="sm"
-                    role="status"
-                    aria-hidden="true"
-                  />{' '}
-                  Fetching...
-                </>
+                <Trans ns="submit">Fetching...</Trans>
               )}
             </Button>
           }

--- a/site/gatsby-site/src/components/submissions/SubmissionForm.js
+++ b/site/gatsby-site/src/components/submissions/SubmissionForm.js
@@ -1,23 +1,24 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Form, Button, Spinner } from 'react-bootstrap';
+import { Form } from 'react-bootstrap';
 import { useFormikContext } from 'formik';
 import * as yup from 'yup';
-import TextInputGroup from 'components/forms/TextInputGroup';
+import TextInputGroup from '../../components/forms/TextInputGroup';
 import useToastContext, { SEVERITY } from '../../hooks/useToast';
-import { dateRegExp } from 'utils/date';
-import { getCloudinaryPublicID, PreviewImageInputGroup } from 'utils/cloudinary';
+import { dateRegExp } from '../../utils/date';
+import { getCloudinaryPublicID, PreviewImageInputGroup } from '../../utils/cloudinary';
 import 'react-bootstrap-typeahead/css/Typeahead.css';
 import { graphql, useStaticQuery } from 'gatsby';
 import Label from '../forms/Label';
-import TagsControl from 'components/forms/TagsControl';
-import IncidentIdField from 'components/incidents/IncidentIdField';
+import TagsControl from '../../components/forms/TagsControl';
+import IncidentIdField from '../../components/incidents/IncidentIdField';
 import getSourceDomain from '../../utils/getSourceDomain';
 import { Editor } from '@bytemd/react';
 import 'bytemd/dist/index.css';
-import supportedLanguages from 'components/i18n/languages.json';
+import supportedLanguages from '../../components/i18n/languages.json';
 import { Trans, useTranslation } from 'react-i18next';
-import RelatedIncidents from 'components/RelatedIncidents';
-import SemanticallyRelatedIncidents from 'components/SemanticallyRelatedIncidents';
+import RelatedIncidents from '../../components/RelatedIncidents';
+import SemanticallyRelatedIncidents from '../../components/SemanticallyRelatedIncidents';
+import Button from '../../elements/Button';
 
 // set in form //
 // * title: "title of the report" # (string) The title of the report that is indexed.
@@ -235,25 +236,16 @@ const SubmissionForm = () => {
           placeholder={t('Report URL')}
           addOnComponent={
             <Button
-              className="outline-secondary"
+              variant="primary"
               disabled={!!errors.url || !touched.url || parsingNews}
               onClick={() => parseNewsUrl(values.url)}
               data-cy="fetch-info"
+              loading={parsingNews}
             >
-              {' '}
               {!parsingNews ? (
                 <Trans ns="submit">Fetch info</Trans>
               ) : (
-                <>
-                  <Spinner
-                    as="span"
-                    animation="border"
-                    size="sm"
-                    role="status"
-                    aria-hidden="true"
-                  />{' '}
-                  <Trans>Fetching...</Trans>
-                </>
+                <Trans ns="submit">Fetching...</Trans>
               )}
             </Button>
           }

--- a/site/gatsby-site/src/elements/Button/index.js
+++ b/site/gatsby-site/src/elements/Button/index.js
@@ -1,20 +1,26 @@
+import { Spinner } from 'flowbite-react';
 import React from 'react';
 
 export default function Button(props) {
-  let classNames = 'tw-btn';
+  let classNames = 'btn';
+
+  if (props.title === 'Flag Report') console.log('--- props.loading', props.loading);
 
   classNames += props.className ? ` ${props.className}` : '';
-  classNames += props.variant ? ` tw-btn-${props.variant}` : '';
-  classNames += props.size ? ` tw-btn-${props.size}` : '';
+  classNames += props.variant ? ` btn-${props.variant}` : '';
+  classNames += props.size ? ` btn-${props.size}` : '';
+  classNames += props.loading ? ` flex gap-2 justify-center` : '';
 
   return (
     <>
       {props.href ? (
         <a {...props} className={`${classNames}`} role="button">
+          {props.loading && <Spinner />}
           {props.children}
         </a>
       ) : (
         <button {...props} className={`${classNames}`}>
+          {props.loading && <Spinner />}
           {props.children}
         </button>
       )}

--- a/site/gatsby-site/src/elements/Button/index.js
+++ b/site/gatsby-site/src/elements/Button/index.js
@@ -9,17 +9,17 @@ export default function Button({
   loading = false,
   ...props
 }) {
-  let classNames = 'btn';
+  let classNames = 'tw-btn';
 
   classNames += props.className ? ` ${props.className}` : '';
-  classNames += variant ? ` btn-${variant}` : '';
-  classNames += size ? ` btn-${size}` : '';
+  classNames += variant ? ` tw-btn-${variant}` : '';
+  classNames += size ? ` tw-btn-${size}` : '';
   classNames += loading ? ` flex gap-2 justify-center` : '';
 
   return (
     <>
       {href ? (
-        <a {...props} className={`${classNames}`} role="button">
+        <a {...props} href={href} className={`${classNames}`} role="button">
           {loading && <Spinner />}
           {props.children}
         </a>

--- a/site/gatsby-site/src/elements/Button/index.js
+++ b/site/gatsby-site/src/elements/Button/index.js
@@ -1,26 +1,31 @@
 import { Spinner } from 'flowbite-react';
 import React from 'react';
 
-export default function Button(props) {
+export default function Button({
+  variant,
+  size = null,
+  href = null,
+  disabled = false,
+  loading = false,
+  ...props
+}) {
   let classNames = 'btn';
 
-  if (props.title === 'Flag Report') console.log('--- props.loading', props.loading);
-
   classNames += props.className ? ` ${props.className}` : '';
-  classNames += props.variant ? ` btn-${props.variant}` : '';
-  classNames += props.size ? ` btn-${props.size}` : '';
-  classNames += props.loading ? ` flex gap-2 justify-center` : '';
+  classNames += variant ? ` btn-${variant}` : '';
+  classNames += size ? ` btn-${size}` : '';
+  classNames += loading ? ` flex gap-2 justify-center` : '';
 
   return (
     <>
-      {props.href ? (
+      {href ? (
         <a {...props} className={`${classNames}`} role="button">
-          {props.loading && <Spinner />}
+          {loading && <Spinner />}
           {props.children}
         </a>
       ) : (
-        <button {...props} className={`${classNames}`}>
-          {props.loading && <Spinner />}
+        <button {...props} disabled={disabled} className={`${classNames}`}>
+          {loading && <Spinner />}
           {props.children}
         </button>
       )}


### PR DESCRIPTION
This PR adds a new loading state to the existing Button element.

<img width="452" alt="image" src="https://user-images.githubusercontent.com/6564809/188521731-1f9405a6-c688-49bd-9220-a24dda3dce9a.png">

Now we can set the loading state as a Button attribute:
ie: 
```
<Button
  className="w-100"
  variant="danger"
  onClick={() => flagReport()}
  data-cy="flag-toggle"
  loading={true}
  >
    <Trans>Flag Report</Trans>
</Button>
```


These pages/components are changed:

- Page `/cite/5` when the user clicks on the Flag button and it opens the Flag Report modal
- Page `/apps/discover` when the user clicks on the Flag button and it opens the Flag Report modal
- Page `/apps/submit` when the user clicks on the "Fetch info" button
- Page `/cite/edit?report_number=23` when the user clicks on the "Fetch info" button


