### PR TITLE
Set custom data setting back to enabled

### DIFF
--- a/site/realm/auth/custom_user_data.json
+++ b/site/realm/auth/custom_user_data.json
@@ -1,5 +1,5 @@
 {
-    "enabled": false,
+    "enabled": true,
     "mongo_service_name": "mongodb-atlas",
     "database_name": "customData",
     "collection_name": "users",


### PR DESCRIPTION
Looks like the issue has been RESOLVED https://www.mongodb.com/community/forums/t/failed-failed-to-import-app-must-specify-a-mongo-service-id/215115/35