### PR TITLE
Handle boolean values in CSET comparison tool

### DIFF
--- a/site/gatsby-site/src/pages/apps/csettool/[id].js
+++ b/site/gatsby-site/src/pages/apps/csettool/[id].js
@@ -42,6 +42,10 @@ const ToolPage = (props) => {
 
             if (isObject(value)) {
               row[classification.namespace] = JSON.stringify(value);
+            } else if (value === true) {
+              row[classification.namespace] = 'True';
+            } else if (value === false) {
+              row[classification.namespace] = 'False';
             } else {
               row[classification.namespace] = value;
             }


### PR DESCRIPTION
Mia pointed out that currently when it's a boolean value it shows up blank.