### PR TITLE
Add Variant condition to `linkReportsToIncidents` function

### DIFF
--- a/site/gatsby-site/cypress/e2e/unit/functions/linkReportsToIncidents.cy.js
+++ b/site/gatsby-site/cypress/e2e/unit/functions/linkReportsToIncidents.cy.js
@@ -40,6 +40,8 @@ const report_1 = {
   embedding: {
     vector: [1, 2, 3, 4],
   },
+  url: 'https://url.com',
+  source_domain: 'domain.com',
 };
 
 const report_2 = {
@@ -48,6 +50,8 @@ const report_2 = {
   embedding: {
     vector: [6, 7, 8],
   },
+  url: 'https://url.com',
+  source_domain: 'domain.com',
 };
 
 const report_3 = {
@@ -56,6 +60,8 @@ const report_3 = {
   embedding: {
     vector: [10],
   },
+  url: 'https://url.com',
+  source_domain: 'domain.com',
 };
 
 describe('Functions', () => {
@@ -170,8 +176,9 @@ describe('Functions', () => {
 
       expect(reportsCollection.updateMany.firstCall.args[0]).to.deep.equal({
         report_number: { $in: [3] },
-        text_inputs: { $in: [null, ''] },
-        text_outputs: { $in: [null, ''] },
+        title: { $nin: [null, ''] },
+        url: { $nin: [null, ''] },
+        source_domain: { $nin: [null, ''] },
       });
       expect(reportsCollection.updateMany.firstCall.args[1]).to.deep.equal({
         $set: { is_incident_report: true },
@@ -258,8 +265,9 @@ describe('Functions', () => {
 
       expect(reportsCollection.updateMany.firstCall.args[0]).to.deep.equal({
         report_number: { $in: [3] },
-        text_inputs: { $in: [null, ''] },
-        text_outputs: { $in: [null, ''] },
+        title: { $nin: [null, ''] },
+        url: { $nin: [null, ''] },
+        source_domain: { $nin: [null, ''] },
       });
       expect(reportsCollection.updateMany.firstCall.args[1]).to.deep.equal({
         $set: { is_incident_report: false },

--- a/site/gatsby-site/migrations/2023.05.03T19.04.47.update-variants-with-flag.js
+++ b/site/gatsby-site/migrations/2023.05.03T19.04.47.update-variants-with-flag.js
@@ -1,0 +1,24 @@
+const config = require('../config');
+
+/**
+ *
+ * @param {{context: {client: import('mongodb').MongoClient}}} context
+ */
+
+exports.up = async ({ context: { client } }) => {
+  await client.connect();
+
+  const reportsCollection = client.db(config.realm.production_db.db_name).collection('reports');
+
+  const updateResult = await reportsCollection.updateMany(
+    {
+      is_incident_report: true,
+      title: { $in: [null, ''] },
+      url: { $in: [null, ''] },
+      source_domain: { $in: [null, ''] },
+    },
+    { $set: { is_incident_report: false } }
+  );
+
+  console.log('Update result:', updateResult);
+};

--- a/site/realm/functions/linkReportsToIncidents.js
+++ b/site/realm/functions/linkReportsToIncidents.js
@@ -63,8 +63,9 @@ exports = async (input) => {
   await reportsCollection.updateMany(
     {
       report_number: { $in: input.report_numbers },
-      text_inputs: { $in: [null, ""] },
-      text_outputs: { $in: [null, ""] },
+      title: { $nin: [null, ""] },
+      url: { $nin: [null, ""] },
+      source_domain: { $nin: [null, ""] },
     },
     {
       $set: { is_incident_report: input.incident_ids.length > 0 }


### PR DESCRIPTION
Don't display Variants on the Latest report component. Fix comment on https://github.com/responsible-ai-collaborative/aiid/pull/1933#issuecomment-1532470734

## Note

This issue will be fixed on Staging once the migration ran. So it won't be fixed on the preview link