### PR TITLE
Update landing page carousel style

### DIFF
--- a/site/gatsby-site/src/components/landing/RandomIncidentsCarousel.js
+++ b/site/gatsby-site/src/components/landing/RandomIncidentsCarousel.js
@@ -1,80 +1,98 @@
-import React from 'react';
-import { StaticQuery, graphql, Link } from 'gatsby';
+import React, { useState } from 'react';
+import { Link } from 'gatsby';
 import md5 from 'md5';
 import { Image } from 'utils/cloudinary';
 import { fill } from '@cloudinary/base/actions/resize';
-import { Carousel } from 'flowbite-react';
+import { Carousel, Spinner } from 'flowbite-react';
+import { gql, useQuery } from '@apollo/client';
 
 const RandomIncidentsCarousel = () => {
-  const generateRandomIncidents = () => {
-    const array = [];
+  const [randomIncidentIds] = useState(
+    Array(5)
+      .fill(0)
+      .map(() => Math.floor(Math.random() * 300))
+  );
 
-    for (let index = 0; index < 5; index++) {
-      array.push(Math.floor(Math.random() * 50 + 1));
-    }
-
-    return array;
-  };
-
-  const randomArray = generateRandomIncidents();
-
-  return (
-    <StaticQuery
-      query={graphql`
-        query RandomIncidentsCarousel {
-          allMongodbAiidprodIncidents {
-            nodes {
-              incident_id
-              reports
-              title
-            }
-          }
-
-          allMongodbAiidprodReports(limit: 50, sort: { order: ASC, fields: id }) {
-            nodes {
-              id
-              report_number
-              image_url
-            }
+  const { loading: incidentsLoading, data: incidentsData } = useQuery(
+    gql`
+      query CarouselIncidents($query: IncidentQueryInput!) {
+        incidents(query: $query) {
+          incident_id
+          title
+          reports {
+            report_number
+            title
+            cloudinary_id
+            image_url
           }
         }
-      `}
-      render={({
-        allMongodbAiidprodReports: { nodes: reports },
-        allMongodbAiidprodIncidents: { nodes: incidents },
-      }) => {
-        const randomIncidents = reports
-          .filter(
-            (node, index) => randomArray.includes(index) && node.image_url !== 'placeholder.svg'
-          )
-          .map((report) => ({
-            ...report,
-            ...incidents.find((incident) => incident.reports.includes(report.report_number)),
-          }));
+      }
+    `,
+    { variables: { query: { incident_id_in: randomIncidentIds } } }
+  );
 
-        return (
-          <div className="flex-1 flex justify-center items-center">
-            <div className="h-56 sm:h-64 xl:h-80 2xl:h-96 w-full">
-              <Carousel slideInterval={6000} slide={false}>
-                {randomIncidents.map(({ id, incident_id, title, image_url, cloudinary_id }) => (
-                  <Link to={`/cite/${incident_id}`} key={id} className="h-full">
-                    <h5 className="text-sm sm:text-lg font-bold tracking-tight text-gray-900 dark:text-white">
-                      {title}
-                    </h5>
-                    <Image
-                      publicID={cloudinary_id ? cloudinary_id : `legacy/${md5(image_url)}`}
-                      alt={title}
-                      transformation={fill().height(480)}
-                      plugins={[]}
-                    />
-                  </Link>
-                ))}
-              </Carousel>
-            </div>
+  const randomIncidents =
+    (incidentsData?.incidents &&
+      incidentsData?.incidents.reduce(
+        (reports, incident) =>
+          reports.concat([
+            {
+              ...incident.reports[0],
+              incident_id: incident.incident_id,
+              title: incident.title || reports[0].title,
+            },
+          ]),
+        []
+      )) ||
+    [];
+
+  return (
+    <div className="flex-1 flex justify-center items-center">
+      <div className="h-full w-full relative">
+        <div className="absolute h-3 inset-x-0 top-0 bg-white filler z-50 block w-50">
+          {/* The carousel insists on using rounded corners, *
+           * so we have to cover them up on top.            */}
+        </div>
+        {incidentsLoading && (
+          <div className="absolute inset-0 flex items-center justify-center">
+            <Spinner size="xl" />
           </div>
-        );
-      }}
-    />
+        )}
+        <Carousel slideInterval={6000} slide={false}>
+          {randomIncidents.map(({ incident_id, title, image_url, cloudinary_id }) => (
+            <Link to={`/cite/${incident_id}`} key={incident_id} className="block h-full relative">
+              <Image
+                publicID={cloudinary_id ? cloudinary_id : `legacy/${md5(image_url)}`}
+                alt={title}
+                transformation={fill().height(800).width(1000)}
+                plugins={[]}
+                className="w-full h-full"
+              />
+              <div className="absolute inset-0 flex items-center justify-center">
+                <h5
+                  className="
+                  text-sm sm:text-lg 
+                  font-bold 
+                  tracking-tight 
+                  text-gray-900 dark:text-white 
+                  w-1/2
+                  backdrop-blur-md
+                  p-6
+                  rounded-md
+                  bg-white/50
+                  top-0
+                  inset-x-0
+                  shadow-lg
+                "
+                >
+                  {title}
+                </h5>
+              </div>
+            </Link>
+          ))}
+        </Carousel>
+      </div>
+    </div>
   );
 };
 

