### PR TITLE
Upgrade to Cypress 12

### DIFF
--- a/site/gatsby-site/package-lock.json
+++ b/site/gatsby-site/package-lock.json
@@ -116,7 +116,7 @@
         "@tailwindcss/typography": "^0.5.8",
         "autoprefixer": "^10.4.7",
         "babel-eslint": "^10.1.0",
-        "cypress": "^11.2.0",
+        "cypress": "^12.0.2",
         "eslint": "^7.17.0",
         "eslint-config-prettier": "^7.1.0",
         "eslint-import-resolver-alias": "^1.1.2",
@@ -10605,9 +10605,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
-      "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.0.2.tgz",
+      "integrity": "sha512-WnLx1DpnbF1vbpDBkgP14rK5yS3U+Gvxrv2fsB4Owma26oIyENj7DDRnsJbSZuTfG4mcuUJxAkRHJR2wBqBfMA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -10658,7 +10658,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
       }
     },
     "node_modules/cypress/node_modules/ansi-styles": {
@@ -43661,9 +43661,9 @@
       }
     },
     "cypress": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
-      "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.0.2.tgz",
+      "integrity": "sha512-WnLx1DpnbF1vbpDBkgP14rK5yS3U+Gvxrv2fsB4Owma26oIyENj7DDRnsJbSZuTfG4mcuUJxAkRHJR2wBqBfMA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/site/gatsby-site/package.json
+++ b/site/gatsby-site/package.json
@@ -125,7 +125,7 @@
     "@tailwindcss/typography": "^0.5.8",
     "autoprefixer": "^10.4.7",
     "babel-eslint": "^10.1.0",
-    "cypress": "^11.2.0",
+    "cypress": "^12.0.2",
     "eslint": "^7.17.0",
     "eslint-config-prettier": "^7.1.0",
     "eslint-import-resolver-alias": "^1.1.2",


### PR DESCRIPTION
Might help with flakyness since it includes an upgraded DOM handling algorithm better suited for React-like frameworks:

> The Fix for Dreaded Detached DOM Errors
A big change coming in Cypress 12 is a fix for one of the oldest and most annoying issues with Cypress, the [“Detached DOM”](https://github.com/cypress-io/cypress/issues/7306) error. The DOM resolution logic has been enhanced to requery new elements that might have replaced the older elements due to DOM updates. This will lead to tests being more reliable and stable.