### PR TITLE
Remove double header

### DIFF
--- a/site/gatsby-site/content/research/3-history/index.es.mdx
+++ b/site/gatsby-site/content/research/3-history/index.es.mdx
@@ -6,8 +6,6 @@ slug: "/research/3-history"
 aiTranslated: true
 ---
 
-# Metodología de recolección inicial
-
 La industria de la aviación en los Estados Unidos está obligada por ley a informar incidentes y accidentes a la Administración Federal de Aviación. No existe un requisito de informe obligatorio para los sistemas inteligentes, por lo que el AIID se basa en los incidentes que han ganado suficiente notoriedad para ser cubiertos en la prensa popular o de investigación. Como resultado, debe considerar que la base de datos es representativa de los "incidentes públicos", en lugar de todos los incidentes que se sabe que han ocurrido en la industria de la inteligencia artificial.
 
 La base de datos actual está dominada por la recopilación inicial de informes de incidentes, que fueron ensamblados con la siguiente metodología por el asistente de investigación Sam Yoon,

--- a/site/gatsby-site/content/research/3-history/index.mdx
+++ b/site/gatsby-site/content/research/3-history/index.mdx
@@ -5,8 +5,6 @@ metaDescription: "How were the initial set of incident reports collected for the
 slug: "/research/3-history"
 ---
 
-# Initial Collection Methodology
-
 The aviation industry in the United States is required by law to report incidents and accidents to the Federal Aviation Administration. There is no compulsory reporting requirement for intelligent systems, so the AIID is built on the incidents that have gained sufficient notoriety to be covered in either the popular or the research press. As a result, you should consider the database to be representative of "public incidents", rather than all incidents that are known to have occured throughout the artificial intelligence industry.
 
 The current database is dominated by the initial collection of incident reports, which were assembled with the following methodology by research assistant Sam Yoon,


### PR DESCRIPTION
Per #1020, removes the double header on "Initial Collection Methodology." Extracted from #1071.