### PR TITLE
When embedding is null unset the field instead of saving it

### DIFF
--- a/site/gatsby-site/cypress/e2e/functions/linkReportsToIncidents.cy.js
+++ b/site/gatsby-site/cypress/e2e/functions/linkReportsToIncidents.cy.js
@@ -251,7 +251,7 @@ describe('Functions', () => {
 
       expect(incidentsCollection.updateOne.firstCall.args[0]).to.deep.equal({ incident_id: 2 });
       expect(incidentsCollection.updateOne.firstCall.args[1]).to.deep.equal({
-        $set: { embedding: null },
+        $unset: { embedding: '' },
       });
 
       expect(reportsCollection.updateMany.firstCall.args[0]).to.deep.equal({

--- a/site/realm/functions/linkReportsToIncidents.js
+++ b/site/realm/functions/linkReportsToIncidents.js
@@ -30,7 +30,9 @@ exports = async (input) => {
 
     const embedding = incidentEmbedding(reports);
 
-    await incidentsCollection.updateOne({ incident_id: incident.incident_id }, { $set: { embedding } });
+    const operation = embedding == null ? { $unset: { embedding: "" } } : { $set: { embedding } }
+
+    await incidentsCollection.updateOne({ incident_id: incident.incident_id }, operation);
   }
 
   await incidentsCollection.updateMany({ reports: { $in: input.report_numbers } }, { $pull: { reports: { $in: input.report_numbers.map(BSON.Int32) } } });
@@ -50,7 +52,9 @@ exports = async (input) => {
 
       const embedding = incidentEmbedding(reports);
 
-      await incidentsCollection.updateOne({ incident_id: incident.incident_id }, { $set: { embedding } });
+      const operation = embedding == null ? { $unset: { embedding: "" } } : { $set: { embedding } }
+
+      await incidentsCollection.updateOne({ incident_id: incident.incident_id }, operation);
     }
   }
 


### PR DESCRIPTION
Otherwise, environments with the following setting toggled off fail:

![image](https://user-images.githubusercontent.com/1172479/206290907-ea68d8b3-61fb-464d-bb67-476e79e826e9.png)

Sadly this setting is not part of Realm's JSON definitions.