### PR TITLE
Don't set embedding on IncidentEditModal submission

### DIFF
--- a/site/gatsby-site/src/components/incidents/IncidentEditModal.js
+++ b/site/gatsby-site/src/components/incidents/IncidentEditModal.js
@@ -27,7 +27,12 @@ export default function IncidentEditModal({ show, onClose, incidentId }) {
 
   const handleSubmit = async (values) => {
     try {
-      const updated = { ...values, reports: undefined, __typename: undefined };
+      const updated = {
+        ...values,
+        reports: undefined,
+        __typename: undefined,
+        embedding: undefined,
+      };
 
       await updateIncident({
         variables: {


### PR DESCRIPTION
Resolves #1147. Since this is a critical bug in production, should this bypass staging?