### PR TITLE
Move Incident updates notifications to post-build

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ To get your Public and Private API Key, follow these [instructions](https://www.
 To get the group ID and the app ID, the easiest way is to navigate to your Atlas Service App dashboard and copy from the URL.
 The URL format is https://realm.mongodb.com/groups/[groupId]/apps/[appId]/dashboard
 
-Email notifications to New Incidents (subscription type **New Incident**) are sent when the next build finishes. This is because we have to wait until the new Incident page is created and accessible.
+Email notifications to New Incidents (subscription type **New Incident**) are sent when the next build finishes. This is because we have to wait until the new Incident page is generated and accessible.
 When a new Incident is created, a pending notification item is saved into the `notifications` DB collection with `processed=false` field.
 And finally, as part of the site build process, we processed all pending notifications (`processed=false`), send the emails to all recipients, and update the items with `processed=true` and `sentDate=[now]`.
 ## Contact

--- a/README.md
+++ b/README.md
@@ -580,9 +580,35 @@ About Facebook Authentication instructions: https://www.mongodb.com/docs/realm/w
 ### Subscription types
 
 - **All**: This subscription type is not defined yet.
+    ```
+    {
+        "userId": "63320ce63ec803072c9f529c"
+        "type": "all",
+    }
+    ```
 - **Incident**: Users with this subscription type will be notified when the incident associated is updated. This subscription type needs an incident_id value associated.
+    ```
+    {
+        "userId": "63320ce63ec803072c9f529c"
+        "type": "incident",
+        "incident_id": 10,
+    }
+    ```
 - **New Incident**: Users with this subscription type will be notified when a new Incident is created. The notification will be sent after finish the next site build when the Incident page is actually created.
+    ```
+    {
+        "userId": "63320ce63ec803072c9f529c"
+        "type": "new-incidents",
+    }
+    ```
 - **Entities**: Users can subscribe to an specific Entity. The user with this subscription type will be notified when a new Incident associated with an specific Entity is created or when an existing Incident is updated to be associated with that Entity.
+    ```
+    {
+        "userId": "63320ce63ec803072c9f529c",
+        "type": "entity"
+        "entityId": "openai",
+    }
+    ```
 
 These subscription types are also documented in [subscriptions.js](site/gatsby-site/src/utils/subscriptions.js) file.
 
@@ -607,9 +633,47 @@ To get your Public and Private API Key, follow these [instructions](https://www.
 To get the group ID and the app ID, the easiest way is to navigate to your Atlas Service App dashboard and copy from the URL.
 The URL format is https://realm.mongodb.com/groups/[groupId]/apps/[appId]/dashboard
 
-Email notifications to New Incidents (subscription type **New Incident**) are sent when the next build finishes. This is because we have to wait until the new Incident page is generated and accessible.
-When a new Incident is created, a pending notification item is saved into the `notifications` DB collection with `processed=false` field.
+Email notifications to New Incidents (subscription type **New Incident**) and Incident updates (subscription type **Incident**) are sent when the next build finishes. This is because we have to wait until the new Incident page is generated and accessible.
+When a new Incident is created or updates, a pending notification item is saved into the `notifications` DB collection with `processed=false` field.
 And finally, as part of the site build process, we processed all pending notifications (`processed=false`), send the emails to all recipients, and update the items with `processed=true` and `sentDate=[now]`.
+
+### Notifications collection definition
+
+- **Incident Updated**
+    ```
+    {
+        "type": "incident-updated",
+        "incident_id": 374,
+        "processed": false
+    }
+    ```
+- **New Incident Report**
+    ```
+    {
+        "type": "new-report-incident",
+        "incident_id": 374,
+        "report_number": 2172,
+        "processed": false
+    }
+    ```
+- **New Incident**
+    ```
+    {
+        "type": 'new-incidents',
+        "incident_id": incidentId,
+        "processed": false,
+    }
+    ```
+- **Entities**
+    ```
+    {
+        "type": "entity",
+        "incident_id": 374,
+        "entity_id": "openai",
+        "isUpdate": true,
+        "processed": false
+    }
+    ```
 ## Contact
 
 For inquiries, you are encouraged to open an issue on this repository or visit the [contact page](https://incidentdatabase.ai/contact).

--- a/site/gatsby-site/cypress/e2e/functions/onIncidentUpdate.cy.js
+++ b/site/gatsby-site/cypress/e2e/functions/onIncidentUpdate.cy.js
@@ -1,0 +1,285 @@
+const { SUBSCRIPTION_TYPE } = require('../../../src/utils/subscriptions');
+
+const onIncidentUpdate = require('../../../../realm/functions/onIncidentUpdate');
+
+const subscriptionsToIncidentUpdates = [
+  {
+    userId: '63320ce63ec803072c9f5291',
+    type: SUBSCRIPTION_TYPE.incident,
+    incident_id: 1,
+  },
+  {
+    userId: '63321072f27421740a80af22',
+    type: SUBSCRIPTION_TYPE.incident,
+    incident_id: 1,
+  },
+];
+
+const subscriptionsToNewEntityIncidents = [
+  {
+    _id: '6356e39e863169c997309502',
+    type: SUBSCRIPTION_TYPE.entity,
+    entityId: 'google',
+    userId: '63321072f27421740a80af23',
+  },
+  {
+    _id: '6356e39e863169c997309503',
+    type: SUBSCRIPTION_TYPE.entity,
+    entityId: 'facebook',
+    userId: '63321072f27421740a80af24',
+  },
+  {
+    _id: '6356e39e863169c997309504',
+    type: SUBSCRIPTION_TYPE.entity,
+    entityId: 'tesla',
+    userId: '63321072f27421740a80af25',
+  },
+];
+
+const fullDocumentBeforeChange = {
+  incident_id: 1,
+  reports: [1, 2],
+  title: '24 Amazon workers sent to hospital after robot accidentally unleashes bear spray',
+  'Alleged deployer of AI system': [],
+  'Alleged developer of AI system': [],
+  'Alleged harmed or nearly harmed parties': [],
+  date: '2018-11-16',
+  description: 'Twenty-four Amazon workers in New Jersey were hospitalized.',
+  nlp_similar_incidents: [],
+};
+
+const fullDocument = {
+  incident_id: 1,
+  reports: [1, 2, 3],
+  title: '24 Amazon workers sent to hospital after robot accidentally unleashes bear spray',
+  'Alleged deployer of AI system': ['google', 'openai'],
+  'Alleged developer of AI system': [],
+  'Alleged harmed or nearly harmed parties': ['facebook'],
+  date: '2018-11-16',
+  description: 'New description',
+  nlp_similar_incidents: [],
+};
+
+const updateDescription = {
+  updatedFields: {
+    description: 'New description',
+  },
+};
+
+const updateDescriptionWithReports = {
+  updatedFields: {
+    reports: [3],
+  },
+};
+
+const updateDescriptionWithEntities = {
+  updatedFields: {
+    'Alleged deployer of AI system': ['google', 'openai'],
+    'Alleged harmed or nearly harmed parties': ['facebook'],
+  },
+};
+
+const stubEverything = () => {
+  const notificationsCollection = {
+    updateOne: cy.stub().as('notifications.updateOne'),
+  };
+
+  const subscriptionsCollection = {
+    find: (() => {
+      const stub = cy.stub();
+
+      stub
+        .withArgs({ type: SUBSCRIPTION_TYPE.incident, incident_id: fullDocument.incident_id })
+        .as(`subscriptions.find("${SUBSCRIPTION_TYPE.incident}", "${fullDocument.incident_id}")`)
+        .returns({ toArray: () => subscriptionsToIncidentUpdates });
+
+      for (const entityId of ['google', 'facebook', 'tesla', 'openai']) {
+        stub
+          .withArgs({ type: SUBSCRIPTION_TYPE.entity, entityId })
+          .as(`subscriptions.find("${SUBSCRIPTION_TYPE.entity}", "${entityId}")`)
+          .returns({
+            toArray: () => subscriptionsToNewEntityIncidents.filter((s) => s.entityId == entityId),
+          });
+      }
+
+      return stub;
+    })(),
+  };
+
+  global.context = {
+    // @ts-ignore
+    services: {
+      get: cy.stub().returns({
+        db: cy.stub().returns({
+          collection: (() => {
+            const stub = cy.stub();
+
+            stub.withArgs('notifications').returns(notificationsCollection);
+            stub.withArgs('subscriptions').returns(subscriptionsCollection);
+
+            return stub;
+          })(),
+        }),
+      }),
+    },
+  };
+
+  global.BSON = { Int32: (x) => x };
+
+  return {
+    notificationsCollection,
+    subscriptionsCollection,
+  };
+};
+
+describe('Functions', () => {
+  it('Incident Updated - Should insert a pending notification to process in the next build', () => {
+    const { notificationsCollection, subscriptionsCollection } = stubEverything();
+
+    cy.wrap(onIncidentUpdate({ updateDescription, fullDocument, fullDocumentBeforeChange })).then(
+      () => {
+        expect(subscriptionsCollection.find.getCall(0).args[0]).to.deep.equal({
+          type: SUBSCRIPTION_TYPE.incident,
+          incident_id: fullDocument.incident_id,
+        });
+
+        const notification = {
+          type: 'incident-updated',
+          incident_id: 1,
+          processed: false,
+        };
+
+        expect(notificationsCollection.updateOne.getCall(0).args).to.deep.equal([
+          notification, // filter
+          notification, // new document
+          { upsert: true },
+        ]);
+      }
+    );
+  });
+
+  it('New Incident Report - Should insert a pending notification to process in the next build', () => {
+    const { notificationsCollection, subscriptionsCollection } = stubEverything();
+
+    cy.wrap(
+      onIncidentUpdate({
+        updateDescription: updateDescriptionWithReports,
+        fullDocument,
+        fullDocumentBeforeChange,
+      })
+    ).then(() => {
+      expect(subscriptionsCollection.find.getCall(0).args[0]).to.deep.equal({
+        type: SUBSCRIPTION_TYPE.incident,
+        incident_id: fullDocument.incident_id,
+      });
+
+      const notification = {
+        type: 'new-report-incident',
+        incident_id: 1,
+        report_number: 3,
+        processed: false,
+      };
+
+      expect(notificationsCollection.updateOne.getCall(0).args).to.deep.equal([
+        notification, // filter
+        notification, // new document
+        { upsert: true },
+      ]);
+    });
+  });
+
+  it('Entity - Should insert a pending notification to process in the next build', () => {
+    const { notificationsCollection, subscriptionsCollection } = stubEverything();
+
+    cy.wrap(
+      onIncidentUpdate({
+        updateDescription: updateDescriptionWithEntities,
+        fullDocument,
+        fullDocumentBeforeChange,
+      })
+    ).then(() => {
+      expect(subscriptionsCollection.find.callCount).to.be.equal(4);
+
+      expect(subscriptionsCollection.find.getCall(0).args[0]).to.deep.equal({
+        type: SUBSCRIPTION_TYPE.incident,
+        incident_id: fullDocument.incident_id,
+      });
+
+      expect(subscriptionsCollection.find.getCall(1).args[0]).to.deep.equal({
+        type: SUBSCRIPTION_TYPE.entity,
+        entityId: 'google',
+      });
+
+      expect(notificationsCollection.updateOne.callCount).to.be.equal(3);
+
+      const notification = {
+        type: SUBSCRIPTION_TYPE.entity,
+        incident_id: 1,
+        entity_id: 'google',
+        isUpdate: true,
+        processed: false,
+      };
+
+      expect(notificationsCollection.updateOne.getCall(1).args).to.deep.equal([
+        notification, // filter
+        notification, // new document
+        { upsert: true },
+      ]);
+
+      notification.entity_id = 'facebook';
+
+      expect(notificationsCollection.updateOne.getCall(2).args).to.deep.equal([
+        notification, // filter
+        notification, // new document
+        { upsert: true },
+      ]);
+    });
+  });
+
+  it(`Shouldn't insert a pending notification if there are no active subscribers`, () => {
+    const notificationsCollection = {
+      updateOne: cy.stub().as('notifications.updateOne'),
+    };
+
+    const subscriptionsCollection = {
+      find: cy.stub().returns({
+        toArray: cy.stub().as('subscriptions.find.toArray').resolves([]),
+      }),
+    };
+
+    global.context = {
+      // @ts-ignore
+      services: {
+        get: cy.stub().returns({
+          db: cy.stub().returns({
+            collection: (() => {
+              const stub = cy.stub();
+
+              stub.withArgs('notifications').returns(notificationsCollection);
+              stub.withArgs('subscriptions').returns(subscriptionsCollection);
+
+              return stub;
+            })(),
+          }),
+        }),
+      },
+    };
+
+    global.BSON = { Int32: (x) => x };
+
+    cy.wrap(
+      onIncidentUpdate({
+        updateDescription: updateDescriptionWithEntities,
+        fullDocument,
+        fullDocumentBeforeChange,
+      })
+    ).then(() => {
+      expect(subscriptionsCollection.find.firstCall.args[0]).to.deep.equal({
+        type: SUBSCRIPTION_TYPE.incident,
+        incident_id: 1,
+      });
+
+      expect(notificationsCollection.updateOne.callCount).to.be.equal(0);
+    });
+  });
+});

--- a/site/realm/functions/onIncidentUpdate.js
+++ b/site/realm/functions/onIncidentUpdate.js
@@ -24,56 +24,17 @@ exports = async function (changeEvent) {
   // Process subscriptions to Incident updates
   if (subscriptionsToIncident.length > 0) {
 
-    const userIds = subscriptionsToIncident.map((subscription) => subscription.userId);
-
-    const recipients = [];
-
-    for (const userId of userIds) {
-      const userResponse = await context.functions.execute('getUser', { userId });
-
-      if (userResponse.email) {
-        recipients.push({
-          email: userResponse.email,
-          userId,
-        });
-      }
-    }
-
     // Check if the "reports" field was updated
     const isReportListChanged = updatedFields.some(field => field.match(/reports/));
+
+    let newReportNumber;
 
     if (isReportListChanged) {
       const { reports: newReports } = fullDocument;
       const { reports: oldReports } = fullDocumentBeforeChange;
 
-      // If a new report is added, send the email notification to all subscribers
       if (newReports.length > oldReports.length) {
-
-        const newReportNumber = newReports.filter(report => !oldReports.includes(report))[0];
-
-        const reportsCollection = context.services.get('mongodb-atlas').db('aiidprod').collection("reports");
-        const newReport = await reportsCollection.findOne({ report_number: newReportNumber })
-
-        //Send email notification
-        const sendEmailParams = {
-          recipients,
-          subject: 'Incident {{incidentId}} was updated',
-          dynamicData: {
-            incidentId: `${incidentId}`,
-            incidentTitle: fullDocument.title,
-            incidentUrl: `https://incidentdatabase.ai/cite/${incidentId}`,
-            reportUrl: `https://incidentdatabase.ai/cite/${incidentId}#r${newReportNumber}`,
-            reportTitle: newReport.title,
-            reportAuthor: newReport.authors[0] ? newReport.authors[0] : '',
-          },
-          templateId: 'NewReportAddedToAnIncident' // Template value from function name sufix from "site/realm/functions/config.json"
-        };
-        const sendEmailresult = await context.functions.execute('sendEmail', sendEmailParams);
-
-        console.log('sendEmailParams', JSON.stringify(sendEmailParams));
-        console.log(JSON.stringify(sendEmailresult));
-
-        return sendEmailresult;
+        newReportNumber = newReports.filter(report => !oldReports.includes(report))[0];
       }
       else { //if a report was deleted
         const deletedReportNumber = oldReports.filter(report => !newReports.includes(report))[0];
@@ -81,23 +42,30 @@ exports = async function (changeEvent) {
       }
     }
 
-    //Send email notification
-    const sendEmailParams = {
-      recipients,
-      subject: 'Incident {{incidentId}} was updated',
-      dynamicData: {
-        incidentId: `${incidentId}`,
-        incidentTitle: fullDocument.title,
-        incidentUrl: `https://incidentdatabase.ai/cite/${incidentId}`,
-      },
-      templateId: 'IncidentUpdate' // Template value from function name sufix from "site/realm/functions/config.json"
-    };
-    const sendEmailresult = await context.functions.execute('sendEmail', sendEmailParams);
+    let notification;
+    if (newReportNumber) {
+      // If there is a new Report > Insert a pending notification to process in the next build
+      notification = {
+        type: 'new-report-incident',
+        incident_id: incidentId,
+        report_number: newReportNumber,
+        processed: false,
+      };
+    }
+    else {
+      // If any other Incident field is updated > Insert a pending notification to process in the next build
+      notification = {
+        type: 'incident-updated',
+        incident_id: incidentId,
+        processed: false,
+      };
+    }
 
-    console.log('sendEmailParams', JSON.stringify(sendEmailParams));
-    console.log(JSON.stringify(sendEmailresult));
-
-    return sendEmailresult;
+    await notificationsCollection.updateOne(
+      notification, // filter
+      notification, // new document
+      { upsert: true }
+    );
   }
 
   // Check if Entity fields changed
@@ -138,13 +106,18 @@ exports = async function (changeEvent) {
 
       // If there are subscribers to Entities > Insert a pending notification to process in the next build
       if (subscriptionsToEntity.length > 0) {
-        await notificationsCollection.insertOne({
+        const notification = {
           type: 'entity',
           incident_id: incidentId,
           entity_id: entityId,
           isUpdate: true,
           processed: false,
-        })
+        };
+        await notificationsCollection.updateOne(
+          notification, // filter
+          notification, // new document
+          { upsert: true }
+        )
       }
     }
   }

--- a/site/realm/functions/onIncidentUpdate.js
+++ b/site/realm/functions/onIncidentUpdate.js
@@ -124,3 +124,7 @@ exports = async function (changeEvent) {
 
   return;
 };
+
+if (typeof module === 'object') {
+  module.exports = exports;
+}


### PR DESCRIPTION
This PR moves the code that sends the Incident updates notifications to the post-build process.

Doing this way, we are sure that the Incident page is updated with the new data.