### PR TITLE
Fix issue https://github.com/responsible-ai-collaborative/aiid/issues…

### DIFF
--- a/site/realm/auth/custom_user_data.json
+++ b/site/realm/auth/custom_user_data.json
@@ -1,5 +1,5 @@
 {
-    "enabled": true,
+    "enabled": false,
     "mongo_service_name": "mongodb-atlas",
     "database_name": "customData",
     "collection_name": "users",


### PR DESCRIPTION
Deals with #1682 but it is not really a fix until we get a response from mongodb devs.

From [here](https://www.mongodb.com/community/forums/t/failed-failed-to-import-app-must-specify-a-mongo-service-id/215115/25):

```
I was able to reproduce the issue which appears to be a bug and have found a workaround.

It seems to be an issue for realm-cli and github auto-deploy if the custom_user_data.json config has the property of "enabled": true

Please try these steps:

In your github or realm-cli repo go to your auth > custom_user_data.json file
update enabled property to false
push the change
notice in your UI that custom user data is still enabled
all future changes from github or realm-cli will be successful
If the config for the enabled property is set to false, the file will be ignored from the change and whatever is causing the bug will be overridden. At the same time it does not affect the actual cloud state of that feature and user data will remain enabled.

I’ll report this bug internally.

Regards
Manny
```

