### PR TITLE
Use local names for languages in switcher

### DIFF
--- a/site/gatsby-site/cypress/e2e/integration/languageSwitcher.cy.js
+++ b/site/gatsby-site/cypress/e2e/integration/languageSwitcher.cy.js
@@ -22,7 +22,7 @@ describe('The Language switcher', () => {
 
     cy.waitForStableDOM();
 
-    cy.get('[data-cy="language-switcher"]').contains('[role="button"]', 'Spanish').click();
+    cy.get('[data-cy="language-switcher"]').contains('[role="button"]', 'Español').click();
 
     cy.url().should('contain', '/es/');
 

--- a/site/gatsby-site/src/components/i18n/LanguageSwitcher.js
+++ b/site/gatsby-site/src/components/i18n/LanguageSwitcher.js
@@ -44,7 +44,7 @@ export default function LanguageSwitcher({ className = '' }) {
             onClick={() => setLanguage(locale.code)}
             className="flex"
           >
-            {locale.name}
+            {locale.localName}
             {locale.code === 'fr' && (
               <span className="ml-2 rounded">
                 <Badge>Beta</Badge>


### PR DESCRIPTION
Resolves #939.

![image](https://user-images.githubusercontent.com/25443411/210591041-84407140-4f5b-4b4f-b22c-098d17279f94.png)
