### PR TITLE
Submit form: Support commas in tag input, mark required fields

### DIFF
--- a/site/gatsby-site/src/components/forms/IncidentReportForm.js
+++ b/site/gatsby-site/src/components/forms/IncidentReportForm.js
@@ -78,6 +78,7 @@ export const schema = yup.object().shape({
       /((https?):\/\/)(\S)*$/,
       '*Must enter URL in http://www.example.com/images/preview.png format'
     ),
+  editor_notes: yup.string(),
   incident_id: yup.number().positive().integer('*Must be an incident number').required(),
 });
 
@@ -119,7 +120,7 @@ const IncidentReportForm = () => {
     }
   }
 
-  const TextInputGroupProps = { values, errors, touched, handleChange, handleBlur };
+  const TextInputGroupProps = { values, errors, touched, handleChange, handleBlur, schema };
 
   const addToast = useToastContext();
 

--- a/site/gatsby-site/src/components/forms/Tags.js
+++ b/site/gatsby-site/src/components/forms/Tags.js
@@ -5,7 +5,9 @@ export default function Tags({ id, inputId, placeHolder, value, onChange, name }
   const ref = useRef(null);
 
   const commitTag = (tag) => {
-    onChange(value ? value.concat(tag) : [tag]);
+    const splitTags = tag.split(',').map((tag) => tag.trim());
+
+    onChange(value ? value.concat(splitTags) : splitTags);
     ref.current.clear();
   };
 
@@ -15,7 +17,10 @@ export default function Tags({ id, inputId, placeHolder, value, onChange, name }
       id={id}
       inputProps={{ id: inputId, name }}
       onKeyDown={(e) => {
-        if (e.key === 'Enter' && e.target.value) {
+        if (e.key === ',') {
+          e.preventDefault();
+        }
+        if (['Enter', ','].includes(e.key) && e.target.value) {
           commitTag(e.target.value);
         }
       }}

--- a/site/gatsby-site/src/components/forms/TagsInputGroup.js
+++ b/site/gatsby-site/src/components/forms/TagsInputGroup.js
@@ -1,0 +1,31 @@
+import React, { useState, useEffect } from 'react';
+import { Form, InputGroup } from 'react-bootstrap';
+import Label from './Label';
+import TagsControl from './TagsControl';
+import { Trans } from 'react-i18next';
+
+const TagsInputGroup = ({ name, label, placeholder, errors, touched, schema, className = '' }) => {
+  const [optional, setOptional] = useState(true);
+
+  useEffect(async () => {
+    if (schema?.fields[name]) {
+      setOptional(await schema.fields[name].isValid(undefined));
+    }
+  }, []);
+
+  return (
+    <div className="bootstrap">
+      <Form.Group className={`form-group ${className}`}>
+        <Label popover={name} label={(optional ? '' : '*') + label} />
+        <TagsControl name={name} placeholder={placeholder} />
+        <InputGroup>
+          <Form.Control.Feedback type="invalid">
+            <Trans ns="validation">{errors[name] && touched[name] ? errors[name] : null}</Trans>
+          </Form.Control.Feedback>
+        </InputGroup>
+      </Form.Group>
+    </div>
+  );
+};
+
+export default TagsInputGroup;

--- a/site/gatsby-site/src/components/forms/TagsInputGroup.js
+++ b/site/gatsby-site/src/components/forms/TagsInputGroup.js
@@ -13,14 +13,22 @@ const TagsInputGroup = ({ name, label, placeholder, errors, touched, schema, cla
     }
   }, []);
 
+  const isInvalid = errors[name] && touched[name];
+
   return (
     <div className="bootstrap">
       <Form.Group className={`form-group ${className}`}>
         <Label popover={name} label={(optional ? '' : '*') + label} />
-        <TagsControl name={name} placeholder={placeholder} />
         <InputGroup>
+          <div
+            className={
+              'tags-control-wrapper rounded-md form-control' + (isInvalid ? ' is-invalid' : '')
+            }
+          >
+            <TagsControl name={name} placeholder={placeholder} />
+          </div>
           <Form.Control.Feedback type="invalid">
-            <Trans ns="validation">{errors[name] && touched[name] ? errors[name] : null}</Trans>
+            <Trans ns="validation">{isInvalid ? errors[name] : null}</Trans>
           </Form.Control.Feedback>
         </InputGroup>
       </Form.Group>

--- a/site/gatsby-site/src/components/forms/TextInputGroup.js
+++ b/site/gatsby-site/src/components/forms/TextInputGroup.js
@@ -36,8 +36,8 @@ const TextInputGroup = ({
             onChange={handleChange}
             onBlur={handleBlur}
             value={values[name] || ''}
-            className={touched[name] && errors[name] ? 'has-error' : null}
             isInvalid={errors[name] && touched[name]}
+            className={addOnComponent ? 'rounded-r-none' : 'rounded-md'}
             {...props}
           />
           {addOnComponent}

--- a/site/gatsby-site/src/components/forms/TextInputGroup.js
+++ b/site/gatsby-site/src/components/forms/TextInputGroup.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Form, InputGroup } from 'react-bootstrap';
 import Label from './Label';
 import { Trans } from 'react-i18next';
@@ -14,31 +14,40 @@ const TextInputGroup = ({
   handleChange,
   handleBlur,
   addOnComponent = null,
+  schema,
   className = '',
   ...props
-}) => (
-  <div className="bootstrap">
-    <Form.Group className={`form-group ${className}`}>
-      <Label popover={name} label={label} />
-      <InputGroup>
-        <Form.Control
-          type={type}
-          name={name}
-          placeholder={placeholder}
-          onChange={handleChange}
-          onBlur={handleBlur}
-          value={values[name] || ''}
-          className={touched[name] && errors[name] ? 'has-error' : null}
-          isInvalid={errors[name] && touched[name]}
-          {...props}
-        />
-        {addOnComponent}
-        <Form.Control.Feedback type="invalid">
-          <Trans ns="validation">{errors[name] && touched[name] ? errors[name] : null}</Trans>
-        </Form.Control.Feedback>
-      </InputGroup>
-    </Form.Group>
-  </div>
-);
+}) => {
+  const [optional, setOptional] = useState(true);
+
+  useEffect(async () => {
+    setOptional(await schema.fields[name].isValid(undefined));
+  }, []);
+
+  return (
+    <div className="bootstrap">
+      <Form.Group className={`form-group ${className}`}>
+        <Label popover={name} label={(optional ? '' : '*') + label} />
+        <InputGroup>
+          <Form.Control
+            type={type}
+            name={name}
+            placeholder={placeholder}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            value={values[name] || ''}
+            className={touched[name] && errors[name] ? 'has-error' : null}
+            isInvalid={errors[name] && touched[name]}
+            {...props}
+          />
+          {addOnComponent}
+          <Form.Control.Feedback type="invalid">
+            <Trans ns="validation">{errors[name] && touched[name] ? errors[name] : null}</Trans>
+          </Form.Control.Feedback>
+        </InputGroup>
+      </Form.Group>
+    </div>
+  );
+};
 
 export default TextInputGroup;

--- a/site/gatsby-site/src/components/submissions/SubmissionForm.js
+++ b/site/gatsby-site/src/components/submissions/SubmissionForm.js
@@ -4,13 +4,13 @@ import { Spinner } from 'flowbite-react';
 import { useFormikContext } from 'formik';
 import * as yup from 'yup';
 import TextInputGroup from '../../components/forms/TextInputGroup';
+import TagsInputGroup from '../../components/forms/TagsInputGroup';
 import useToastContext, { SEVERITY } from '../../hooks/useToast';
 import { dateRegExp } from '../../utils/date';
 import { getCloudinaryPublicID, PreviewImageInputGroup } from '../../utils/cloudinary';
 import 'react-bootstrap-typeahead/css/Typeahead.css';
 import { graphql, useStaticQuery } from 'gatsby';
 import Label from '../forms/Label';
-import TagsControl from '../../components/forms/TagsControl';
 import IncidentIdField from '../../components/incidents/IncidentIdField';
 import getSourceDomain from '../../utils/getSourceDomain';
 import { Editor } from '@bytemd/react';
@@ -51,7 +51,7 @@ export const schema = yup.object().shape({
   description: yup
     .string()
     .min(3, 'Description must have at least 3 characters')
-    .max(200, "Description can't be longer than 200 characters")
+    .max(500, "Description can't be longer than 500 characters")
     .when('_id', {
       is: (_id) => _id !== undefined,
       then: yup.string().required('*Incident Description required'),
@@ -78,7 +78,7 @@ export const schema = yup.object().shape({
     .max(200, "Harmed Parties can't be longer than 200 characters")
     .when('_id', {
       is: (_id) => _id !== undefined,
-      then: yup.string().required('*Harm Parties is required'),
+      then: yup.string().required('*Harmed Parties is required'),
     }),
   authors: yup
     .string()
@@ -117,6 +117,7 @@ export const schema = yup.object().shape({
     is: (incident_id) => incident_id == '' || incident_id === undefined,
     then: yup.date().required('*Incident Date required'),
   }),
+  editor_notes: yup.string(),
 });
 
 const SubmissionForm = () => {
@@ -158,7 +159,7 @@ const SubmissionForm = () => {
 
   const { t } = useTranslation(['submit']);
 
-  const TextInputGroupProps = { values, errors, touched, handleChange, handleBlur };
+  const TextInputGroupProps = { values, errors, touched, handleChange, handleBlur, schema };
 
   const addToast = useToastContext();
 
@@ -281,25 +282,23 @@ const SubmissionForm = () => {
           {...TextInputGroupProps}
         />
 
-        <Form.Group className="mt-3">
-          <Label popover="authors" label={t('Author(s)')} />
-          <TagsControl
-            name="authors"
-            placeholder={t('The author or authors of the report')}
-            {...TextInputGroupProps}
-          />
-        </Form.Group>
+        <TagsInputGroup
+          name="authors"
+          label={t('Author(s)')}
+          placeholder={t('The author or authors of the report')}
+          className="mt-3"
+          {...TextInputGroupProps}
+        />
 
         <RelatedIncidents incident={values} setFieldValue={setFieldValue} columns={['byAuthors']} />
 
-        <Form.Group className="mt-3">
-          <Label popover="submitters" label={t('Submitter(s)')} />
-          <TagsControl
-            name="submitters"
-            placeholder={t('Your name as you would like it to appear in the leaderboard')}
-            {...TextInputGroupProps}
-          />
-        </Form.Group>
+        <TagsInputGroup
+          name="submitters"
+          placeholder={t('Your name as you would like it to appear in the leaderboard')}
+          label={t('Submitter(s)')}
+          className="mt-3"
+          {...TextInputGroupProps}
+        />
 
         <TextInputGroup
           name="date_published"
@@ -418,37 +417,35 @@ const SubmissionForm = () => {
             {...TextInputGroupProps}
           />
 
-          <Form.Group className="mt-3">
-            <Label popover="tags" label={t('Tags')} />
-            <TagsControl name={'tags'} />
-          </Form.Group>
+          <TagsInputGroup name="tags" label={t('Tags')} className="mt-3" {...TextInputGroupProps} />
 
-          <Form.Group className="mt-3">
-            <Label popover="developers" label={t('Alleged developer of AI system')} />
-            <TagsControl
-              name="developers"
-              placeholder={t('Who created or built the technology involved in the incident?')}
-              {...TextInputGroupProps}
-            />
-          </Form.Group>
+          {!values.incident_id && (
+            <>
+              <TagsInputGroup
+                name="developers"
+                label={t('Alleged developer of AI system')}
+                placeholder={t('Who created or built the technology involved in the incident?')}
+                className="mt-3"
+                {...TextInputGroupProps}
+              />
 
-          <Form.Group className="mt-3">
-            <Label popover="deployers" label={t('Alleged deployer of AI system')} />
-            <TagsControl
-              name="deployers"
-              placeholder={t('Who employed or was responsible for the technology?')}
-              {...TextInputGroupProps}
-            />
-          </Form.Group>
+              <TagsInputGroup
+                name="deployers"
+                label={t('Alleged deployer of AI system')}
+                placeholder={t('Who employed or was responsible for the technology?')}
+                className="mt-3"
+                {...TextInputGroupProps}
+              />
 
-          <Form.Group className="mt-3">
-            <Label popover="harmed_parties" label={t('Alleged harmed or nearly harmed parties')} />
-            <TagsControl
-              name="harmed_parties"
-              placeholder={t('Who experienced negative impacts?')}
-              {...TextInputGroupProps}
-            />
-          </Form.Group>
+              <TagsInputGroup
+                name="harmed_parties"
+                label={t('Alleged harmed or nearly harmed parties')}
+                placeholder={t('Who experienced negative impacts?')}
+                className="mt-3"
+                {...TextInputGroupProps}
+              />
+            </>
+          )}
 
           <TextInputGroup
             name="editor_notes"

--- a/site/gatsby-site/src/components/submissions/SubmissionForm.js
+++ b/site/gatsby-site/src/components/submissions/SubmissionForm.js
@@ -87,8 +87,12 @@ export const schema = yup.object().shape({
     .required('*Author is required. Anonymous or the publication can be entered.'),
   submitters: yup
     .string()
-    .min(3, '*Submitter must have at least 3 characters')
-    .max(200, "*Submitter list can't be longer than 200 characters"),
+    .max(200, "*Submitter list can't be longer than 200 characters")
+    .test(
+      'len',
+      '*Submitter must have at least 3 characters',
+      (val) => val === undefined || val.length == 0 || 3 <= val.length
+    ),
   text: yup
     .string()
     .min(80, `*Text must have at least 80 characters`)
@@ -251,7 +255,7 @@ const SubmissionForm = () => {
           placeholder={t('Report URL')}
           addOnComponent={
             <Button
-              className="outline-secondary"
+              className="outline-secondary rounded-l-none"
               disabled={!!errors.url || !touched.url || parsingNews}
               onClick={() => parseNewsUrl(values.url)}
               data-cy="fetch-info"

--- a/site/gatsby-site/src/components/submissions/SubmissionForm.js
+++ b/site/gatsby-site/src/components/submissions/SubmissionForm.js
@@ -411,7 +411,7 @@ const SubmissionForm = () => {
             name="description"
             label={t('Description')}
             as="textarea"
-            placeholder={t('Report Description')}
+            placeholder={t('Incident Description')}
             rows={3}
             className="mt-3"
             {...TextInputGroupProps}

--- a/site/gatsby-site/src/global.css
+++ b/site/gatsby-site/src/global.css
@@ -893,6 +893,18 @@ img {
   }
 }
 
+/* Needed to get bootstrap error styles for Tag Input */
+.tags-control-wrapper {
+  padding: 0px !important;
+}
+.tags-control-wrapper .form-control {
+  border: 0px !important;
+  background-color: rgba(255, 255, 255, 0) !important;
+}
+.tags-control-wrapper.is-invalid .form-control.focus {
+  box-shadow: 0 0 0 0.25rem rgba(220, 53, 69, 0.25) !important;
+}
+
 /* disable Github Permalink */
 .bytemd-toolbar-right [bytemd-tippy-path='5'] {
   display: none;

--- a/site/gatsby-site/src/pages/apps/submit.js
+++ b/site/gatsby-site/src/pages/apps/submit.js
@@ -22,12 +22,12 @@ const SubmitPage = (props) => {
       <p>
         <Trans ns="submit" i18nKey="submitFormDescription">
           The following form will create a new incident report for{' '}
-          <Link to="/apps/submitted">review </Link> and inclusion into the AI Incident Database.
+          <Link to="/apps/submitted">review</Link> and inclusion into the AI Incident Database.
           Fields beginning with an asterisk (*) are required. Please carefully check your entries
           for content issues (e.g., accidental copy and paste of advertisements). For details on the
           database ingestion process, please check the{' '}
-          <Link to="/research/1-criteria/">research pages</Link>
-          or <Link to="/contact">contact us with questions.</Link>
+          <Link to="/research/1-criteria/">research pages</Link> or{' '}
+          <Link to="/contact">contact us with questions</Link>.
         </Trans>
       </p>
       <SubmitForm />

--- a/site/gatsby-site/src/pages/apps/submit.js
+++ b/site/gatsby-site/src/pages/apps/submit.js
@@ -23,10 +23,11 @@ const SubmitPage = (props) => {
         <Trans ns="submit" i18nKey="submitFormDescription">
           The following form will create a new incident report for{' '}
           <Link to="/apps/submitted">review </Link> and inclusion into the AI Incident Database.
-          Please carefully check your entries for content issues (e.g., accidental copy and paste of
-          advertisements). For details on the database ingestion process, please check the{' '}
-          <Link to="/research/1-criteria/">research pages</Link> or{' '}
-          <Link to="/contact">contact us with questions.</Link>{' '}
+          Fields beginning with an asterisk (*) are required. Please carefully check your entries
+          for content issues (e.g., accidental copy and paste of advertisements). For details on the
+          database ingestion process, please check the{' '}
+          <Link to="/research/1-criteria/">research pages</Link>
+          or <Link to="/contact">contact us with questions.</Link>
         </Trans>
       </p>
       <SubmitForm />

--- a/site/gatsby-site/src/utils/cloudinary.js
+++ b/site/gatsby-site/src/utils/cloudinary.js
@@ -91,6 +91,7 @@ const PreviewImageInputGroup = ({
   handleChange,
   handleBlur,
   className = '',
+  schema,
 }) => {
   const [cloudinaryID, setCloudinaryID] = useState(cloudinary_id);
 
@@ -160,6 +161,7 @@ const PreviewImageInputGroup = ({
         handleChange={handleChange}
         className={className}
         handleBlur={handleBlur}
+        schema={schema}
       />
       <figure data-cy="image-preview-figure" id="image-preview-figure" className="text-center">
         <div
@@ -167,9 +169,9 @@ const PreviewImageInputGroup = ({
           style={{ height: '50vh', marginTop: '1rem' }}
         >
           {updatingImage ? (
-            <Spinner size="xl"/>
+            <Spinner size="xl" />
           ) : (
-            <Image publicID={cloudinaryID} style={{ maxHeight: '100%' }} alt="Selected image"/>
+            <Image publicID={cloudinaryID} style={{ maxHeight: '100%' }} alt="Selected image" />
           )}
         </div>
         <figcaption className="mt-2">


### PR DESCRIPTION
Implements all of the changes named in #1112.

- In tag inputs, a comma now begins a new tag, and a pasted comma-separated list get split into its components.
- Adds an asterisk before required fields.
- Hides the entity fields when .
- Sets the max description length to 500.