--- a/site/gatsby-site/src/components/landing/RandomIncidentsCarousel.js
+++ b/site/gatsby-site/src/components/landing/RandomIncidentsCarousel.js
@@ -1,98 +1,102 @@
-import React, { useState } from 'react';
-import { Link } from 'gatsby';
+import React from 'react';
+import { StaticQuery, graphql, Link } from 'gatsby';
 import md5 from 'md5';
 import { Image } from 'utils/cloudinary';
 import { fill } from '@cloudinary/base/actions/resize';
-import { Carousel, Spinner } from 'flowbite-react';
-import { gql, useQuery } from '@apollo/client';
+import { Carousel } from 'flowbite-react';
 
 const RandomIncidentsCarousel = () => {
-  const [randomIncidentIds] = useState(
-    Array(5)
-      .fill(0)
-      .map(() => Math.floor(Math.random() * 300))
-  );
-
-  const { loading: incidentsLoading, data: incidentsData } = useQuery(
-    gql`
-      query CarouselIncidents($query: IncidentQueryInput!) {
-        incidents(query: $query) {
-          incident_id
-          title
-          reports {
-            report_number
-            title
-            cloudinary_id
-            image_url
+  return (
+    <StaticQuery
+      query={graphql`
+        query RandomIncidentsCarousel {
+          allMongodbAiidprodIncidents {
+            nodes {
+              incident_id
+              reports
+              title
+            }
+          }
+          allMongodbAiidprodReports(limit: 50, sort: { order: ASC, fields: id }) {
+            nodes {
+              id
+              report_number
+              image_url
+              cloudinary_id
+            }
           }
         }
-      }
-    `,
-    { variables: { query: { incident_id_in: randomIncidentIds } } }
-  );
+      `}
+      render={({
+        allMongodbAiidprodReports: { nodes: reports },
+        allMongodbAiidprodIncidents: { nodes: incidents },
+      }) => {
+        const randomIncidents = [];
 
-  const randomIncidents =
-    (incidentsData?.incidents &&
-      incidentsData?.incidents.reduce(
-        (reports, incident) =>
-          reports.concat([
-            {
-              ...incident.reports[0],
+        while (randomIncidents.length < 5) {
+          const incident = incidents.splice(Math.floor(Math.random() * incidents.length), 1)[0];
+
+          const reportWithImage = reports.find(
+            (report) => incident.reports.includes(report.report_number) && report.cloudinary_id
+          );
+
+          if (reportWithImage) {
+            randomIncidents.push({
+              ...reportWithImage,
               incident_id: incident.incident_id,
-              title: incident.title || reports[0].title,
-            },
-          ]),
-        []
-      )) ||
-    [];
-
-  return (
-    <div className="flex-1 flex justify-center items-center">
-      <div className="h-full w-full relative">
-        <div className="absolute h-3 inset-x-0 top-0 bg-white filler z-50 block w-50">
-          {/* The carousel insists on using rounded corners, *
-           * so we have to cover them up on top.            */}
-        </div>
-        {incidentsLoading && (
-          <div className="absolute inset-0 flex items-center justify-center">
-            <Spinner size="xl" />
-          </div>
-        )}
-        <Carousel slideInterval={6000} slide={false}>
-          {randomIncidents.map(({ incident_id, title, image_url, cloudinary_id }) => (
-            <Link to={`/cite/${incident_id}`} key={incident_id} className="block h-full relative">
-              <Image
-                publicID={cloudinary_id ? cloudinary_id : `legacy/${md5(image_url)}`}
-                alt={title}
-                transformation={fill().height(800).width(1000)}
-                plugins={[]}
-                className="w-full h-full"
-              />
-              <div className="absolute inset-0 flex items-center justify-center">
-                <h5
-                  className="
-                  text-sm sm:text-lg 
-                  font-bold 
-                  tracking-tight 
-                  text-gray-900 dark:text-white 
-                  w-1/2
-                  backdrop-blur-md
-                  p-6
-                  rounded-md
-                  bg-white/50
-                  top-0
-                  inset-x-0
-                  shadow-lg
-                "
-                >
-                  {title}
-                </h5>
+              title: incident.title || reportWithImage.title,
+            });
+          }
+        }
+        return (
+          <div className="flex-1 flex justify-center items-center">
+            <div className="h-full w-full relative">
+              <div className="absolute h-3 inset-x-0 top-0 bg-white filler z-50 block w-50">
+                {/* The carousel insists on using rounded corners, *
+                 * so we have to cover them up on top.            */}
               </div>
-            </Link>
-          ))}
-        </Carousel>
-      </div>
-    </div>
+              <Carousel slideInterval={6000} slide={false}>
+                {randomIncidents.map(({ incident_id, title, image_url, cloudinary_id }) => (
+                  <Link
+                    to={`/cite/${incident_id}`}
+                    key={incident_id}
+                    className="block h-full relative"
+                  >
+                    <Image
+                      publicID={cloudinary_id ? cloudinary_id : `legacy/${md5(image_url)}`}
+                      alt={title}
+                      transformation={fill().height(800).width(1000)}
+                      plugins={[]}
+                      className="w-full h-full object-cover"
+                    />
+                    <div className="absolute inset-0 flex items-center justify-center">
+                      <h5
+                        className="
+                      text-sm sm:text-lg 
+                      font-bold 
+                      tracking-tight 
+                      text-gray-900 dark:text-white 
+                      w-1/2
+                      backdrop-blur-md
+                      p-6
+                      rounded-md
+                      bg-white/50
+                      top-0
+                      inset-x-0
+                      shadow-lg
+                    "
+                      >
+                        {title}
+                      </h5>
+                    </div>
+                  </Link>
+                ))}
+              </Carousel>
+            </div>
+          </div>
+        );
+      }}
+    />
   );
 };
 

