### PR TITLE
Fix/edit report issues

### DIFF
--- a/site/gatsby-site/cypress/e2e/integration/cite.cy.js
+++ b/site/gatsby-site/cypress/e2e/integration/cite.cy.js
@@ -252,6 +252,22 @@ describe('Cite pages', () => {
     cy.contains('[data-cy="prefilled-incident-id"]', 'Adding a new report to incident 10').should(
       'be.visible'
     );
+
+    cy.get(`.incident-ids-field [data-cy="token"]`).contains('10').should('be.visible');
+  });
+
+  it('Should pre-fill submit report response form', () => {
+    cy.visit(url);
+
+    cy.contains('New Response').scrollIntoView().click();
+
+    cy.waitForStableDOM();
+
+    cy.contains('[data-cy="prefilled-incident-id"]', 'Adding a new response to incident 10').should(
+      'be.visible'
+    );
+
+    cy.get(`.incident-ids-field [data-cy="token"]`).contains('10').should('be.visible');
   });
 
   it('should render Next and Previous incident buttons', () => {

--- a/site/gatsby-site/src/components/cite/Tools.js
+++ b/site/gatsby-site/src/components/cite/Tools.js
@@ -59,7 +59,7 @@ function Tools({
         </Button>
         <Button
           color="gray"
-          href={`/apps/submit?tags=${RESPONSE_TAG}&incident_id=${incident.incident_id}`}
+          href={`/apps/submit?tags=${RESPONSE_TAG}&incident_ids=${incident.incident_id}`}
         >
           <FontAwesomeIcon
             icon={faPlus}

--- a/site/gatsby-site/src/components/incidents/IncidentsField.js
+++ b/site/gatsby-site/src/components/incidents/IncidentsField.js
@@ -57,7 +57,7 @@ export default function IncidentsField({ id, name, placeHolder = '' }) {
   return (
     <>
       <AsyncTypeahead
-        className="Typeahead"
+        className="Typeahead incident-ids-field"
         filterBy={() => true}
         id={id}
         inputProps={{ id: 'input-' + id, name }}

--- a/site/gatsby-site/src/components/submissions/SubmissionForm.js
+++ b/site/gatsby-site/src/components/submissions/SubmissionForm.js
@@ -333,8 +333,8 @@ const SubmissionForm = () => {
           columns={['byIncidentId']}
         />
 
-        {!values.incident_ids && (
-          <>
+        {(!values.incident_ids || values.incident_ids.length === 0) && (
+          <div data-cy="incident-data-section">
             <hr className="my-4" />
             <h3 className="text-lg">Incident Data</h3>
             <TextInputGroup
@@ -400,7 +400,7 @@ const SubmissionForm = () => {
               {...TextInputGroupProps}
             />
             <hr />
-          </>
+          </div>
         )}
 
         <TextInputGroup

--- a/site/gatsby-site/src/components/submissions/SubmissionForm.js
+++ b/site/gatsby-site/src/components/submissions/SubmissionForm.js
@@ -333,7 +333,7 @@ const SubmissionForm = () => {
           columns={['byIncidentId']}
         />
 
-        {!values.incident_id && (
+        {!values.incident_ids && (
           <>
             <hr className="my-4" />
             <h3 className="text-lg">Incident Data</h3>


### PR DESCRIPTION
- closes #2049 

Fixes two issues
1. When editing a submission and selecting an incident in the `Incident IDs` field -> The `Incident Data` section is hidden.
2. From a citation, after clicking `New Response` it automatically loads the `Incident IDs` field.