### PR TITLE
Re-enable subscription to New Incidents option

### DIFF
--- a/site/gatsby-site/cypress/e2e/subscriptions.cy.js
+++ b/site/gatsby-site/cypress/e2e/subscriptions.cy.js
@@ -127,7 +127,7 @@ describe('Subscriptions', () => {
     cy.contains("You don't have active subscriptions to Incident updates").should('exist');
   });
 
-  it.skip("Should display the switch toggle off if user does't have a subscription to new incidents", () => {
+  it("Should display the switch toggle off if user does't have a subscription to new incidents", () => {
     cy.login(Cypress.env('e2eUsername'), Cypress.env('e2ePassword'));
 
     cy.conditionalIntercept(
@@ -144,7 +144,7 @@ describe('Subscriptions', () => {
     cy.get('button[role=switch][aria-checked=false]').should('exist');
   });
 
-  it.skip('Should display the switch toggle on if user have a subscription to new incidents', () => {
+  it('Should display the switch toggle on if user have a subscription to new incidents', () => {
     cy.login(Cypress.env('e2eUsername'), Cypress.env('e2ePassword'));
 
     cy.conditionalIntercept(
@@ -161,7 +161,7 @@ describe('Subscriptions', () => {
     cy.get('button[role=switch][aria-checked=true]').should('exist');
   });
 
-  it.skip('Subscribe/Unsubscribe to new incidents', () => {
+  it('Subscribe/Unsubscribe to new incidents', () => {
     cy.conditionalIntercept(
       '**/login',
       (req) => req.body.username == Cypress.env('e2eUsername'),

--- a/site/gatsby-site/src/components/UserSubscriptions.js
+++ b/site/gatsby-site/src/components/UserSubscriptions.js
@@ -88,7 +88,7 @@ const UserSubscriptions = () => {
 
   return (
     <div className="mt-4">
-      <div className="my-4 hidden">
+      <div className="my-4">
         <ToggleSwitch
           checked={isSubscribeToNewIncidents}
           label={t('Notify me of new Incidents')}


### PR DESCRIPTION
This PR re-enable the `Notify on new Incidents` switch option on the Account page. This is because we already merged this PR https://github.com/responsible-ai-collaborative/aiid/pull/1331 which improves how we treat New Incident events.

<img width="882" alt="Screen Shot 2022-11-07 at 20 17 42" src="https://user-images.githubusercontent.com/6564809/200435823-067f5f0c-7c9d-4f7b-a74c-af1a7279ba5f.png">
