### PR TITLE
Add incident_title and editors to submissions for editors

### DIFF
--- a/site/gatsby-site/cypress/e2e/submit.cy.js
+++ b/site/gatsby-site/cypress/e2e/submit.cy.js
@@ -2,6 +2,8 @@ import parseNews from '../fixtures/api/parseNews.json';
 
 import semanticallyRelated from '../fixtures/api/semanticallyRelated.json';
 
+import { maybeIt } from '../support/utils';
+
 describe('The Submit form', () => {
   const url = '/apps/submit';
 
@@ -43,6 +45,8 @@ describe('The Submit form', () => {
 
     cy.get('[data-cy="extra-fields"]').click();
 
+    cy.get('[name="incident_title"]').should('not.exist');
+
     cy.get('[name="tags"]').type('New Tag{enter}');
 
     cy.get('[name="editor_notes"').type('Here are some notes');
@@ -80,6 +84,87 @@ describe('The Submit form', () => {
 
     cy.contains('Please review. Some data is missing.').should('not.exist');
   });
+
+  maybeIt(
+    'As editor, should submit a new report not linked to any incident, adding an incident title and editors.',
+    () => {
+      cy.login(Cypress.env('e2eUsername'), Cypress.env('e2ePassword'));
+
+      cy.intercept('GET', parserURL, parseNews).as('parseNews');
+
+      cy.conditionalIntercept(
+        '**/graphql',
+        (req) => req.body.operationName == 'InsertSubmission',
+        'insertSubmission',
+        {
+          data: {
+            insertOneSubmission: { __typename: 'Submission', _id: '6272f2218933c7a9b512e13b' },
+          },
+        }
+      );
+
+      cy.visit(url);
+
+      cy.get('input[name="url"]').type(
+        `https://www.arstechnica.com/gadgets/2017/11/youtube-to-crack-down-on-inappropriate-content-masked-as-kids-cartoons/`
+      );
+
+      cy.get('button').contains('Fetch info').click();
+
+      cy.wait('@parseNews');
+
+      cy.get('input[name="submitters"]').type('Something');
+
+      cy.get('[name="incident_date"]').type('2020-01-01');
+
+      cy.get('[name="language"]').select('Spanish');
+
+      cy.get('[data-cy="extra-fields"]').click();
+
+      cy.get('[name="tags"]').type('New Tag{enter}');
+
+      cy.get('[name="incident_title"]').type('Elsagate');
+
+      cy.get('[name="incident_editors"]').type('Sean McGregor, Khoa Lam');
+
+      cy.get('[name="editor_notes"').type('Here are some notes');
+
+      cy.get('button[type="submit"]').click();
+
+      cy.wait('@insertSubmission').then((xhr) => {
+        expect(xhr.request.body.variables.submission).to.deep.nested.include({
+          title: 'YouTube to crack down on inappropriate content masked as kids’ cartoons',
+          submitters: ['Something'],
+          authors: ['Valentina Palladino'],
+          incident_date: '2020-01-01',
+          date_published: '2017-11-10',
+          image_url:
+            'https://cdn.arstechnica.net/wp-content/uploads/2017/11/Screen-Shot-2017-11-10-at-9.25.47-AM-760x380.png',
+          tags: ['New Tag'],
+          incident_id: 0,
+          incident_title: 'Elsagate',
+          incident_editors: ['Sean McGregor', 'Khoa Lam'],
+          text: "## Recent news stories and blog\n\nposts _highlighted_ the underbelly of YouTube Kids, Google's children-friendly version.",
+          plain_text:
+            "Recent news stories and blog\n\nposts highlighted the underbelly of YouTube Kids, Google's children-friendly version.\n",
+          url: `https://www.arstechnica.com/gadgets/2017/11/youtube-to-crack-down-on-inappropriate-content-masked-as-kids-cartoons/`,
+          source_domain: `arstechnica.com`,
+          language: 'es',
+          editor_notes: 'Here are some notes',
+        });
+      });
+
+      cy.wait(0);
+
+      cy.get('[data-cy="toast"]')
+        .contains('Report successfully added to review queue')
+        .should('be.visible');
+
+      cy.get('[data-cy="toast"] a').should('have.attr', 'href', '/apps/submitted');
+
+      cy.contains('Please review. Some data is missing.').should('not.exist');
+    }
+  );
 
   it('Should submit a new report linked to incident 1 once all fields are filled properly', () => {
     cy.intercept('GET', parserURL, parseNews).as('parseNews');

--- a/site/gatsby-site/src/components/submissions/SubmissionForm.js
+++ b/site/gatsby-site/src/components/submissions/SubmissionForm.js
@@ -457,7 +457,7 @@ const SubmissionForm = () => {
               />
 
               <TagsInputGroup
-                name="editors"
+                name="incident_editors"
                 label={t('Editors')}
                 className="mt-3"
                 {...TextInputGroupProps}

--- a/site/gatsby-site/src/components/submissions/SubmissionForm.js
+++ b/site/gatsby-site/src/components/submissions/SubmissionForm.js
@@ -19,6 +19,7 @@ import supportedLanguages from '../../components/i18n/languages.json';
 import { Trans, useTranslation } from 'react-i18next';
 import RelatedIncidents from '../../components/RelatedIncidents';
 import SemanticallyRelatedIncidents from '../../components/SemanticallyRelatedIncidents';
+import { useUserContext } from 'contexts/userContext';
 
 // set in form //
 // * title: "title of the report" # (string) The title of the report that is indexed.
@@ -119,6 +120,7 @@ export const schema = yup.object().shape({
     is: (incident_id) => incident_id == '' || incident_id === undefined,
     then: yup.date().required('*Incident Date required'),
   }),
+  incident_title: yup.string(),
   editor_notes: yup.string(),
 });
 
@@ -160,6 +162,8 @@ const SubmissionForm = () => {
   } = useFormikContext();
 
   const { t } = useTranslation(['submit']);
+
+  const { isRole } = useUserContext();
 
   const TextInputGroupProps = { values, errors, touched, handleChange, handleBlur, schema };
 
@@ -433,12 +437,28 @@ const SubmissionForm = () => {
 
           {!values.incident_id && (
             <>
+              {isRole('incident_editor') && (
+                <TextInputGroup
+                  name="incident_title"
+                  label={t('Incident Title')}
+                  placeholder={t('Incident title')}
+                  className="mt-3"
+                  {...TextInputGroupProps}
+                />
+              )}
               <TextInputGroup
                 name="description"
                 label={t('Description')}
                 as="textarea"
                 placeholder={t('Incident Description')}
                 rows={3}
+                className="mt-3"
+                {...TextInputGroupProps}
+              />
+
+              <TagsInputGroup
+                name="editors"
+                label={t('Editors')}
                 className="mt-3"
                 {...TextInputGroupProps}
               />

--- a/site/gatsby-site/src/components/submissions/SubmissionForm.js
+++ b/site/gatsby-site/src/components/submissions/SubmissionForm.js
@@ -456,12 +456,14 @@ const SubmissionForm = () => {
                 {...TextInputGroupProps}
               />
 
-              <TagsInputGroup
-                name="incident_editors"
-                label={t('Editors')}
-                className="mt-3"
-                {...TextInputGroupProps}
-              />
+              {isRole('incident_editor') && (
+                <TagsInputGroup
+                  name="incident_editors"
+                  label={t('Editors')}
+                  className="mt-3"
+                  {...TextInputGroupProps}
+                />
+              )}
 
               <TagsInputGroup
                 name="developers"

--- a/site/gatsby-site/src/components/submissions/SubmissionReview.js
+++ b/site/gatsby-site/src/components/submissions/SubmissionReview.js
@@ -54,7 +54,15 @@ const dateRender = [
   'date_modified',
 ];
 
-const otherDetails = ['language', '_id', 'developers', 'deployers', 'harmed_parties'];
+const otherDetails = [
+  'language',
+  '_id',
+  'developers',
+  'deployers',
+  'harmed_parties',
+  'incident_title',
+  'incident_editors',
+];
 
 const SubmissionReview = ({ submission }) => {
   const { isRole } = useUserContext();
@@ -131,6 +139,8 @@ const SubmissionReview = ({ submission }) => {
     const report = {
       ...submission,
       incident_id: undefined,
+      incident_title: undefined,
+      incident_editors: undefined,
       deployers: undefined,
       developers: undefined,
       harmed_parties: undefined,
@@ -171,7 +181,7 @@ const SubmissionReview = ({ submission }) => {
             incident_id: incident.incident_id,
           },
           set: {
-            title: submission.title,
+            title: submission.incident_title || submission.title,
             date: submission.incident_date,
             description: submission.description,
           },

--- a/site/gatsby-site/src/components/submissions/SubmissionReview.js
+++ b/site/gatsby-site/src/components/submissions/SubmissionReview.js
@@ -105,7 +105,8 @@ const SubmissionReview = ({ submission }) => {
       (!submission.description ||
         !submission.developers ||
         !submission.deployers ||
-        !submission.harmed_parties)
+        !submission.harmed_parties ||
+        !submission.incident_title)
     ) {
       addToast({
         message: `Please review submission before approving. Some data is missing.`,

--- a/site/gatsby-site/src/graphql/submissions.js
+++ b/site/gatsby-site/src/graphql/submissions.js
@@ -21,6 +21,8 @@ export const FIND_SUBMISSIONS = gql`
       image_url
       incident_date
       incident_id
+      incident_editors
+      incident_title
       language
       source_domain
       text
@@ -57,6 +59,8 @@ export const FIND_SUBMISSION = gql`
       image_url
       incident_date
       incident_id
+      incident_editors
+      incident_title
       language
       source_domain
       text
@@ -92,6 +96,8 @@ export const UPDATE_SUBMISSION = gql`
       image_url
       incident_date
       incident_id
+      incident_editors
+      incident_title
       language
       source_domain
       text

--- a/site/realm/data_sources/mongodb-atlas/aiidprod/submissions/schema.json
+++ b/site/realm/data_sources/mongodb-atlas/aiidprod/submissions/schema.json
@@ -39,6 +39,12 @@
                 "bsonType": "string"
             }
         },
+        "editors": {
+            "bsonType": "array",
+            "items": {
+                "bsonType": "string"
+            }
+        },
         "editor_dissimilar_incidents": {
             "bsonType": "array",
             "items": {
@@ -82,6 +88,9 @@
         },
         "incident_id": {
             "bsonType": "int"
+        },
+        "incident_title": {
+            "bsonType": "string"
         },
         "language": {
             "bsonType": "string"

--- a/site/realm/data_sources/mongodb-atlas/aiidprod/submissions/schema.json
+++ b/site/realm/data_sources/mongodb-atlas/aiidprod/submissions/schema.json
@@ -39,12 +39,6 @@
                 "bsonType": "string"
             }
         },
-        "editors": {
-            "bsonType": "array",
-            "items": {
-                "bsonType": "string"
-            }
-        },
         "editor_dissimilar_incidents": {
             "bsonType": "array",
             "items": {
@@ -91,6 +85,12 @@
         },
         "incident_title": {
             "bsonType": "string"
+        },
+        "incident_editors": {
+            "bsonType": "array",
+            "items": {
+                "bsonType": "string"
+            }
         },
         "language": {
             "bsonType": "string"

--- a/site/realm/functions/promoteSubmissionToReport.js
+++ b/site/realm/functions/promoteSubmissionToReport.js
@@ -15,11 +15,11 @@ exports = async (input) => {
     const lastIncident = await incidents.find({}).sort({incident_id: -1}).limit(1).next();
     
     const newIncident = {
-      title: submission.title,
+      title: submission.incident_title || submission.title,
       description: submission.description,
       incident_id: lastIncident.incident_id + 1,
       reports: [],
-      editors: ["Sean McGregor"],
+      editors: submission.editors || ["Sean McGregor"],
       date: submission.incident_date,
       "Alleged deployer of AI system": submission.deployers || [],
       "Alleged developer of AI system": submission.developers || [],

--- a/site/realm/functions/promoteSubmissionToReport.js
+++ b/site/realm/functions/promoteSubmissionToReport.js
@@ -19,7 +19,7 @@ exports = async (input) => {
       description: submission.description,
       incident_id: lastIncident.incident_id + 1,
       reports: [],
-      editors: submission.editors || ["Sean McGregor"],
+      editors: submission.incident_editors || ["Sean McGregor"],
       date: submission.incident_date,
       "Alleged deployer of AI system": submission.deployers || [],
       "Alleged developer of AI system": submission.developers || [],


### PR DESCRIPTION
Resolves #1266.

<img width="500" src="https://user-images.githubusercontent.com/25443411/198332823-968c5f16-ccf5-43a0-95ae-3f06033474a6.png"/>

- I think ultimately these fields should go outside of "Tell us more" along with any other fields that are mandatory. However, that change belongs in another PR.
  - Maybe for editors we should just not collapse the tell us more section at all ?

## Testing / Breakage Attempts

- As editor, make and promote submission with incident ID
  - Can't add incident title or editors
  - Check MongoDB that new report content is correct

- As editor, make and promote submission without incident ID
  - Don't add incident title or editors
    or other optional information on submission
  - Blocked from promoting until more info is added
    - Form validation requires title. Add it. 
    - Doesn't require editor - leave it blank.
  - Check MongoDB that new incident and report content is correct

- As editor, make and promote submission without incident ID
  - Add everything *except* the incident title
  - **Found bug**: When only the incident title is missing,
    it allows promotion, even though it requires it in the form.
    Fixed by adding `!submission.incident_title` to missing data check.
  - Check MongoDB that new incident and report content is correct

- When logged out, make submission without incident ID
  - **Found bug**: Displays editors, but not title, to logged-out users
  
- When logged out, make submission with incident ID

- As editor, promote both of the above
