### PR TITLE
Fix Tools btns margin right

### DIFF
--- a/site/gatsby-site/src/templates/cite.js
+++ b/site/gatsby-site/src/templates/cite.js
@@ -226,12 +226,12 @@ function CitePage(props) {
                 >
                   <Trans>New Report</Trans>
                 </Button>
-                <Button variant="outline-primary" className="me-2" href={'/summaries/incidents'}>
+                <Button variant="outline-primary" className="mr-2" href={'/summaries/incidents'}>
                   <Trans>All Incidents</Trans>
                 </Button>
                 <Button
                   variant="outline-primary"
-                  className="me-2"
+                  className="mr-2"
                   href={'/apps/discover?incident_id=' + incident.incident_id}
                 >
                   <Trans>Discover</Trans>
@@ -239,7 +239,7 @@ function CitePage(props) {
                 {isRole('incident_editor') && (
                   <Button
                     variant="outline-primary"
-                    className="me-2"
+                    className="mr-2"
                     href={'/incidents/edit?incident_id=' + incident.incident_id}
                   >
                     Edit Incident


### PR DESCRIPTION
Fixes margin of the Btns in the "Tools" section on the cite page 