### PR TITLE
Add migration to fix broken classification attributes

### DIFF
--- a/site/gatsby-site/cypress/e2e/unit/migrations/2023.06.26T21.29.07.fix-gmf-multi.cy.js
+++ b/site/gatsby-site/cypress/e2e/unit/migrations/2023.06.26T21.29.07.fix-gmf-multi.cy.js
@@ -1,7 +1,5 @@
 const { up } = require('../../../../migrations/2023.06.26T21.29.07.fix-gmf-multi');
 
-//should be on its own /cypress/unit folder or something
-
 const classification_1 = {
   _id: { $oid: '63ff9df8b8231a8c28674ad3' },
   notes: '',

--- a/site/gatsby-site/cypress/e2e/unit/migrations/2023.06.26T21.29.07.fix-gmf-multi.cy.js
+++ b/site/gatsby-site/cypress/e2e/unit/migrations/2023.06.26T21.29.07.fix-gmf-multi.cy.js
@@ -1,0 +1,125 @@
+const { up } = require('../../../../migrations/2023.06.26T21.29.07.fix-gmf-multi');
+
+//should be on its own /cypress/unit folder or something
+
+const classification_1 = {
+  _id: { $oid: '63ff9df8b8231a8c28674ad3' },
+  notes: '',
+  publish: false,
+  incident_id: { $numberInt: '100' },
+  namespace: 'CSETv1',
+  attributes: [
+    { short_name: 'String', value_json: '"just a string"' },
+    {
+      short_name: 'Entities with nested values',
+      value_json: JSON.stringify([
+        {
+          attributes: [
+            {
+              short_name: 'should be ignored',
+              value_json: '"Lucie Inland"',
+            },
+            {
+              short_name: 'Entity Relationship to the AI',
+              value_json: JSON.stringify([
+                'string value',
+                {
+                  customOption: true,
+                  label: 'broken item',
+                  id: 'new-id-1',
+                },
+              ]),
+            },
+          ],
+        },
+      ]),
+    },
+    {
+      short_name: 'Mixed string list',
+      value_json: JSON.stringify([
+        'item 1',
+        'item 2',
+        {
+          customOption: true,
+          label: 'broken item',
+          id: 'new-id-1',
+        },
+      ]),
+    },
+    {
+      short_name: 'Pure string list',
+      value_json: JSON.stringify(['item 1', 'item 2']),
+    },
+  ],
+};
+
+describe('Functions', () => {
+  it('Should convert existing classifications to string', () => {
+    const classificationsCollection = {
+      find: cy.stub().returns({
+        hasNext: cy.stub().onFirstCall().resolves(true).onSecondCall().resolves(false),
+        next: cy.stub().onFirstCall().resolves(classification_1),
+      }),
+      updateOne: cy.stub().resolves({}),
+    };
+
+    const context = {
+      client: {
+        connect: cy.stub().resolves(),
+
+        db: cy.stub().returns({
+          collection: (() => {
+            const stub = cy.stub();
+
+            stub.withArgs('classifications').returns(classificationsCollection);
+
+            return stub;
+          })(),
+        }),
+      },
+    };
+
+    cy.wrap(up({ context })).then(() => {
+      expect(
+        classificationsCollection.updateOne.firstCall.args[1].$set.attributes[0]
+      ).to.deep.equal({
+        short_name: 'String',
+        value_json: '"just a string"',
+      });
+
+      expect(
+        classificationsCollection.updateOne.firstCall.args[1].$set.attributes[1]
+      ).to.deep.equal({
+        short_name: 'Entities with nested values',
+        value_json: JSON.stringify([
+          {
+            attributes: [
+              {
+                short_name: 'should be ignored',
+                value_json: '"Lucie Inland"',
+              },
+              {
+                short_name: 'Entity Relationship to the AI',
+                value_json: JSON.stringify(['string value', 'broken item']),
+              },
+            ],
+          },
+        ]),
+      });
+
+      expect(
+        classificationsCollection.updateOne.firstCall.args[1].$set.attributes[2]
+      ).to.deep.equal({
+        short_name: 'Mixed string list',
+        value_json: JSON.stringify(['item 1', 'item 2', 'broken item']),
+      });
+
+      expect(
+        classificationsCollection.updateOne.firstCall.args[1].$set.attributes[3]
+      ).to.deep.equal({
+        short_name: 'Pure string list',
+        value_json: JSON.stringify(['item 1', 'item 2']),
+      });
+    });
+  });
+});

--- a/site/gatsby-site/migrations/2023.06.26T21.29.07.fix-gmf-multi.js
+++ b/site/gatsby-site/migrations/2023.06.26T21.29.07.fix-gmf-multi.js
@@ -1,0 +1,85 @@
+const { isArray } = require('lodash');
+
+const config = require('../config');
+
+/**
+ *
+ * @param {{context: {client: import('mongodb').MongoClient}}} context
+ */
+exports.up = async ({ context: { client } }) => {
+  await client.connect();
+
+  const fixValueJsonOptions = (value_json) => {
+    const value = JSON.parse(value_json);
+
+    const newValue = value.map((v) => v.label);
+
+    return newValue;
+  };
+
+  const classificationsCollection = client
+    .db(config.realm.production_db.db_name)
+    .collection('classifications');
+
+  const classifications = classificationsCollection.find({
+    'attributes.value_json': { $regex: 'customOption' },
+  });
+
+  while (await classifications.hasNext()) {
+    const classification = await classifications.next();
+
+    const attributes = classification.attributes.map((attribute) => {
+      if (attribute.value_json && attribute.value_json.includes('customOption')) {
+        try {
+          const value = JSON.parse(attribute.value_json);
+
+          if (isArray(value) && value?.[0]?.attributes) {
+            // seems to be only with entities
+
+            const updated = value.map((v) => {
+              const { attributes } = v;
+
+              return {
+                ...v,
+                attributes: attributes.map((a) => {
+                  if (a.value_json.includes('customOption')) {
+                    const options = fixValueJsonOptions(a.value_json);
+
+                    const value_json = JSON.stringify(options);
+
+                    return { ...a, value_json };
+                  }
+
+                  return a;
+                }),
+              };
+            });
+
+            return { ...attribute, value_json: updated };
+          } else {
+            const options = fixValueJsonOptions(attribute.value_json);
+
+            const updated = JSON.stringify(options);
+
+            return { ...attribute, value_json: updated };
+          }
+        } catch (e) {
+          console.log(
+            `Error parsing classification ${classification.namespace} ${classification.incident_id}, value: ${attribute.value_json}`
+          );
+
+          throw e; // we want to stop the migration
+        }
+      }
+
+      return attribute;
+    });
+
+    const result = await classificationsCollection.updateOne(
+      { _id: classification._id },
+      { $set: { attributes } }
+    );
+
+    console.log(`Updated ${classification._id} : ${result.modifiedCount}`);
+  }
+};

--- a/site/gatsby-site/migrations/2023.06.26T21.29.07.fix-gmf-multi.js
+++ b/site/gatsby-site/migrations/2023.06.26T21.29.07.fix-gmf-multi.js
@@ -13,7 +13,7 @@ exports.up = async ({ context: { client } }) => {
     const value = JSON.parse(value_json);
 
     const newValue = value
-      .map((v) => v.label)
+      .map((v) => (isString(v) ? v : v.label))
       .filter((v) => isString(v))
       .map((v) => v.trim());
 


### PR DESCRIPTION
closes #2088 

I thought it would be easy, but then it turned out that Entities had the same issue.