### PR TITLE
Remove bootstrap styling from apps/incidents layout, blur modal bg

### DIFF
--- a/site/gatsby-site/src/bootstrap.scss
+++ b/site/gatsby-site/src/bootstrap.scss
@@ -11,6 +11,10 @@ body.modal-open .accordion-item .accordion-button {
     color: #fff !important;
 }
 
+.fade.modal.show {
+    backdrop-filter: blur(10px);
+}
+
 #dropdown-basic-button {
     display: flex;
     align-items: center;

--- a/site/gatsby-site/src/components/discover/QuickAccess.js
+++ b/site/gatsby-site/src/components/discover/QuickAccess.js
@@ -13,7 +13,7 @@ const Wrapper = styled.div`
   align-items: center;
   justify-content: center;
   a {
-    color: #001934;
+    color: #001934 !important;
   }
 `;
 

--- a/site/gatsby-site/src/pages/apps/incidents.js
+++ b/site/gatsby-site/src/pages/apps/incidents.js
@@ -13,21 +13,23 @@ export default function IncidentsPage(props) {
   const { t } = useTranslation();
 
   return (
-    <LayoutHideSidebar {...props} className="bootstrap">
+    <LayoutHideSidebar {...props}>
       <AiidHelmet>
         <title>{t('Incidents')}</title>
       </AiidHelmet>
-      {!incidentsData && (
-        <div className="p-4 flex justify-center align-items-center gap-2">
-          <Spinner />
-          <Trans>Fetching Incidents...</Trans>
-        </div>
-      )}
-      {incidentsData && incidentsData.incidents && (
-        <div className="ms-3 mt-2 mb-2">
-          <IncidentsTable data={incidentsData.incidents} />
-        </div>
-      )}
+      <div className="bootstrap">
+        {!incidentsData && (
+          <div className="p-4 flex justify-center align-items-center gap-2">
+            <Spinner />
+            <Trans>Fetching Incidents...</Trans>
+          </div>
+        )}
+        {incidentsData && incidentsData.incidents && (
+          <div className="ms-3 mt-2 mb-2">
+            <IncidentsTable data={incidentsData.incidents} />
+          </div>
+        )}
+      </div>
     </LayoutHideSidebar>
   );
 }


### PR DESCRIPTION
Resolves #1221.

The visual change in the quick access buttons was caused by Bootstrap styles being applied unexpectedly. In the case of the incidents app, that was simple to change. In the case of modals, it's tricky because Bootstrap wants to apply styles selecting `body.modal-open`. I couldn't figure out a way around that, so I just blurred the modal backdrop so no one will notice that the styles are a little off. Eventually, we should switch to [Flowbite modals](https://flowbite-react.com/modal).