### PR TITLE
Remove bootstrap & styled-components from toast component

### DIFF
--- a/site/gatsby-site/cypress/e2e/integration/citeEdit.cy.js
+++ b/site/gatsby-site/cypress/e2e/integration/citeEdit.cy.js
@@ -200,9 +200,7 @@ describe('Edit report', () => {
       expect(xhr.request.body.variables.input.title).eq('Este es un titulo en Espanol!');
     });
 
-    cy.get('div[class^="ToastContext"]')
-      .contains('Incident report 10 updated successfully.')
-      .should('exist');
+    cy.get('.tw-toast').contains('Incident report 10 updated successfully.').should('exist');
   });
 
   maybeIt('Should load and update Issue values', () => {

--- a/site/gatsby-site/cypress/e2e/integration/incidents/edit.cy.js
+++ b/site/gatsby-site/cypress/e2e/integration/incidents/edit.cy.js
@@ -141,8 +141,6 @@ describe('Incidents', () => {
       expect(xhr.request.body.variables.set.editors).to.deep.eq(['Sean McGregor', 'Test Editor']);
     });
 
-    cy.get('div[class^="ToastContext"]')
-      .contains('Incident 10 updated successfully.')
-      .should('exist');
+    cy.get('.tw-toast').contains('Incident 10 updated successfully.').should('exist');
   });
 });

--- a/site/gatsby-site/cypress/e2e/integration/landingPage.cy.js
+++ b/site/gatsby-site/cypress/e2e/integration/landingPage.cy.js
@@ -48,7 +48,7 @@ describe('The Landing page', () => {
       );
     });
 
-    cy.get('div[class^="ToastContext"]')
+    cy.get('.tw-toast')
       .contains('Report successfully added to review queue. You can see your submission here.')
       .should('exist');
   });

--- a/site/gatsby-site/cypress/e2e/integration/submit.cy.js
+++ b/site/gatsby-site/cypress/e2e/integration/submit.cy.js
@@ -86,7 +86,7 @@ describe('The Submit form', () => {
       });
     });
 
-    cy.get('div[class^="ToastContext"]')
+    cy.get('.tw-toast')
       .contains('Report successfully added to review queue. You can see your submission')
       .should('exist');
 
@@ -171,11 +171,11 @@ describe('The Submit form', () => {
         });
       });
 
-      cy.get('div[class^="ToastContext"]')
+      cy.get('.tw-toast')
         .contains('Report successfully added to review queue')
         .should('be.visible');
 
-      cy.get('div[class^="ToastContext"] a').should('have.attr', 'href', '/apps/submitted/');
+      cy.get('.tw-toast a').should('have.attr', 'href', '/apps/submitted/');
 
       cy.contains('Please review. Some data is missing.').should('not.exist');
     }
@@ -358,7 +358,7 @@ describe('The Submit form', () => {
 
     cy.wait('@parseNews');
 
-    cy.get('div[class^="ToastContext"]')
+    cy.get('.tw-toast')
       .contains('Error reaching news info endpoint, please try again in a few seconds.')
       .should('exist');
   });
@@ -921,7 +921,7 @@ describe('The Submit form', () => {
 
     cy.wait('@insertSubmission');
 
-    cy.get('div[class^="ToastContext"]')
+    cy.get('.tw-toast')
       .contains('Informe agregado exitosamente a la cola de revisión.')
       .should('exist');
   });
@@ -956,7 +956,7 @@ describe('The Submit form', () => {
 
     cy.get('[data-cy="submit-step-1"]').click();
 
-    cy.get('div[class^="ToastContext"]')
+    cy.get('.tw-toast')
       .contains('Report successfully added to review queue. You can see your submission')
       .should('exist');
   });
@@ -999,7 +999,7 @@ describe('The Submit form', () => {
 
     cy.get('[data-cy="submit-step-2"]').click();
 
-    cy.get('div[class^="ToastContext"]')
+    cy.get('.tw-toast')
       .contains('Report successfully added to review queue. You can see your submission')
       .should('exist');
   });
