### PR TITLE
Hotfix: Give entity insert and write permissions to default user

### DIFF
--- a/site/realm/data_sources/mongodb-atlas/aiidprod/entities/rules.json
+++ b/site/realm/data_sources/mongodb-atlas/aiidprod/entities/rules.json
@@ -14,11 +14,11 @@
             "search": true
         },
         {
-            "name": "deafult",
+            "name": "default",
             "apply_when": {},
             "read": true,
-            "write": false,
-            "insert": false,
+            "write": true,
+            "insert": true,
             "delete": false,
             "search": true
         }


### PR DESCRIPTION
Resolves #1668.

We should probably find a way to fix this without giving blanket permissions, but making the submission form work is higher-priority. 