--- a/site/gatsby-site/src/components/landing/RandomReports.js
+++ b/site/gatsby-site/src/components/landing/RandomReports.js
@@ -5,9 +5,9 @@ import { Trans } from 'react-i18next';
 export default function RandomReports() {
   return (
     <div className="flex rounded-lg border border-gray-200 bg-white shadow-md dark:border-gray-700 dark:bg-gray-800 flex-col h-full">
-      <div className="flex h-full flex-col gap-4 p-6">
-        <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
-          <Trans ns="landing">Random Reports</Trans>
+      <div className="flex h-full flex-col gap-0 p-0">
+        <h5 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white mx-4 mt-4 mb-1">
+          <Trans ns="landing">Random Incidents</Trans>
         </h5>
         <RandomIncidentsCarousel />
       </div>

--- a/site/gatsby-site/src/templates/landingPage.js
+++ b/site/gatsby-site/src/templates/landingPage.js
@@ -103,7 +103,7 @@ const LandingPage = (props) => {
         </div>
 
         <div className="mb-10 flex flex-col sm:flex-row md:flex-col lg:flex-row gap-10 flex-wrap">
-          <div className="flex-1 lg:max-w-[50%]">
+          <div className="flex-1 lg:max-w-[50%] grow">
             <WordCounts localWordCounts={localWordCounts} />
           </div>
           <div className="flex-1 lg:max-w-[50%] self-stretch">


### PR DESCRIPTION
The current random reports carousel looks a bit bare on staging. This brings back the central label with a frosted glass background, plus it makes the query select from the first 300 rather than 50 incidents.

https://user-images.githubusercontent.com/25443411/192364620-9de0bf98-6afd-4a36-aece-8d0505387247.mp4

