### PR TITLE
Add migration to delete invalid candidates

### DIFF
--- a/site/gatsby-site/migrations/2022.10.12T18.56.08.fix-candidates.js
+++ b/site/gatsby-site/migrations/2022.10.12T18.56.08.fix-candidates.js
@@ -1,0 +1,16 @@
+const config = require('../config');
+
+/**
+ *
+ * @param {{context: {client: import('mongodb').MongoClient}}} context
+ */
+
+exports.up = async ({ context: { client } }) => {
+  await client.connect();
+
+  const collection = client.db(config.realm.production_db.db_name).collection('candidates');
+
+  const result = await collection.deleteMany({ date_published: { $exists: true, $eq: null } });
+
+  console.log(`Removed  ${result.deletedCount} records.`);
+};


### PR DESCRIPTION
This is to remove the existing candidate that breaks the graphql endpoint.

There is  more work to be done by @lmcnulty  