### PR TITLE
Avoid send notifications on `gatsby build` for Cypress

### DIFF
--- a/site/gatsby-site/gatsby-node.js
+++ b/site/gatsby-site/gatsby-node.js
@@ -336,7 +336,7 @@ exports.onPreBuild = function ({ reporter }) {
 exports.onPostBuild = async ({ reporter }) => {
   reporter.info('Site has been built!');
 
-  if (process.env.CONTEXT == 'production') {
+  if (process.env.CI != 'true' && process.env.CONTEXT == 'production') {
     reporter.info('Processing pending notifications...');
 
     const processNotifications = require('./postBuild/processNotifications');

--- a/site/gatsby-site/netlify.toml
+++ b/site/gatsby-site/netlify.toml
@@ -13,7 +13,7 @@ TERM = "xterm"
     enable = true
     record = false
     spa = true
-    start = 'gatsby build && gatsby serve -p 8080'
+    start = 'CI=true gatsby build && gatsby serve -p 8080'
     wait-on = 'http://localhost:8080'
     wait-on-timeout = '600' # seconds
     browser = 'chromium'


### PR DESCRIPTION
This PR avoids sending notifications on the `gatsby build` fired by Cypress process setting a env variable `CI=true`