### PR TITLE
Change cset attribute publish value_json from null to "false"

### DIFF
--- a/site/gatsby-site/migrations/2023.02.12T19.24.41.remove-publish-null.js
+++ b/site/gatsby-site/migrations/2023.02.12T19.24.41.remove-publish-null.js
@@ -1,0 +1,30 @@
+/** @type {import('umzug').MigrationFn<any>} */
+const config = require('../config');
+
+/** @type {import('umzug').MigrationFn<any>} */
+exports.up = async ({ context: { client } }) => {
+  const classifications = client
+    .db(config.realm.production_db.db_name)
+    .collection('classifications');
+
+  const csetClassifications = await classifications.find({ namespace: 'CSET' });
+
+  while (await csetClassifications.hasNext()) {
+    const csetClassification = await csetClassifications.next();
+
+    const attributes = csetClassification.attributes;
+
+    const publishAttribute = attributes.find((a) => a.short_name == 'Publish');
+
+    if (publishAttribute.value_json === null) {
+      publishAttribute.value_json = 'false';
+      await classifications.updateOne(
+        { namespace: 'CSET', incident_id: csetClassification.incident_id },
+        { $set: { attributes } }
+      );
+    }
+  }
+};
+
+/** @type {import('umzug').MigrationFn<any>} */
+exports.down = async () => {};


### PR DESCRIPTION
I believe the error @cesarvarela pointed out in https://github.com/responsible-ai-collaborative/aiid/pull/1605#issuecomment-1427103644 was caused by CSET classifications having `{short_name: "Publish", value_json: null}`. This changes the value from `null` to `"false"`.