### PR TITLE
Disable cypress

### DIFF
--- a/site/gatsby-site/i18n/config.json
+++ b/site/gatsby-site/i18n/config.json
@@ -14,5 +14,13 @@
     "localName": "Español",
     "langDir": "ltr",
     "dateFormat": "DD-MM-YYYY"
+  },
+  {
+    "code": "fr",
+    "hrefLang": "fr",
+    "name": "French",
+    "localName": "FRench",
+    "langDir": "ltr",
+    "dateFormat": "DD-MM-YYYY"
   }
 ]

--- a/site/gatsby-site/netlify.toml
+++ b/site/gatsby-site/netlify.toml
@@ -5,13 +5,3 @@ TERM = "xterm"
 [[plugins]]
   package = "@netlify/plugin-gatsby"
 
-[[plugins]]
-  package = "netlify-plugin-cypress"
-  [plugins.inputs]
-    enable = false
-  [plugins.inputs.postBuild]
-    record = true
-    enable = true
-    spa = true
-    start = 'gatsby serve -p 8080'
-


### PR DESCRIPTION
This is to get an idea of how well the netlify box performs if it doesn't have to start a cypress instance.