### PR TITLE
Fix tsne visualization and popovers

### DIFF
--- a/site/gatsby-site/src/bootstrap.scss
+++ b/site/gatsby-site/src/bootstrap.scss
@@ -1,4 +1,4 @@
-.bootstrap, body.modal-open {
+.bootstrap, body.modal-open, .fade.show {
     --bs-border-color-translucent: rgba(0,0,0,0.175);
     --bs-border-color: #dee2e6;
     --bs-accordion-border-color: var(--bs-border-color);
@@ -8,4 +8,9 @@
 body.modal-open .accordion-item .accordion-button {
     background-color: #0d6efd !important;
     color: #fff !important;
+}
+
+.bootstrap .popover-arrow {
+    display: none !important;
+
 }

--- a/site/gatsby-site/src/bootstrap.scss
+++ b/site/gatsby-site/src/bootstrap.scss
@@ -9,8 +9,3 @@ body.modal-open .accordion-item .accordion-button {
     background-color: #0d6efd !important;
     color: #fff !important;
 }
-
-.bootstrap .popover-arrow {
-    display: none !important;
-
-}

--- a/site/gatsby-site/src/components/cite/TsneVisualization.js
+++ b/site/gatsby-site/src/components/cite/TsneVisualization.js
@@ -125,7 +125,7 @@ const PlotPoint = ({
   const onLeft = clientPosition?.x < window.innerWidth / 2;
 
   return (
-    <div className="bootstrap">
+    <>
       <LocalizedLink
         id={'spatial-incident-' + incident.incident_id}
         to={'/cite/' + incident.incident_id}
@@ -227,7 +227,7 @@ const PlotPoint = ({
           )}
         </div>
       )}
-    </div>
+    </>
   );
 };
 

--- a/site/gatsby-site/src/components/forms/Label.js
+++ b/site/gatsby-site/src/components/forms/Label.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { OverlayTrigger, Form, Popover } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
@@ -15,13 +15,16 @@ const Label = ({ popover, label }) => {
     return <Form.Label>{label} :</Form.Label>;
   }
 
+  const ref = useRef(null);
+
   return (
-    <div className="bootstrap relative">
-      <OverlayTrigger
-        placement={'top'}
-        overlay={
-          <div className="bootstrap lg:left-72 z-10">
-            <Popover data-cy={`popover-${popover}`}>
+    <>
+      <div className="bootstrap" ref={ref}>
+        <OverlayTrigger
+          placement={'top'}
+          container={ref}
+          overlay={
+            <UpdatingPopover data-cy={`popover-${popover}`}>
               <Popover.Header as="h3">
                 <Trans ns="popovers" i18nKey={`${popover}.title`} />
               </Popover.Header>
@@ -32,23 +35,23 @@ const Label = ({ popover, label }) => {
                   components={{ linkto: <Link /> }}
                 />
               </Popover.Body>
-            </Popover>
-          </div>
-        }
-        {...(show ? { show } : {})}
-      >
-        <Form.Label data-cy={`label-${popover}`}>
-          {label}{' '}
-          <FontAwesomeIcon
-            icon={faQuestionCircle}
-            style={{ color: 'rgb(210, 210, 210)', cursor: 'pointer' }}
-            className="far fa-question-circle"
-            onClick={() => setShow(!show)}
-          />{' '}
-          :
-        </Form.Label>
-      </OverlayTrigger>
-    </div>
+            </UpdatingPopover>
+          }
+          {...(show ? { show } : {})}
+        >
+          <Form.Label data-cy={`label-${popover}`} className="relative">
+            {label}{' '}
+            <FontAwesomeIcon
+              icon={faQuestionCircle}
+              style={{ color: 'rgb(210, 210, 210)', cursor: 'pointer' }}
+              className="far fa-question-circle"
+              onClick={() => setShow(!show)}
+            />{' '}
+            :
+          </Form.Label>
+        </OverlayTrigger>
+      </div>
+    </>
   );
 };
 
@@ -78,5 +81,22 @@ Label.defaultProps = {
   placement: 'top',
   trigger: ['hover', 'focus'],
 };
+
+// This is used to force the popover to re-render to adjust correctly to the label's position
+const UpdatingPopover = React.forwardRef(({ popper, children, ...props }, ref) => {
+  useEffect(() => {
+    setTimeout(() => {
+      popper.scheduleUpdate();
+    }, 0);
+  }, [children, popper]);
+
+  return (
+    <Popover ref={ref} {...props}>
+      {children}
+    </Popover>
+  );
+});
+
+UpdatingPopover.displayName = 'UpdatingPopover';
 
 export default Label;

--- a/site/gatsby-site/src/components/forms/Label.js
+++ b/site/gatsby-site/src/components/forms/Label.js
@@ -16,18 +16,24 @@ const Label = ({ popover, label }) => {
   }
 
   return (
-    <div className="bootstrap">
+    <div className="bootstrap relative">
       <OverlayTrigger
         placement={'top'}
         overlay={
-          <Popover data-cy={`popover-${popover}`}>
-            <Popover.Header as="h3">
-              <Trans ns="popovers" i18nKey={`${popover}.title`} />
-            </Popover.Header>
-            <Popover.Body>
-              <Trans ns="popovers" i18nKey={`${popover}.text`} components={{ linkto: <Link /> }} />
-            </Popover.Body>
-          </Popover>
+          <div className="bootstrap lg:left-72 z-10">
+            <Popover data-cy={`popover-${popover}`}>
+              <Popover.Header as="h3">
+                <Trans ns="popovers" i18nKey={`${popover}.title`} />
+              </Popover.Header>
+              <Popover.Body>
+                <Trans
+                  ns="popovers"
+                  i18nKey={`${popover}.text`}
+                  components={{ linkto: <Link /> }}
+                />
+              </Popover.Body>
+            </Popover>
+          </div>
         }
         {...(show ? { show } : {})}
       >


### PR DESCRIPTION
There is currently an issue with bootstrap popovers and tailwind. In order to apply bootstrap to the popovers, we must wrap them in a div with class bootstrap. However, there seems to be an issue with the SASS bootstrap we are using and the popover's arrow style. For now, I've removed the arrow. I also created an issue so that in the future Bootstrap popovers are replaced with Flowbite's Tooltips. This will imply also replacing the forms inputs with Flowbite styling.

This PR also fixes the TSNE visualization that was incorrectly wrapped in a bootstrap div

- resolves #1065 