### PR TITLE
ListGroup margins

### DIFF
--- a/site/gatsby-site/src/components/WordList.js
+++ b/site/gatsby-site/src/components/WordList.js
@@ -3,14 +3,14 @@ import React from 'react';
 
 const Wordlist = ({ content }) => {
   return (
-    <ListGroup>
+    <ListGroup className="ml-0">
       {content.map((value, index) => (
         <div
           className={`p-3 ${index < content.length - 1 ? 'border-b' : ''}`}
           key={`word-${value[0]}`}
         >
           <div className="flex flex-row w-full justify-between">
-            <p className="truncate text-sm font-medium text-gray-900 dark:text-white mb-0">
+            <p className="truncate text-sm font-medium text-gray-900 dark:text-white my-0">
               {value[0]}
             </p>
             <span className="bg-blue-100 text-blue-800 text-xs font-semibold mr-2 px-2.5 py-0.5 rounded dark:bg-blue-200 dark:text-blue-800">

--- a/site/gatsby-site/src/components/WordList.js
+++ b/site/gatsby-site/src/components/WordList.js
@@ -3,7 +3,7 @@ import React from 'react';
 
 const Wordlist = ({ content }) => {
   return (
-    <ListGroup className="ml-0">
+    <ListGroup>
       {content.map((value, index) => (
         <div
           className={`p-3 ${index < content.length - 1 ? 'border-b' : ''}`}

--- a/site/gatsby-site/src/components/leaderboards/Leaderboard.js
+++ b/site/gatsby-site/src/components/leaderboards/Leaderboard.js
@@ -34,7 +34,7 @@ const Medal = styled.div`
   display: inline-block;
 `;
 
-export const Leaderboard = ({ dataHash, leaderboard: { attribute, title }, limit }) => {
+export const Leaderboard = ({ dataHash, leaderboard: { attribute, title }, limit, className }) => {
   let sortedArray = [];
 
   for (const item in dataHash) {
@@ -54,7 +54,7 @@ export const Leaderboard = ({ dataHash, leaderboard: { attribute, title }, limit
   }
 
   return (
-    <div className="max-w-sm flex-1 self-stretch">
+    <div className={`max-w-sm flex-1 self-stretch ${className || ''}`}>
       <div className="flex rounded-lg border border-gray-200 bg-white shadow-md dark:border-gray-700 dark:bg-gray-800 flex-col w-full">
         <div className="flex items-center justify-between px-6 pt-6 pb-4 hover:bg-gray-100 dark:hover:bg-gray-700">
           <LocalizedLink to={`/summaries/leaderboard`}>
@@ -77,7 +77,7 @@ export const Leaderboard = ({ dataHash, leaderboard: { attribute, title }, limit
                       <Medal className="pr-2">{medalMap(index + 1)}</Medal>
                     </div>
                     <div className="min-w-0 flex-1">
-                      <p className="truncate text-sm font-medium text-gray-900 dark:text-w  hite mb-0">
+                      <p className="truncate text-sm font-medium text-gray-900 dark:text-w  hite mb-0 my-0">
                         {item.label}
                       </p>
                     </div>

--- a/site/gatsby-site/src/components/styles/Docs.js
+++ b/site/gatsby-site/src/components/styles/Docs.js
@@ -39,8 +39,8 @@ export const StyledMainWrapper = styled.div`
   max-width: 800px;
   color: ${(props) => props.theme.colors.text};
 
-  ul,
-  ol {
+  > ul,
+  > ol {
     -webkit-padding-start: 40px;
     -moz-padding-start: 40px;
     -o-padding-start: 40px;

--- a/site/gatsby-site/src/pages/summaries/incidents.js
+++ b/site/gatsby-site/src/pages/summaries/incidents.js
@@ -8,7 +8,7 @@ import { StyledHeading, StyledMainWrapper } from 'components/styles/Docs';
 
 const ReportList = ({ items }) => {
   return (
-    <ul>
+    <ul className="pl-8 leading-6 my-4">
       {items.map((report) => (
         <li key={report.report_number} data-cy={`report-${report.report_number}`}>
           <a href={report.url}>{report.title}</a>

--- a/site/gatsby-site/src/templates/backups.js
+++ b/site/gatsby-site/src/templates/backups.js
@@ -42,7 +42,7 @@ const Backups = ({ pageContext, ...props }) => {
         <Container>
           <Row>
             <Col xs={12}>
-              <ul>
+              <ul className="pl-8 leading-6">
                 {backups
                   .map((b) => ({
                     ...b,

--- a/site/gatsby-site/src/templates/wordcounts.js
+++ b/site/gatsby-site/src/templates/wordcounts.js
@@ -56,7 +56,7 @@ const WordCounts = ({ pageContext, ...props }) => {
           </Trans>
         </p>
         <Container>
-          <ul>
+          <ul className="pl-0">
             {wordClouds &&
               wordCountsSorted &&
               wordClouds.map((wordCloud, idx) => (


### PR DESCRIPTION
Resolves #1290.

<table>
  <tr><th>Before</th><th>After</th>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/25443411/196718683-cdcd1c31-ca53-4eb4-804c-2bb6fdf1a70a.png"/></td>
    <td><img src="https://user-images.githubusercontent.com/25443411/196718888-e1d45978-3200-496c-8ace-8f41e6ec0e0d.png"/></td>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/25443411/196719684-16282356-df8f-4690-bb5f-7553e22d543a.png"/></td>
    <td><img src="https://user-images.githubusercontent.com/25443411/196719389-d4927116-b7b6-4837-868e-a84c78653f5e.png"/></td>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/25443411/196720062-af6e44ca-c2b1-4d86-be86-37b0354f2667.png"/></td>
    <td><img src="https://user-images.githubusercontent.com/25443411/196720260-f783a387-cdca-4ce2-b921-ba754fcd865e.png"/></td>
  </tr>

</table>

## Breakage Attempts
- Checked for incorrect padding and margins in
	- Bulleted lists in blog posts
	- RelatedIncidents ListView
	- Taxonomies
	- Entities
	- Table View
	- Site footer list
	- Footer pages
	  - **Found** in Database Snapshots
	  - **Found** in /summaries/incidents
	- Submission Queue
	- Submit form
	- Discover
- Checked for list padding behavior on mobile to ensure it's the same between top-level and manually-styled lists.