### PR TITLE
Fix sort direction for submitted date replica

### DIFF
--- a/site/gatsby-site/src/utils/AlgoliaUpdater.js
+++ b/site/gatsby-site/src/utils/AlgoliaUpdater.js
@@ -351,7 +351,7 @@ class AlgoliaUpdater {
         );
 
         await dateSubmittedAscReplicaIndex.setSettings({
-          ranking: ['desc(epoch_date_submitted)'],
+          ranking: ['asc(epoch_date_submitted)'],
         });
       });
   };


### PR DESCRIPTION
- solves sorting issue mentioned in https://github.com/responsible-ai-collaborative/aiid/pull/1616#issuecomment-1442622974 : sorting display the same results for submitted date desc or asc
Can be tested here
https://deploy-preview-11--clarayoudale-staging.netlify.app/
