### PR TITLE
Fix edge case on submission review form

### DIFF
--- a/site/gatsby-site/cypress/e2e/apps/submitted.cy.js
+++ b/site/gatsby-site/cypress/e2e/apps/submitted.cy.js
@@ -615,8 +615,6 @@ describe('Submitted reports', () => {
       (r) => r.incident_id === 0 && r.description === undefined
     );
 
-    console.log(submission);
-
     cy.conditionalIntercept(
       '**/graphql',
       (req) => req.body.operationName == 'FindSubmissions',

--- a/site/gatsby-site/src/components/submissions/SubmissionReview.js
+++ b/site/gatsby-site/src/components/submissions/SubmissionReview.js
@@ -93,10 +93,11 @@ const SubmissionReview = ({ submission }) => {
 
   const promoteSubmission = useCallback(async () => {
     if (
-      !submission.description ||
-      !submission.developers ||
-      !submission.deployers ||
-      !submission.harmed_parties
+      isNewIncident &&
+      (!submission.description ||
+        !submission.developers ||
+        !submission.deployers ||
+        !submission.harmed_parties)
     ) {
       addToast({
         message: `Please review submission before approving. Some data is missing.`,


### PR DESCRIPTION
This closes #1305

This is the behavior implemented:

1. On `/apps/submit` submission form, none of these fields are **required**:
- `Incident ID`
- `description`
- `Alleged developer of AI system`
- `Alleged deployer of AI system`
- `Alleged harmed or nearly harmed parties`

2. On `/apps/submitted`submission review form:

2.1. If no `Incident ID` is set, all of these fields are **required** and will be set to the New Incident created:
- `description`
- `Alleged developer of AI system`
- `Alleged deployer of AI system`
- `Alleged harmed or nearly harmed parties`

2.2. If a valid `Incident ID` is set, none of these fields are required since they will be picked from the Incident selected:
- `description`
- `Alleged developer of AI system`
- `Alleged deployer of AI system`
- `Alleged harmed or nearly harmed parties`