### PR TITLE
Fix missing FR translations

### DIFF
--- a/site/gatsby-site/src/templates/cite.js
+++ b/site/gatsby-site/src/templates/cite.js
@@ -67,6 +67,7 @@ function CitePage(props) {
       allMongodbAiidprodReports,
       allMongodbTranslationsReportsEs,
       allMongodbTranslationsReportsEn,
+      allMongodbTranslationsReportsFr,
       incident,
     },
   } = props;
@@ -93,7 +94,11 @@ function CitePage(props) {
 
   const incidentReports = getTranslatedReports({
     allMongodbAiidprodReports,
-    translations: { en: allMongodbTranslationsReportsEn, es: allMongodbTranslationsReportsEs },
+    translations: {
+      en: allMongodbTranslationsReportsEn,
+      es: allMongodbTranslationsReportsEs,
+      fr: allMongodbTranslationsReportsFr,
+    },
     locale,
   });
 


### PR DESCRIPTION
Takes care of citation pages missing report translations to `fr`
