### PR TITLE
Fix "Incidents" typo in entity header

### DIFF
--- a/site/gatsby-site/i18n/locales/es/entities.json
+++ b/site/gatsby-site/i18n/locales/es/entities.json
@@ -19,7 +19,7 @@
     "{{count}} Report": "{{count}} Reporte",
     "{{count}} Report_plural": "{{count}} Reportes",
     "Incidents involved as both Developer and Deployer": "Incidentes involucrados como desarrollador e implementador",
-    "Incindents Harmed By": "Afectado por Incidentes",
+    "Incidents Harmed By": "Afectado por Incidentes",
     "Alleged: <2></2> developed and deployed an AI system, which harmed <5></5>.": "Presunto: un sistema de IA desarrollado e implementado por <2></2>, perjudicó a <5></5>.",
     "Alleged: <1></1> developed an AI system deployed by <4></4>, which harmed <6></6>.": "Presunto: un sistema de IA desarrollado por <1></1> e implementado por <4></4>, perjudicó a <6></6>.",
     "Entities involved in AI Incidents": "^Entities involved in AI Incidents",

--- a/site/gatsby-site/i18n/locales/fr/entities.json
+++ b/site/gatsby-site/i18n/locales/fr/entities.json
@@ -19,7 +19,7 @@
     "{{count}} Report": "{{count}} Rapport",
     "{{count}} Report_plural": "{{count}} Rapports",
     "Incidents involved as both Developer and Deployer": "Incidents impliqués en tant que développeur et déployeur",
-    "Incindents Harmed By": "Affecté par des incidents",
+    "Incidents Harmed By": "Affecté par des incidents",
     "Alleged: <2></2> developed and deployed an AI system, which harmed <5></5>.": "Présumé : Un système d'IA développé et mis en œuvre par <2></2>, endommagé <5></5>.",
     "Alleged: <1></1> developed an AI system deployed by <4></4>, which harmed <6></6>.": "Présumé : un système d'IA développé par <1></1> et mis en œuvre par <4></4>, endommagé <6></6>.",
     "Entities involved in AI Incidents": "Entités impliquées dans les incidents IA",

--- a/site/gatsby-site/src/components/entities/EntityCard.js
+++ b/site/gatsby-site/src/components/entities/EntityCard.js
@@ -11,7 +11,7 @@ export default function EntityCard({ entity, ...props }) {
       key: 'incidentsAsBoth',
     },
     {
-      header: 'Incindents Harmed By',
+      header: 'Incidents Harmed By',
       key: 'incidentsHarmedBy',
     },
     {

--- a/site/gatsby-site/src/templates/entity.js
+++ b/site/gatsby-site/src/templates/entity.js
@@ -63,7 +63,7 @@ const EntityPage = ({ pageContext, data, ...props }) => {
       key: 'incidentsAsBoth',
     },
     {
-      header: 'Incindents Harmed By',
+      header: 'Incidents Harmed By',
       key: 'incidentsHarmedBy',
     },
     {


### PR DESCRIPTION
## Summary

Fixed the "Incidents Harmed By" header on entity pages:

<img width="681" alt="Screen Shot 2023-02-27 at 2 41 36 PM" src="https://user-images.githubusercontent.com/1416347/221666713-f0a28532-751c-4da6-97b9-b368d27684d3.png">
