### PR TITLE
Entities improvements

### DIFF
--- a/site/gatsby-site/src/components/entities/CommonEntities.js
+++ b/site/gatsby-site/src/components/entities/CommonEntities.js
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { graphql, useStaticQuery } from 'gatsby';
 import { computeEntities } from 'utils/entities';
-import { Card, Button } from 'flowbite-react';
+import { Card } from 'flowbite-react';
 import { Trans } from 'react-i18next';
 import Link from 'components/ui/Link';
 import facebook from '../../images/facebook.svg';
@@ -57,11 +57,13 @@ export default function CommonEntities() {
           const harmedCount = entity.harmedEntities.length;
 
           return (
-            <div
+            <Link
               key={entity.id}
+              to={`/entities/${entity.id}`}
               className="
-                p-4 pb-16 gap-4 
+                p-4 gap-4 
                 bg-white dark:bg-gray-800
+                hover:bg-gray-100 dark:hover:bg-gray-700
                 rounded-lg 
                 border border-gray-200 dark:border-gray-700 
                 flex 
@@ -96,7 +98,7 @@ export default function CommonEntities() {
                     {index + 1}.&nbsp;{entity.name}
                   </h5>
                 </Link>
-                <ul className="list-none">
+                <ul className="list-none text-black dark:text-white">
                   <li>
                     <Trans ns="entities">
                       Involved in{' '}
@@ -116,26 +118,8 @@ export default function CommonEntities() {
                     </Trans>
                   </li>
                 </ul>
-                <Link className="absolute bottom-4 right-4" to={`/entities/${entity.id}`}>
-                  <Button color="gray">
-                    <Trans>More</Trans>
-                    <svg
-                      aria-hidden="true"
-                      className="ml-2 -mr-1 w-4 h-4"
-                      fill="currentColor"
-                      viewBox="0 0 20 20"
-                      xmlns="http://www.w3.org/2000/svg"
-                    >
-                      <path
-                        fillRule="evenodd"
-                        d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-                        clipRule="evenodd"
-                      ></path>
-                    </svg>
-                  </Button>
-                </Link>
               </div>
-            </div>
+            </Link>
           );
         })}
       </div>

