### PR TITLE
Prevent gatsby i18n theme to duplicate pages

### DIFF
--- a/site/gatsby-site/cypress/e2e/unit/pageCreators/createReportPages.cy.js
+++ b/site/gatsby-site/cypress/e2e/unit/pageCreators/createReportPages.cy.js
@@ -10,14 +10,6 @@ const response = {
         },
         {
           report_number: 2,
-          language: 'en',
-        },
-        {
-          report_number: 3,
-          language: 'en',
-        },
-        {
-          report_number: 4,
           language: 'es',
         },
       ],
@@ -25,17 +17,47 @@ const response = {
   },
 };
 
+const languages = [
+  {
+    code: 'en',
+    hrefLang: 'en-US',
+    name: 'English',
+    localName: 'English',
+    langDir: 'ltr',
+    dateFormat: 'MM/DD/YYYY',
+  },
+  {
+    code: 'es',
+    hrefLang: 'es',
+    name: 'Spanish',
+    localName: 'Español',
+    langDir: 'ltr',
+    dateFormat: 'DD-MM-YYYY',
+  },
+  {
+    code: 'fr',
+    hrefLang: 'fr',
+    name: 'French',
+    localName: 'Français',
+    langDir: 'ltr',
+    dateFormat: 'DD-MM-YYYY',
+  },
+];
+
 describe('createReportPages', () => {
   it('Should parse properly', () => {
     const graphql = cy.stub().resolves(response);
 
     const createPage = cy.stub();
 
-    cy.wrap(createReportPages(graphql, createPage)).then(() => {
-      expect(createPage.callCount).to.eq(4);
+    cy.wrap(createReportPages(graphql, createPage, { languages })).then(() => {
+      expect(createPage.callCount).to.eq(6);
 
       cy.wrap(createPage.getCall(0).args[0]).then((page) => {
         expect(page.path).contain('/reports/1');
+        expect(page.context.originalPath).eq('/reports/1');
+        expect(page.context.locale).eq('en');
+        expect(page.context.hrefLang).eq('en-US');
         expect(page.context.report_number).eq(1);
         expect(page.context.language).eq('en');
         expect(page.context.translate_es).eq(true);
@@ -45,16 +67,22 @@ describe('createReportPages', () => {
 
       cy.wrap(createPage.getCall(1).args[0]).then((page) => {
         expect(page.path).contain('/reports/2');
+        expect(page.context.originalPath).eq('/reports/2');
+        expect(page.context.locale).eq('en');
+        expect(page.context.hrefLang).eq('en-US');
         expect(page.context.report_number).eq(2);
-        expect(page.context.language).eq('en');
-        expect(page.context.translate_es).eq(true);
-        expect(page.context.translate_en).eq(false);
+        expect(page.context.language).eq('es');
+        expect(page.context.translate_es).eq(false);
+        expect(page.context.translate_en).eq(true);
         expect(page.context.translate_fr).eq(true);
       });
 
       cy.wrap(createPage.getCall(2).args[0]).then((page) => {
-        expect(page.path).contain('/reports/3');
-        expect(page.context.report_number).eq(3);
+        expect(page.path).contain('/es/reports/1');
+        expect(page.context.originalPath).eq('/es/reports/1');
+        expect(page.context.locale).eq('es');
+        expect(page.context.hrefLang).eq('es');
+        expect(page.context.report_number).eq(1);
         expect(page.context.language).eq('en');
         expect(page.context.translate_es).eq(true);
         expect(page.context.translate_en).eq(false);
@@ -62,8 +90,35 @@ describe('createReportPages', () => {
       });
 
       cy.wrap(createPage.getCall(3).args[0]).then((page) => {
-        expect(page.path).contain('/reports/4');
-        expect(page.context.report_number).eq(4);
+        expect(page.path).contain('/es/reports/2');
+        expect(page.context.originalPath).eq('/es/reports/2');
+        expect(page.context.locale).eq('es');
+        expect(page.context.hrefLang).eq('es');
+        expect(page.context.report_number).eq(2);
+        expect(page.context.language).eq('es');
+        expect(page.context.translate_es).eq(false);
+        expect(page.context.translate_en).eq(true);
+        expect(page.context.translate_fr).eq(true);
+      });
+
+      cy.wrap(createPage.getCall(4).args[0]).then((page) => {
+        expect(page.path).contain('/fr/reports/1');
+        expect(page.context.originalPath).eq('/fr/reports/1');
+        expect(page.context.locale).eq('fr');
+        expect(page.context.hrefLang).eq('fr');
+        expect(page.context.report_number).eq(1);
+        expect(page.context.language).eq('en');
+        expect(page.context.translate_es).eq(true);
+        expect(page.context.translate_en).eq(false);
+        expect(page.context.translate_fr).eq(true);
+      });
+
+      cy.wrap(createPage.getCall(5).args[0]).then((page) => {
+        expect(page.path).contain('/fr/reports/2');
+        expect(page.context.originalPath).eq('/fr/reports/2');
+        expect(page.context.locale).eq('fr');
+        expect(page.context.hrefLang).eq('fr');
+        expect(page.context.report_number).eq(2);
         expect(page.context.language).eq('es');
         expect(page.context.translate_es).eq(false);
         expect(page.context.translate_en).eq(true);

--- a/site/gatsby-site/page-creators/createReportPages.js
+++ b/site/gatsby-site/page-creators/createReportPages.js
@@ -1,10 +1,8 @@
-const config = require('../config');
-
 const path = require('path');
 
 const { switchLocalizedPath } = require('../i18n');
 
-const createReportPages = async (graphql, createPage) => {
+const createReportPages = async (graphql, createPage, { languages }) => {
   const result = await graphql(
     `
       query ReportPages {
@@ -31,10 +29,10 @@ const createReportPages = async (graphql, createPage) => {
     });
   }
 
-  for (const language of config.i18n.availableLanguages) {
+  for (const language of languages) {
     for (const context of pageContexts) {
       const pagePath = switchLocalizedPath({
-        newLang: language,
+        newLang: language.code,
         path: '/reports/' + context.report_number,
       });
 
@@ -43,6 +41,9 @@ const createReportPages = async (graphql, createPage) => {
         component: path.resolve('./src/templates/report.js'),
         context: {
           ...context,
+          originalPath: pagePath,
+          locale: language.code,
+          hrefLang: language.hrefLang,
           translate_es: context.language !== 'es',
           translate_fr: context.language !== 'fr',
           translate_en: context.language !== 'en',


### PR DESCRIPTION
This prevents URLs like these from being generated: https://incidentdatabase.ai/fr/es/reports/217

The reason why these changes work is obscure and dependent on internal implementation,https://github.com/gatsbyjs/themes/issues/104 but it is the easiest way: 

closes #1546 