@@ -1287,11 +1287,9 @@ describe('The Submit form', () => {
       });
     });
 
-    cy.get('div[class^="ToastContext"]')
-      .contains('Report successfully added to review queue')
-      .should('be.visible');
+    cy.get('.tw-toast').contains('Report successfully added to review queue').should('be.visible');
 
-    cy.get('div[class^="ToastContext"] a').should('have.attr', 'href', '/apps/submitted/');
+    cy.get('.tw-toast a').should('have.attr', 'href', '/apps/submitted/');
 
     cy.contains('Please review. Some data is missing.').should('not.exist');
   });
@@ -1326,7 +1324,7 @@ describe('The Submit form', () => {
 
     cy.get('[data-cy="submit-step-1"]').click();
 
-    cy.get('div[class^="ToastContext"]')
+    cy.get('.tw-toast')
       .contains('Report successfully added to review queue. You can see your submission')
       .should('exist');
 
@@ -1344,7 +1342,7 @@ describe('The Submit form', () => {
 
     cy.get('[data-cy="submit-step-1"]').click();
 
-    cy.get('div[class^="ToastContext"]')
+    cy.get('.tw-toast')
       .contains('Report successfully added to review queue. You can see your submission')
       .should('exist');
   });
@@ -1360,7 +1358,7 @@ describe('The Submit form', () => {
 
     cy.wait('@parseNews');
 
-    cy.get('div[class^="ToastContext"]')
+    cy.get('.tw-toast')
       .contains('Please verify all information programmatically pulled from the report')
       .should('exist');
 

--- a/site/gatsby-site/src/components/sidebar/index.js
+++ b/site/gatsby-site/src/components/sidebar/index.js
@@ -115,7 +115,7 @@ const Sidebar = ({ defaultCollapsed = false, location = null }) => {
       <aside
         id="sidebar"
         aria-label="Sidebar"
-        className={`${sidebarWidth} sticky top-0 flex flex-col md:bg-text-light-gray`}
+        className={`${sidebarWidth} sticky top-0 flex flex-col md:bg-text-light-gray z-2`}
         style={{
           height:
             (headerVisiblePixels && !isMobile) || window.innerWidth > 768

--- a/site/gatsby-site/src/contexts/ToastContext.js
+++ b/site/gatsby-site/src/contexts/ToastContext.js
@@ -1,40 +1,7 @@
 import React, { useCallback, useEffect, useState, createContext } from 'react';
-import styled from 'styled-components';
-import { Toast, Button } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTimes } from '@fortawesome/free-solid-svg-icons';
 import { globalHistory } from '@reach/router';
-
-const ToastsWrapper = styled.div`
-  position: fixed;
-  bottom: 2em;
-  left: 2em;
-  max-width: 100% !important;
-  z-index: 1056;
-`;
-
-const CloseButton = styled(Button)`
-  color: white !important;
-`;
-
-const ToastBodyContent = styled.div`
-  svg {
-    margin-right: 0.5em;
-  }
-  a {
-    text-decoration: underline !important;
-    color: white !important;
-  }
-`;
-
-const ToastBody = styled(Toast.Body)`
-  &&& {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-  }
-`;
+import { Toast } from 'flowbite-react';
 
 const ToastContext = createContext();
 
@@ -74,31 +41,26 @@ export function ToastContextProvider({ children }) {
   return (
     <ToastContext.Provider value={addToast}>
       {children}
-      <ToastsWrapper className="bootstrap">
+      <div className="fixed bottom-0 left-0 max-w-full z-50 box-conten mb-4 ml-4">
         {toasts.map(({ message, severity, error, id }, index) => {
           if ('Rollbar' in window && error) {
             Rollbar.error(error);
           }
           return (
-            <Toast
-              key={id}
-              className={severity.className}
-              style={{ maxWidth: '100%' }}
-              data-cy="toast"
-            >
-              <ToastBody style={{ color: 'white' }}>
-                <ToastBodyContent>
+            <Toast className="tw-toast" data-cy="toast" key={id}>
+              <div
+                className={`w-full h-full flex ${severity.className} items-center p-4 rounded gap-3 text-white`}
+              >
+                <div className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-white">
                   <FontAwesomeIcon icon={severity.icon} className={severity.faClass} />
-                  {message}
-                </ToastBodyContent>
-                <CloseButton onClick={(e) => removeToast(e, index)} variant="link">
-                  <FontAwesomeIcon icon={faTimes} className="fas fa-times" />
-                </CloseButton>
-              </ToastBody>
+                </div>
+                <div className="text-sm font-normal">{message}</div>
+                <Toast.Toggle className="mx-0" onClick={(e) => removeToast(e, index)} />
+              </div>
             </Toast>
           );
         })}
-      </ToastsWrapper>
+      </div>
     </ToastContext.Provider>
   );
 }

--- a/site/gatsby-site/src/hooks/useToast.js
+++ b/site/gatsby-site/src/hooks/useToast.js
@@ -12,25 +12,25 @@ export const SEVERITY = {
   success: {
     key: 'success',
     icon: faCheckCircle,
-    faClass: 'far fa-check-circle fa-lg',
+    faClass: 'far fa-check-circle fa-2xl',
     className: 'bg-green-600',
   },
   danger: {
     key: 'danger',
     icon: faTimesCircle,
-    faClass: 'far fa-times-circle fa-lg',
+    faClass: 'far fa-times-circle fa-2xl',
     className: 'bg-red-700',
   },
   warning: {
     key: 'warning',
     icon: faExclamationTriangle,
-    faClass: 'far fa-exclamation-triangle fa-lg',
+    faClass: 'far fa-exclamation-triangle fa-2xl',
     className: 'bg-amber-400',
   },
   info: {
     key: 'info',
     icon: faInfoCircle,
-    faClass: 'far fa-info-circle fa-lg',
+    faClass: 'far fa-info-circle fa-2xl',
     className: 'bg-blue-600',
   },
 };

--- a/site/gatsby-site/src/tailwind.css
+++ b/site/gatsby-site/src/tailwind.css
@@ -736,4 +736,12 @@
   .reports-table td {
     @apply m-0 p-2 last:border-r-0;
   }
+
+  .tw-toast {
+    @apply p-0 mb-2 !important;
+  }
+
+  .tw-toast a {
+    @apply underline text-white !important;
+  }
 }

--- a/site/gatsby-site/src/templates/citeTemplate.js
+++ b/site/gatsby-site/src/templates/citeTemplate.js
@@ -183,7 +183,7 @@ function CiteTemplate({
             subscriptions
           </Trans>
         ),
-        severity: SEVERITY.success,
+        severity: SEVERITY.info,
       });
     }
   };
@@ -221,7 +221,6 @@ function CiteTemplate({
           </div>
         </div>
       </div>
-
       <div className="flex mt-6">
         <div className="shrink-1">
           <Row>

--- a/site/gatsby-site/tailwind.config.js
+++ b/site/gatsby-site/tailwind.config.js
@@ -17,6 +17,7 @@ let safelist = [
   'tw-tooltip-left',
   'tw-btn-link',
   'bg-amber-400',
+  'tw-toast',
 ];
 
 // Whitelisting level options from ListItem component


### PR DESCRIPTION
- Helps with #1732 
- Helps with #1617 

Uses tailwind toasts instead of bootstrap

Where can you test the toasts:
- On [cite/10](https://deploy-preview-1858--staging-aiid.netlify.app/cite/10/), click `Subscribed to Updates` btn inside tools. This will display the info toast.
- When subscribing to notifications on an incident. This will display the success toast.
- Trying to login with a wrong username/password. This will display the fail toast