### PR TITLE
Add copies of CSETv1 taxonomy for 3 annotators

### DIFF
--- a/site/gatsby-site/migrations/2023.03.13T16.16.18.copy-csetv1-taxonomy.js
+++ b/site/gatsby-site/migrations/2023.03.13T16.16.18.copy-csetv1-taxonomy.js
@@ -1,0 +1,25 @@
+const config = require('../config');
+
+/** @type {import('umzug').MigrationFn<any>} */
+exports.up = async ({ context: { client } }) => {
+  const taxaCollection = client.db(config.realm.production_db.db_name).collection('taxa');
+
+  const csetV1Taxonomy = await taxaCollection.findOne({ namespace: 'CSETv1' });
+
+  for (let i = 1; i < 4; i++) {
+    await taxaCollection.insertOne({
+      ...csetV1Taxonomy,
+      _id: undefined,
+      namespace: 'CSETv1_Annotator-' + i,
+    });
+  }
+};
+
+/** @type {import('umzug').MigrationFn<any>} */
+exports.down = async ({ context: { client } }) => {
+  const taxaCollection = client.db(config.realm.production_db.db_name).collection('taxa');
+
+  for (let i = 1; i < 4; i++) {
+    await taxaCollection.deleteOne({ namespace: 'CSETv1_Annotator-' + i });
+  }
+};


### PR DESCRIPTION
This is needed because CSET intends to have multiple annotators annotate the same incident for reliability purposes.