### PR TITLE
Make schema dummy_fields list of objects instead of object

### DIFF
--- a/site/realm/data_sources/mongodb-atlas/aiidprod/taxa/schema.json
+++ b/site/realm/data_sources/mongodb-atlas/aiidprod/taxa/schema.json
@@ -13,11 +13,14 @@
             "bsonType": "int"
         },
         "dummy_fields": {
+          "bsonType": "array",
+          "items": {
             "bsonType": "object",
             "properties": {
               "field_number": { "bsonType": "string" },
               "short_name": { "bsonType": "string" }
             }
+          }
         },
         "field_list": {
             "bsonType": "array",


### PR DESCRIPTION
This fixes the broken classifications app from https://github.com/responsible-ai-collaborative/aiid/pull/1605#issuecomment-1426559484.