### PR TITLE
Fix `react-bootstrap-typeahead` version

### DIFF
--- a/site/gatsby-site/package.json
+++ b/site/gatsby-site/package.json
@@ -75,7 +75,7 @@
     "react-billboardjs": "^3.0.1",
     "react-bootstrap": "^2.0.0-rc.1",
     "react-bootstrap-daterangepicker": "^7.0.0",
-    "react-bootstrap-typeahead": "^6.0.0-alpha.6",
+    "react-bootstrap-typeahead": "6.0.0-alpha.6",
     "react-d3-cloud": "^1.0.5",
     "react-dom": "^17.0.2",
     "react-feather": "^2.0.9",


### PR DESCRIPTION
Closes #1117 