### PR TITLE
Fix sorting

### DIFF
--- a/site/gatsby-site/cypress/e2e/unit/AlgoliaUpdater.cy.js
+++ b/site/gatsby-site/cypress/e2e/unit/AlgoliaUpdater.cy.js
@@ -228,6 +228,24 @@ describe('Algolia', () => {
         stub.withArgs('instant_search-es-featured').returns(esIndexReplica);
         stub.withArgs('instant_search-en-featured').returns(enIndexReplica);
 
+        stub.withArgs('instant_search-es_epoch_incident_date_desc').returns(esIndexReplica);
+        stub.withArgs('instant_search-en_epoch_incident_date_desc').returns(enIndexReplica);
+
+        stub.withArgs('instant_search-es_epoch_incident_date_asc').returns(esIndexReplica);
+        stub.withArgs('instant_search-en_epoch_incident_date_asc').returns(enIndexReplica);
+
+        stub.withArgs('instant_search-es_epoch_date_published_desc').returns(esIndexReplica);
+        stub.withArgs('instant_search-en_epoch_date_published_desc').returns(enIndexReplica);
+
+        stub.withArgs('instant_search-es_epoch_date_published_asc').returns(esIndexReplica);
+        stub.withArgs('instant_search-en_epoch_date_published_asc').returns(enIndexReplica);
+
+        stub.withArgs('instant_search-es_epoch_date_submitted_desc').returns(esIndexReplica);
+        stub.withArgs('instant_search-en_epoch_date_submitted_desc').returns(enIndexReplica);
+
+        stub.withArgs('instant_search-es_epoch_date_submitted_asc').returns(esIndexReplica);
+        stub.withArgs('instant_search-en_epoch_date_submitted_asc').returns(enIndexReplica);
+
         return stub;
       })(),
     };

--- a/site/gatsby-site/i18n/locales/es/translation.json
+++ b/site/gatsby-site/i18n/locales/es/translation.json
@@ -235,5 +235,12 @@
   "Quality Control": "Control de calidad",
   "All": "Todo",
   "Sort by": "Ordenar por",
-  "Display Option": "Opción de visualización"
+  "Display Option": "Opción de visualización",
+  "Relevance": "Relevancia",
+  "Newest Incident Date": "Fecha del incidente más reciente",
+  "Oldest Incident Date": "Fecha del incidente más antigua",
+  "Newest Published Date": "Fecha de publicación más reciente",
+  "Oldest Published Date": "Fecha de publicación más antigua",
+  "Newest Submitted Date": "Fecha de envío más reciente",
+  "Oldest Submitted Date": "Fecha de envío más antigua"
 }

--- a/site/gatsby-site/i18n/locales/fr/translation.json
+++ b/site/gatsby-site/i18n/locales/fr/translation.json
@@ -224,5 +224,12 @@
   "Quality Control": "Contrôle de qualité",
   "All": "Tous",
   "Sort by": "Trier par",
-  "Display Option": "Option d'affichage"
+  "Display Option": "Option d'affichage",
+  "Relevance": "Pertinence",
+  "Newest Incident Date": "Date de l'incident plus récente",
+  "Oldest Incident Date": "Date de l'incident plus ancienne", 
+  "Newest Published Date": "Date de publication plus récente",
+  "Oldest Published Date": "Date de publication plus ancienne",
+  "Newest Submitted Date": "Date de soumission plus récente",
+  "Oldest Submitted Date": "Date de soumission plus ancienne"
 }

