### PR TITLE
Use plain_text instead of text (markdown) in RSS feed

### DIFF
--- a/site/gatsby-site/gatsby-config.js
+++ b/site/gatsby-site/gatsby-config.js
@@ -148,7 +148,7 @@ const plugins = [
 
               const dateSubmitted = new Date(edge.node.date_submitted).toUTCString();
 
-              const description = `${edge.node.text.slice(0, 240)} ... ${
+              const description = `${edge.node.plain_text.slice(0, 240)} ... ${
                 matchingIncidents
                   ? '(https://incidentdatabase.ai/cite/' + incident_id + '#' + report_number + ')'
                   : '(report_number: ' + report_number + ')'


### PR DESCRIPTION
- Fixes https://github.com/responsible-ai-collaborative/aiid/pull/2052#issuecomment-1572961928
Uses plain_text instead of text (markdown) to display in description node in RSS feed