### PR TITLE
Prevent 0 from being counted as missing range value

### DIFF
--- a/site/gatsby-site/src/components/discover/filterTypes/RangeInput.js
+++ b/site/gatsby-site/src/components/discover/filterTypes/RangeInput.js
@@ -11,7 +11,7 @@ const formatDate = (epoch) => new Date(epoch * 1000).toISOString().substr(0, 10)
 const dateToEpoch = (date) => new Date(date).getTime() / 1000;
 
 const RangeInput = ({ min, max, currentRefinement, refine, attribute }) => {
-  if (!min || !max) {
+  if ((!min && min !== 0) || (!max && max !== 0)) {
     return null;
   }
 


### PR DESCRIPTION
Resolves #1273.

The date range filters could use some other improvements, but this causes them to at least appear.