--- a/site/gatsby-site/src/components/discover/SORTING_LISTS.js
+++ b/site/gatsby-site/src/components/discover/SORTING_LISTS.js
@@ -4,7 +4,7 @@ const SORTING_LIST = [
   {
     default: true,
     name: 'relevance',
-    value: 'instant_search-en',
+    value: 'instant_search-{{locale}}',
     label: 'Relevance',
     faIcon: faCalendarAlt,
     faClasses: 'far fa-calendar-alt',
@@ -12,7 +12,7 @@ const SORTING_LIST = [
   },
   {
     name: 'incident-date-desc',
-    value: 'instant_search-en_epoch_incident_date_desc',
+    value: 'instant_search-{{locale}}_epoch_incident_date_desc',
     label: 'Newest Incident Date',
     faIcon: faCalendarAlt,
     faClasses: 'far fa-calendar-alt',
@@ -20,7 +20,7 @@ const SORTING_LIST = [
   },
   {
     name: 'incident-date-asc',
-    value: 'instant_search-en_epoch_incident_date_asc',
+    value: 'instant_search-{{locale}}_epoch_incident_date_asc',
     label: 'Oldest Incident Date',
     faIcon: faCalendarAlt,
     faClasses: 'far fa-calendar-alt',
@@ -29,7 +29,7 @@ const SORTING_LIST = [
   },
   {
     name: 'published-date-desc',
-    value: 'instant_search-en_epoch_date_published_desc',
+    value: 'instant_search-{{locale}}_epoch_date_published_desc',
     label: 'Newest Published Date',
     faIcon: faCalendarAlt,
     faClasses: 'far fa-calendar-alt',
@@ -37,7 +37,7 @@ const SORTING_LIST = [
   },
   {
     name: 'published-date-asc',
-    value: 'instant_search-en_epoch_date_published_asc',
+    value: 'instant_search-{{locale}}_epoch_date_published_asc',
     label: 'Oldest Published Date',
     faIcon: faCalendarAlt,
     faClasses: 'far fa-calendar-alt',
@@ -46,7 +46,7 @@ const SORTING_LIST = [
   },
   {
     name: 'submitted-date-desc',
-    value: 'instant_search-en_epoch_date_submitted_desc',
+    value: 'instant_search-{{locale}}_epoch_date_submitted_desc',
     label: 'Newest Submitted Date',
     faIcon: faCalendarAlt,
     faClasses: 'far fa-calendar-alt',
@@ -54,7 +54,7 @@ const SORTING_LIST = [
   },
   {
     name: 'submitted-date-asc',
-    value: 'instant_search-en_epoch_date_submitted_asc',
+    value: 'instant_search-{{locale}}_epoch_date_submitted_asc',
     label: 'Oldest Submitted Date',
     faIcon: faCalendarAlt,
     faClasses: 'far fa-calendar-alt',

--- a/site/gatsby-site/src/components/discover/Sorting.js
+++ b/site/gatsby-site/src/components/discover/Sorting.js
@@ -3,18 +3,21 @@ import { connectSortBy } from 'react-instantsearch-dom';
 import { Dropdown } from 'flowbite-react';
 import { Trans, useTranslation } from 'react-i18next';
 import SORTING_LIST from './SORTING_LISTS';
+import { useLocalization } from 'gatsby-theme-i18n';
 
 function Sorting(props) {
   const [selectedItem, setSelectedItem] = useState(SORTING_LIST.find((s) => s.default));
 
   const { t } = useTranslation();
 
+  const { locale } = useLocalization();
+
   const sortResults = (item) => {
     setSelectedItem(item);
   };
 
   useEffect(() => {
-    props.refine(`${selectedItem.value}`);
+    props.refine(`${selectedItem.value.replace('{{locale}}', locale)}`);
   }, [selectedItem]);
 
   return (
@@ -32,8 +35,8 @@ function Sorting(props) {
           {props.items.map((item) => (
             <>
               <Dropdown.Item
-                key={item.value}
-                value={item.value}
+                key={item.value.replace('{{locale}}', locale)}
+                value={item.value.replace('{{locale}}', locale)}
                 style={{ fontWeight: item.isRefined ? 'bold' : '' }}
                 onClick={() => {
                   sortResults(item);

--- a/site/gatsby-site/src/utils/AlgoliaUpdater.js
+++ b/site/gatsby-site/src/utils/AlgoliaUpdater.js
@@ -305,6 +305,54 @@ class AlgoliaUpdater {
         await featuredReplicaIndex.setSettings({
           ranking: ['desc(featured)', 'desc(text)'],
         });
+
+        const incidentDateDescReplicaIndex = await this.algoliaClient.initIndex(
+          incidentDateDescReplicaIndexName
+        );
+
+        await incidentDateDescReplicaIndex.setSettings({
+          ranking: ['desc(epoch_incident_date)'],
+        });
+
+        const incidentDateAscReplicaIndex = await this.algoliaClient.initIndex(
+          incidentDateAscReplicaIndexName
+        );
+
+        await incidentDateAscReplicaIndex.setSettings({
+          ranking: ['asc(epoch_incident_date)'],
+        });
+
+        const datePublishedDescReplicaIndex = await this.algoliaClient.initIndex(
+          datePublishedDescReplicaIndexName
+        );
+
+        await datePublishedDescReplicaIndex.setSettings({
+          ranking: ['desc(epoch_date_published)'],
+        });
+
+        const datePublishedAscReplicaIndex = await this.algoliaClient.initIndex(
+          datePublishedAscReplicaIndexName
+        );
+
+        await datePublishedAscReplicaIndex.setSettings({
+          ranking: ['asc(epoch_date_published)'],
+        });
+
+        const dateSubmittedDescReplicaIndex = await this.algoliaClient.initIndex(
+          dateSubmittedDescReplicaIndexName
+        );
+
+        await dateSubmittedDescReplicaIndex.setSettings({
+          ranking: ['desc(epoch_date_submitted)'],
+        });
+
+        const dateSubmittedAscReplicaIndex = await this.algoliaClient.initIndex(
+          dateSubmittedAscReplicaIndexName
+        );
+
+        await dateSubmittedAscReplicaIndex.setSettings({
+          ranking: ['desc(epoch_date_submitted)'],
+        });
       });
   };
 


### PR DESCRIPTION
According to Algolia [documentation](https://www.algolia.com/doc/guides/managing-results/refine-results/sorting/how-to/creating-replicas/#standard-replicas), to create replicas that involve sorting, the format is:
`[index-name]_[sort-field-name]_[sort-direction]`
Which in our case is:
**EN**:
`instant_search-en_epoch_incident_date_desc`,`instant_search-en_epoch_incident_date_asc`, `instant_search-en_epoch_date_published_desc`, `instant_search-en_epoch_date_published_asc`, `instant_search-en_epoch_date_submitted_desc`, `instant_search-en_epoch_date_submitted_asc`
**ES**:
`instant_search-es_epoch_incident_date_desc`, `instant_search-es_epoch_incident_date_asc`, `instant_search-es_epoch_date_published_desc`, `instant_search-es_epoch_date_published_asc`, `instant_search-es_epoch_date_submitted_desc`, `instant_search-es_epoch_date_submitted_asc`
**FR**:
`instant_search-fr_epoch_incident_date_desc`, `instant_search-fr_epoch_incident_date_asc`, `instant_search-fr_epoch_date_published_desc`, `instant_search-fr_epoch_date_published_asc`, `instant_search-fr_epoch_date_submitted_desc`, `instant_search-fr_epoch_date_submitted_asc`

When specifying those replicas on AlgoliaUpdater `setSettings` it _should_ create the replicas with the specified sort.

However this doesn't work always, so the best solution here was to set the ranking manually once the replicas were created (same as it is currently done for the `instant_search-en-featured` replica.

This is currently working on my [environment](https://app.netlify.com/sites/clarayoudale-staging/deploys/63f7b4332ddac70008ea43b2)

I also added missing translations I spotted
