### PR TITLE
Disable subscriptions and notifications to new Incidents

### DIFF
--- a/site/gatsby-site/cypress/e2e/subscriptions.cy.js
+++ b/site/gatsby-site/cypress/e2e/subscriptions.cy.js
@@ -127,7 +127,7 @@ describe('Subscriptions', () => {
     cy.contains("You don't have active subscriptions to Incident updates").should('exist');
   });
 
-  it("Should display the switch toggle off if user does't have a subscription to new incidents", () => {
+  it.skip("Should display the switch toggle off if user does't have a subscription to new incidents", () => {
     cy.login(Cypress.env('e2eUsername'), Cypress.env('e2ePassword'));
 
     cy.conditionalIntercept(
@@ -144,7 +144,7 @@ describe('Subscriptions', () => {
     cy.get('button[role=switch][aria-checked=false]').should('exist');
   });
 
-  it('Should display the switch toggle on if user have a subscription to new incidents', () => {
+  it.skip('Should display the switch toggle on if user have a subscription to new incidents', () => {
     cy.login(Cypress.env('e2eUsername'), Cypress.env('e2ePassword'));
 
     cy.conditionalIntercept(
@@ -161,7 +161,7 @@ describe('Subscriptions', () => {
     cy.get('button[role=switch][aria-checked=true]').should('exist');
   });
 
-  it('Subscribe/Unsubscribe to new incidents', () => {
+  it.skip('Subscribe/Unsubscribe to new incidents', () => {
     cy.conditionalIntercept(
       '**/login',
       (req) => req.body.username == Cypress.env('e2eUsername'),

--- a/site/gatsby-site/src/components/UserSubscriptions.js
+++ b/site/gatsby-site/src/components/UserSubscriptions.js
@@ -88,7 +88,7 @@ const UserSubscriptions = () => {
 
   return (
     <div className="mt-4">
-      <div className="my-4">
+      <div className="my-4 hidden">
         <ToggleSwitch
           checked={isSubscribeToNewIncidents}
           label={t('Notify me of new Incidents')}

--- a/site/realm/triggers/onNewIncident.json
+++ b/site/realm/triggers/onNewIncident.json
@@ -15,7 +15,7 @@
         "unordered": false,
         "skip_catchup_events": false
     },
-    "disabled": false,
+    "disabled": true,
     "event_processors": {
         "FUNCTION": {
             "config": {


### PR DESCRIPTION
Temporarily disable subscriptions and notifications to new Incidents until we resolve how to handle unexisting Incident pages.
We should send a New Incident email notification after the Incident page is generated.