### PR TITLE
Add missing `text` field on Variants query

### DIFF
--- a/site/gatsby-site/src/graphql/variants.js
+++ b/site/gatsby-site/src/graphql/variants.js
@@ -33,6 +33,7 @@ export const FIND_INCIDENT_VARIANTS = gql`
       reports {
         report_number
         title
+        text
         url
         source_domain
         date_published


### PR DESCRIPTION
This fixes a bug found on the smoke test for PR https://github.com/responsible-ai-collaborative/aiid/pull/1987