### PR TITLE
Fix incidents table scrolling

### DIFF
--- a/site/gatsby-site/src/pages/apps/incidents.js
+++ b/site/gatsby-site/src/pages/apps/incidents.js
@@ -24,7 +24,7 @@ export default function IncidentsPage(props) {
           </div>
         )}
         {incidentsData && incidentsData.incidents && (
-          <div className="ms-3 mt-2 mb-2">
+          <div className="ms-3 mt-2 mb-2 overflow-x-auto">
             <IncidentsTable data={incidentsData.incidents} />
           </div>
         )}


### PR DESCRIPTION
Fixes issue from https://github.com/responsible-ai-collaborative/aiid/pull/1581#issuecomment-1419846254 where it was not possible to scroll horizontally on the incidents table.