--- a/site/gatsby-site/src/components/entities/EntityCard.js
+++ b/site/gatsby-site/src/components/entities/EntityCard.js
@@ -30,7 +30,10 @@ export default function EntityCard({ entity, ...props }) {
       className={`mt-6 p-6 bg-white rounded-lg border border-gray-200 shadow-md dark:bg-gray-800 dark:border-gray-700`}
       {...props}
     >
-      <Link to={`/entities/${entity.id}`}>
+      <Link to={`/entities/${entity.id}`} className="hover:underline">
+        <span className="text-sm text-black dark:text-white">
+          <Trans>Entity</Trans>
+        </span>
         <h3 className="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
           {entity.name}
         </h3>
@@ -61,7 +64,7 @@ export default function EntityCard({ entity, ...props }) {
                       <li key={incident.incident_id} className="py-3 sm:py-4">
                         <Link
                           to={`/cite/${incident.incident_id}`}
-                          className="tracking-tight text-gray-900 dark:text-white"
+                          className="tracking-tight text-gray-900 dark:text-white hover:underline"
                         >
                           <div className="m-0">
                             <div className="inline-block text-muted-gray">

--- a/site/gatsby-site/src/components/entities/EntityCard.js
+++ b/site/gatsby-site/src/components/entities/EntityCard.js
@@ -1,0 +1,120 @@
+import Link from 'components/ui/Link';
+import React, { Fragment, useState } from 'react';
+import { Trans } from 'react-i18next';
+
+const sortByReports = (a, b) => b.reports.length - a.reports.length;
+
+export default function EntityCard({ entity, ...props }) {
+  const sections = [
+    {
+      header: 'Incidents involved as both Developer and Deployer',
+      key: 'incidentsAsBoth',
+    },
+    {
+      header: 'Incindents Harmed By',
+      key: 'incidentsHarmedBy',
+    },
+    {
+      header: 'Incidents involved as Developer',
+      key: 'incidentsAsDeveloper',
+    },
+    {
+      header: 'Incidents involved as Deployer',
+      key: 'incidentsAsDeployer',
+    },
+  ];
+
+  return (
+    <div
+      key={entity.id}
+      className={`mt-6 p-6 bg-white rounded-lg border border-gray-200 shadow-md dark:bg-gray-800 dark:border-gray-700`}
+      {...props}
+    >
+      <Link to={`/entities/${entity.id}`}>
+        <h3 className="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+          {entity.name}
+        </h3>
+      </Link>
+
+      <div>
+        {sections
+          .filter((section) => entity[section.key].length)
+          .map((section) => {
+            const [open, setOpen] = useState(false);
+
+            const visible = 2;
+
+            const hidden = entity[section.key].length - visible;
+
+            return (
+              <Fragment key={section.key}>
+                <h5 className="mt-6">
+                  <Trans ns="entities">{section.header}</Trans>
+                </h5>
+                <ul className="divide-y divide-gray-200 dark:divide-gray-700 list-none">
+                  {entity[section.key].sort(sortByReports).map((incident, index) => {
+                    if (index >= visible && !open) {
+                      return null;
+                    }
+
+                    return (
+                      <li key={incident.incident_id} className="py-3 sm:py-4">
+                        <Link
+                          to={`/cite/${incident.incident_id}`}
+                          className="tracking-tight text-gray-900 dark:text-white"
+                        >
+                          <div className="m-0">
+                            <div className="inline-block text-muted-gray">
+                              <Trans>Incident {{ id: incident.incident_id }}</Trans>
+                            </div>
+                            <div className="ml-2 inline-block bg-red-100 text-red-800 text-xs font-semibold mr-2 px-2.5 py-0.5 rounded dark:bg-green-200 dark:text-green-900">
+                              <Trans count={incident.reports.length} ns="entities">
+                                {{ count: incident.reports.length }} Report
+                              </Trans>
+                            </div>
+                          </div>
+                          <p className="mt-1 mb-0 text-md">{incident.title}</p>
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
+
+                {entity[section.key].length > 3 && (
+                  <div className="flex justify-center">
+                    <button
+                      onClick={() => setOpen((open) => !open)}
+                      className="text-blue-700 border hover:bg-blue-700 hover:text-white focus:ring-4 focus:outline-none focus:ring-blue-300 rounded-lg text-xs p-1.5 text-center inline-flex items-center mr-2  dark:text-blue-500 dark:hover:text-white dark:focus:ring-blue-800"
+                    >
+                      {open ? <Trans>View Less</Trans> : <Trans>View ({{ hidden }}) more</Trans>}
+                    </button>
+                  </div>
+                )}
+              </Fragment>
+            );
+          })}
+      </div>
+
+      <Link
+        to={`/entities/${entity.id}`}
+        href="#"
+        className="inline-flex mt-4 items-center py-2 px-3 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
+      >
+        <Trans>More</Trans>
+        <svg
+          aria-hidden="true"
+          className="ml-2 mr-1 w-4 h-4"
+          fill="currentColor"
+          viewBox="0 0 20 20"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            fillRule="evenodd"
+            d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+            clipRule="evenodd"
+          ></path>
+        </svg>
+      </Link>
+    </div>
+  );
+}

--- a/site/gatsby-site/src/components/incidents/IncidentCard.js
+++ b/site/gatsby-site/src/components/incidents/IncidentCard.js
@@ -8,7 +8,7 @@ export default function IncidentCard({ incident, className = '', ...props }) {
       className={`p-6 bg-white rounded-lg border border-gray-200 shadow-md dark:bg-gray-800 dark:border-gray-700 ${className}`}
       {...props}
     >
-      <Link to={`/cite/${incident.incident_id}`}>
+      <Link to={`/cite/${incident.incident_id}`} className="hover:underline">
         <h4 className="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
           <span className="text-sm">
             <Trans>Incident {{ id: incident.incident_id }}</Trans>

--- a/site/gatsby-site/src/templates/entity.js
+++ b/site/gatsby-site/src/templates/entity.js
@@ -1,3 +1,4 @@
+import EntityCard from 'components/entities/EntityCard';
 import IncidentCard from 'components/incidents/IncidentCard';
 import Layout from 'components/Layout';
 import Link from 'components/ui/Link';
@@ -84,9 +85,9 @@ const EntityPage = ({ pageContext, data, ...props }) => {
           <div key={section.header}>
             {entityIncidents[section.key].length > 0 && (
               <>
-                <h4 className="mt-24">
+                <h2 className="mt-24">
                   <Trans ns="entities">{section.header}</Trans>
-                </h4>
+                </h2>
                 <div className="grid gap-4 grid-flow-row-dense md:grid-cols-2 mt-6">
                   {entityIncidents[section.key].map((incident, index) => {
                     if (index >= visible && !open) {
@@ -112,80 +113,14 @@ const EntityPage = ({ pageContext, data, ...props }) => {
 
       {relatedEntitiesData.length > 0 && (
         <>
-          <h4 className="mt-24">
+          <h2 className="mt-24">
             <Trans ns="entities">Related Entities</Trans>
-          </h4>
-          {relatedEntitiesData.map((entity) => (
-            <div
-              key={entity.id}
-              className={`mt-6 p-6 bg-white rounded-lg border border-gray-200 shadow-md dark:bg-gray-800 dark:border-gray-700`}
-            >
-              <Link to={`/entities/${entity.id}`}>
-                <h5 className="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
-                  {entity.name}
-                </h5>
-              </Link>
-
-              {sections
-                .filter((section) => entity[section.key].length)
-                .map((section) => {
-                  const [open, setOpen] = useState(false);
-
-                  const visible = 3;
-
-                  const hidden = entity[section.key].length - visible;
-
-                  return (
-                    <Fragment key={section.key}>
-                      <h5 className="mt-6">
-                        <Trans ns="entities">{section.header}</Trans>
-                      </h5>
-                      <ul className="divide-y divide-gray-200 dark:divide-gray-700 list-none">
-                        {entity[section.key].sort(sortByReports).map((incident, index) => {
-                          if (index >= visible && !open) {
-                            return null;
-                          }
-
-                          return (
-                            <li key={incident.incident_id} className="py-3 sm:py-4">
-                              <Link
-                                to={`/cite/${incident.incident_id}`}
-                                className="tracking-tight text-gray-900 dark:text-white"
-                              >
-                                <div className="m-0">
-                                  <div className="inline-block text-muted-gray">
-                                    <Trans>Incident {{ id: incident.incident_id }}</Trans>
-                                  </div>
-                                  <div className="ml-2 inline-block bg-red-100 text-red-800 text-xs font-semibold mr-2 px-2.5 py-0.5 rounded dark:bg-green-200 dark:text-green-900">
-                                    <Trans count={incident.reports.length} ns="entities">
-                                      {{ count: incident.reports.length }} Report
-                                    </Trans>
-                                  </div>
-                                </div>
-                                <p className="mt-1 mb-0 text-md">{incident.title}</p>
-                              </Link>
-                            </li>
-                          );
-                        })}
-                      </ul>
-
-                      {entity[section.key].length > 3 && (
-                        <button
-                          onClick={() => setOpen((open) => !open)}
-                          className="text-blue-700 border hover:bg-blue-700 hover:text-white focus:ring-4 focus:outline-none focus:ring-blue-300 rounded-lg text-xs p-1.5 text-center inline-flex items-center mr-2  dark:text-blue-500 dark:hover:text-white dark:focus:ring-blue-800"
-                        >
-                          {open ? (
-                            <Trans>View Less</Trans>
-                          ) : (
-                            <Trans>View ({{ hidden }}) more</Trans>
-                          )}
-                        </button>
-                      )}
-                    </Fragment>
-                  );
-                })}
-            </div>
-          ))}
+          </h2>
+          <div className="grid gap-4 grid-flow-row-dense md:grid-cols-2 mt-6">
+            {relatedEntitiesData.map((entity) => (
+              <EntityCard key={entity.id} entity={entity} />
+            ))}
+          </div>
         </>
       )}
     </Layout>


### PR DESCRIPTION
- [x] These both reference specific things that could be clickable, but only one of them is actually clickable. Either "Latest Incident Report" should be clickable (preferred) or "2. Facebook" should not be clickable.
<img width="391" alt="Screen Shot 2022-09-27 at 2 49 12 PM" src="https://user-images.githubusercontent.com/64780/192642403-ec087155-2092-4cbb-b074-a2268565056b.png">

- [x] The "Common Entities" panel on the landing page should be clickable in its entirety (e.g., the logo and the white space surrounding it should lead to the entity page)

- [x] The relative size of text is off on the entities page:

- [x] The entity pages have two different types of cards (incidents and entities). The designs between them should be harmonized (consistent width properties, button affordances/more button, etc.)

Deals with stuff from https://github.com/responsible-ai-collaborative/aiid/issues/1063#issuecomment-1260089697