### PR TITLE
Fix/discover language switch

### DIFF
--- a/site/gatsby-site/src/components/i18n/LanguageSwitcher.js
+++ b/site/gatsby-site/src/components/i18n/LanguageSwitcher.js
@@ -17,7 +17,11 @@ export default function LanguageSwitcher({ className = '' }) {
 
     const newPath = localizedPath({ path, language });
 
-    navigate(newPath + search);
+    if (newPath.includes('apps/discover/')) {
+      window.location.href = newPath + search;
+    } else {
+      navigate(newPath + search);
+    }
   };
 
   return (

--- a/site/gatsby-site/src/pages/apps/discover.js
+++ b/site/gatsby-site/src/pages/apps/discover.js
@@ -20,6 +20,7 @@ import Row from 'elements/Row';
 import Col from 'elements/Col';
 import Layout from 'components/Layout';
 import { VIEW_TYPES } from 'utils/discover';
+import some from 'lodash/some';
 
 const searchClient = algoliasearch(
   config.header.search.algoliaAppId,
@@ -213,16 +214,20 @@ function DiscoverApp(props) {
 
     const extraQuery = { display: query.display };
 
-    setQuery({ ...searchQuery, ...extraQuery }, 'push');
+    if (!some([searchQuery], extraQuery)) {
+      //Only reset query if it has changed otherwise it triggers on Locale update and reloads the page to the previous locale
 
-    setViewType(
-      (searchState.refinementList.hideDuplicates === 'true' ||
-        searchState.refinementList.hideDuplicates === true) &&
-        searchState.refinementList.is_incident_report.length > 0 &&
-        searchState.refinementList.is_incident_report[0] === 'true'
-        ? VIEW_TYPES.INCIDENTS
-        : VIEW_TYPES.REPORTS
-    );
+      setQuery({ ...searchQuery, ...extraQuery }, 'push');
+
+      setViewType(
+        (searchState.refinementList.hideDuplicates === 'true' ||
+          searchState.refinementList.hideDuplicates === true) &&
+          searchState.refinementList.is_incident_report.length > 0 &&
+          searchState.refinementList.is_incident_report[0] === 'true'
+          ? VIEW_TYPES.INCIDENTS
+          : VIEW_TYPES.REPORTS
+      );
+    }
   }, [searchState]);
 
   const authorsModal = useModal();

--- a/site/gatsby-site/src/pages/apps/discover.js
+++ b/site/gatsby-site/src/pages/apps/discover.js
@@ -20,7 +20,6 @@ import Row from 'elements/Row';
 import Col from 'elements/Col';
 import Layout from 'components/Layout';
 import { VIEW_TYPES } from 'utils/discover';
-import some from 'lodash/some';
 
 const searchClient = algoliasearch(
   config.header.search.algoliaAppId,
@@ -214,20 +213,16 @@ function DiscoverApp(props) {
 
     const extraQuery = { display: query.display };
 
-    if (!some([searchQuery], extraQuery)) {
-      //Only set query if it has changed otherwise it triggers on Locale update and reloads the page to the previous locale
+    setQuery({ ...searchQuery, ...extraQuery }, 'push');
 
-      setQuery({ ...searchQuery, ...extraQuery }, 'push');
-
-      setViewType(
-        (searchState.refinementList.hideDuplicates === 'true' ||
-          searchState.refinementList.hideDuplicates === true) &&
-          searchState.refinementList.is_incident_report.length > 0 &&
-          searchState.refinementList.is_incident_report[0] === 'true'
-          ? VIEW_TYPES.INCIDENTS
-          : VIEW_TYPES.REPORTS
-      );
-    }
+    setViewType(
+      (searchState.refinementList.hideDuplicates === 'true' ||
+        searchState.refinementList.hideDuplicates === true) &&
+        searchState.refinementList.is_incident_report.length > 0 &&
+        searchState.refinementList.is_incident_report[0] === 'true'
+        ? VIEW_TYPES.INCIDENTS
+        : VIEW_TYPES.REPORTS
+    );
   }, [searchState]);
 
   const authorsModal = useModal();

--- a/site/gatsby-site/src/pages/apps/discover.js
+++ b/site/gatsby-site/src/pages/apps/discover.js
@@ -215,7 +215,7 @@ function DiscoverApp(props) {
     const extraQuery = { display: query.display };
 
     if (!some([searchQuery], extraQuery)) {
-      //Only reset query if it has changed otherwise it triggers on Locale update and reloads the page to the previous locale
+      //Only set query if it has changed otherwise it triggers on Locale update and reloads the page to the previous locale
 
       setQuery({ ...searchQuery, ...extraQuery }, 'push');
 


### PR DESCRIPTION
- closes #1642 

This is caused because of a double re-render of the discover page when switching languages.
The first render is due to the language switch which is correct, but this leads to the `searchState` being updated and the useEffect being rendered a second time, but this time with the previous language (for some reason I cannot comprehend).

More specifically the issue happens because of line 216, which is necessary to update the URL params and query.

This is not the best solution to the issue, so let me know if you can think of something else that fixes this.

[Deploy Preview #1644](https://deploy-preview-1644--staging-aiid.netlify.app/)

