### PR TITLE
Use <a> instead of <Link> in September blog post

### DIFF
--- a/site/gatsby-site/blog/incident-report-2022-september/index.es.mdx
+++ b/site/gatsby-site/blog/incident-report-2022-september/index.es.mdx
@@ -63,9 +63,9 @@ _Incidentes antiguos que tienen nuevos informes o actualizaciones._
   <tr>
     <td className="align-top border-1 border-gray-200 px-4 py-2">
       <strong>Incidente n.º 293: </strong>
-      <Link to="/cite/293">
+      <a href="/cite/293">
         El automóvil autónomo de Cruise involucrado en una colisión con lesiones múltiples en una intersección de San Francisco
-      </Link>
+      </a>
     </td>
     <td className="align-top border-1 border-gray-200 px-4 py-2">
       <ul className="pl-0">
@@ -93,9 +93,9 @@ _Incidentes antiguos que tienen nuevos informes o actualizaciones._
   <tr>
     <td className="align-top border-1 border-gray-200 px-4 py-2">
       <strong>Incidente n.º 183:</strong>
-      <Link to="/cite/183">
+      <a href="/cite/183">
         El algoritmo de confiabilidad de Airbnb supuestamente prohibió a los usuarios sin explicación y discriminó a las trabajadoras sexuales
-      </Link>
+      </a>
     </td>
     <td className="align-top border-1 border-gray-200 px-4 py-2">
       <ul className="pl-0">
@@ -114,9 +114,9 @@ _Incidentes antiguos que tienen nuevos informes o actualizaciones._
   <tr>
     <td className="align-top border-1 border-gray-200 px-4 py-2">
       <strong>Incidente n.º 353:</strong>
-      <Link to="/cite/353">
+      <a href="/cite/353">
         Tesla en piloto automático se estrelló contra un camión de remolque en Florida, matando al conductor
-      </Link>
+      </a>
     </td>
     <td className="align-top border-1 border-gray-200 px-4 py-2">
       <ul className="pl-0">
@@ -144,9 +144,9 @@ _Incidentes antiguos que tienen nuevos informes o actualizaciones._
   <tr>
     <td className="align-top border-1 border-gray-200 px-4 py-2">
       <strong>Incidente n.º 254:</strong>
-      <Link to="/cite/254">
+      <a href="/cite/254">
         La agrupación de rostros de Google supuestamente recopiló y analizó la estructura facial de los usuarios sin consentimiento, violó la BIPA
-      </Link>
+      </a>
     </td>
     <td className="align-top border-1 border-gray-200 px-4 py-2">
       <ul className="pl-0">

--- a/site/gatsby-site/blog/incident-report-2022-september/index.fr.mdx
+++ b/site/gatsby-site/blog/incident-report-2022-september/index.fr.mdx
@@ -62,9 +62,9 @@ _Older incidents that have new reports or updates._
   <tr>
     <td className="align-top border-1 border-gray-200 px-4 py-2">
       <strong>Incident #293: </strong>
-      <Link to="/cite/293">
+      <a href="/cite/293">
         Cruise’s Self-Driving Car Involved in a Multiple-Injury Collision at an San Francisco Intersection
-      </Link>
+      </a>
     </td>
     <td className="align-top border-1 border-gray-200 px-4 py-2">
       <ul className="pl-0">
@@ -92,9 +92,9 @@ _Older incidents that have new reports or updates._
   <tr>
     <td className="align-top border-1 border-gray-200 px-4 py-2">
       <strong>Incident #183:</strong>
-      <Link to="/cite/183">
+      <a href="/cite/183">
         Airbnb's Trustworthiness Algorithm Allegedly Banned Users without Explanation, and Discriminated against Sex Workers
-      </Link>
+      </a>
     </td>
     <td className="align-top border-1 border-gray-200 px-4 py-2">
       <ul className="pl-0">
@@ -113,9 +113,9 @@ _Older incidents that have new reports or updates._
   <tr>
     <td className="align-top border-1 border-gray-200 px-4 py-2">
       <strong>Incident #353:</strong>
-      <Link to="/cite/353">
+      <a href="/cite/353">
         Tesla on Autopilot Crashed into Trailer Truck in Florida, Killing Driver
-      </Link>
+      </a>
     </td>
     <td className="align-top border-1 border-gray-200 px-4 py-2">
       <ul className="pl-0">
@@ -143,9 +143,9 @@ _Older incidents that have new reports or updates._
   <tr>
     <td className="align-top border-1 border-gray-200 px-4 py-2">
       <strong>Incident #254:</strong>
-      <Link to="/cite/254">
+      <a href="/cite/254">
         Google’s Face Grouping Allegedly Collected and Analyzed Users’ Facial Structure without Consent, Violated BIPA
-      </Link>
+      </a>
     </td>
     <td className="align-top border-1 border-gray-200 px-4 py-2">
       <ul className="pl-0">

--- a/site/gatsby-site/blog/incident-report-2022-september/index.mdx
+++ b/site/gatsby-site/blog/incident-report-2022-september/index.mdx
@@ -61,10 +61,10 @@ _Older incidents that have new reports or updates._
   </tr>
   <tr>
     <td className="align-top border-1 border-gray-200 px-4 py-2">
-      <strong>Incident #293: </strong>
-      <Link to="/cite/293">
+      <strong>Incident #293:</strong>{' '}
+      <a href="/cite/293">
         Cruise’s Self-Driving Car Involved in a Multiple-Injury Collision at an San Francisco Intersection
-      </Link>
+      </a>
     </td>
     <td className="align-top border-1 border-gray-200 px-4 py-2">
       <ul className="pl-0">
@@ -91,10 +91,10 @@ _Older incidents that have new reports or updates._
   </tr>
   <tr>
     <td className="align-top border-1 border-gray-200 px-4 py-2">
-      <strong>Incident #183:</strong>
-      <Link to="/cite/183">
+      <strong>Incident #183:</strong>{' '}
+      <a href="/cite/183">
         Airbnb's Trustworthiness Algorithm Allegedly Banned Users without Explanation, and Discriminated against Sex Workers
-      </Link>
+      </a>
     </td>
     <td className="align-top border-1 border-gray-200 px-4 py-2">
       <ul className="pl-0">
@@ -112,10 +112,10 @@ _Older incidents that have new reports or updates._
   </tr>
   <tr>
     <td className="align-top border-1 border-gray-200 px-4 py-2">
-      <strong>Incident #353:</strong>
-      <Link to="/cite/353">
+      <strong>Incident #353:</strong>{' '}
+      <a href="/cite/353">
         Tesla on Autopilot Crashed into Trailer Truck in Florida, Killing Driver
-      </Link>
+      </a>
     </td>
     <td className="align-top border-1 border-gray-200 px-4 py-2">
       <ul className="pl-0">
@@ -142,10 +142,10 @@ _Older incidents that have new reports or updates._
   </tr>
   <tr>
     <td className="align-top border-1 border-gray-200 px-4 py-2">
-      <strong>Incident #254:</strong>
-      <Link to="/cite/254">
+      <strong>Incident #254:</strong>{' '}
+      <a href="/cite/254">
         Google’s Face Grouping Allegedly Collected and Analyzed Users’ Facial Structure without Consent, Violated BIPA
-      </Link>
+      </a>
     </td>
     <td className="align-top border-1 border-gray-200 px-4 py-2">
       <ul className="pl-0">


### PR DESCRIPTION
Resolves #1295.

## Breakage Attempts
- Checked that each link renders as a LocalizedLink with the React developer tools.
- Followed each link and confirmed that it led to the expected location.
- Tested that the back and forward buttons worked as expected.