### PR TITLE
Remove latest reports' carousel autoplay

### DIFF
--- a/site/gatsby-site/src/components/landing/LatestReports.js
+++ b/site/gatsby-site/src/components/landing/LatestReports.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import LatestIncidentReport from 'components/landing/LatestIncidentReport';
-import { Card, Carousel } from 'flowbite-react';
+import { Carousel } from 'flowbite-react';
 import { Trans } from 'react-i18next';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faArrowCircleLeft, faArrowCircleRight } from '@fortawesome/free-solid-svg-icons';
@@ -8,31 +8,29 @@ import { faArrowCircleLeft, faArrowCircleRight } from '@fortawesome/free-solid-s
 export default function LatestReports({ latestReports }) {
   return (
     <>
-      <Card>
-        <h5 className="text-2xl font-bold tracking-tight text-gray-900  dark:text-white w-full hover:text-primary-blue">
-          <Trans ns="landing">Latest Incident Reports</Trans>
-        </h5>
-        <Carousel
-          className="latest-reports-carousel"
-          slide={false}
-          leftControl={
-            <FontAwesomeIcon
-              icon={faArrowCircleLeft}
-              className="h-8 w-8 text-white bg-gray-500 shadow rounded-full"
-            />
-          }
-          rightControl={
-            <FontAwesomeIcon
-              icon={faArrowCircleRight}
-              className="h-8 w-8 text-white bg-gray-500 shadow rounded-full"
-            />
-          }
-        >
-          {latestReports.map((report) => (
-            <LatestIncidentReport report={report} key={`latest-report-${report.title}`} />
-          ))}
-        </Carousel>
-      </Card>
+      <h5 className="text-2xl font-bold tracking-tight text-gray-900  dark:text-white w-full hover:text-primary-blue">
+        <Trans ns="landing">Latest Incident Reports</Trans>
+      </h5>
+      <Carousel
+        className="latest-reports-carousel"
+        slide={false}
+        leftControl={
+          <FontAwesomeIcon
+            icon={faArrowCircleLeft}
+            className="h-8 w-8 text-white bg-gray-500 shadow rounded-full"
+          />
+        }
+        rightControl={
+          <FontAwesomeIcon
+            icon={faArrowCircleRight}
+            className="h-8 w-8 text-white bg-gray-500 shadow rounded-full"
+          />
+        }
+      >
+        {latestReports.map((report) => (
+          <LatestIncidentReport report={report} key={`latest-report-${report.title}`} />
+        ))}
+      </Carousel>
     </>
   );
 }

--- a/site/gatsby-site/src/components/landing/LatestReports.js
+++ b/site/gatsby-site/src/components/landing/LatestReports.js
@@ -14,7 +14,7 @@ export default function LatestReports({ latestReports }) {
         </h5>
         <Carousel
           className="latest-reports-carousel"
-          slideInterval={15000}
+          slide={false}
           leftControl={
             <FontAwesomeIcon
               icon={faArrowCircleLeft}


### PR DESCRIPTION
Fixes from https://github.com/responsible-ai-collaborative/aiid/pull/2103#issuecomment-1600371741
- Setting the latest incident box to not auto-scroll
- The carousel already took up a big portion of the landing page and the new card that wraps the carousel introduces more whitespace surrounding it. It is too much space on the landing page.