### PR TITLE
Add missing reset form logic on step 2 and 3

### DIFF
--- a/site/gatsby-site/cypress/e2e/integration/submit.cy.js
+++ b/site/gatsby-site/cypress/e2e/integration/submit.cy.js
@@ -1126,6 +1126,12 @@ describe('The Submit form', () => {
     cy.get('.tw-toast')
       .contains('Report successfully added to review queue. You can see your submission')
       .should('exist');
+
+    const keys = ['url', 'title', 'authors', 'incident_date'];
+
+    keys.forEach((key) => {
+      cy.get(`input[name="${key}"]`).should('have.value', '');
+    });
   });
 
   it('Should submit on step 2', () => {
@@ -1169,6 +1175,14 @@ describe('The Submit form', () => {
     cy.get('.tw-toast')
       .contains('Report successfully added to review queue. You can see your submission')
       .should('exist');
+
+    cy.waitForStableDOM();
+
+    const keys = ['url', 'title', 'authors', 'incident_date'];
+
+    keys.forEach((key) => {
+      cy.get(`input[name="${key}"]`).should('have.value', '');
+    });
   });
 
   it('Should display an error message if data is missing', () => {

--- a/site/gatsby-site/src/components/forms/SubmissionWizard/StepThree.js
+++ b/site/gatsby-site/src/components/forms/SubmissionWizard/StepThree.js
@@ -133,6 +133,8 @@ const StepThree = (props) => {
           submissionFailed={props.submissionFailed}
           entityNames={entityNames}
           setSavingInLocalStorage={props.setSavingInLocalStorage}
+          submissionComplete={props.submissionComplete}
+          submissionReset={props.submissionReset}
         />
       </Formik>
     </StepContainer>
@@ -146,6 +148,8 @@ const FormDetails = ({
   submitForm,
   validateAndSubmitForm,
   submissionFailed,
+  submissionComplete,
+  submissionReset,
   entityNames,
   setSavingInLocalStorage,
 }) => {
@@ -166,6 +170,7 @@ const FormDetails = ({
     setFieldTouched,
     isValid,
     validateForm,
+    resetForm,
   } = useFormikContext();
 
   useEffect(() => {
@@ -175,10 +180,15 @@ const FormDetails = ({
   }, [data, errors]);
 
   useEffect(() => {
-    if (submissionFailed) {
+    if (submissionFailed || submissionComplete || submissionReset.reset) {
       setIsSubmitting(false);
+      setSubmitCount(0);
     }
-  }, [submissionFailed]);
+
+    if (submissionComplete || submissionReset.reset) {
+      resetForm();
+    }
+  }, [submissionFailed, submissionComplete, submissionReset]);
 
   const saveInLocalStorage = useRef(
     debounce((values) => {

--- a/site/gatsby-site/src/components/forms/SubmissionWizard/StepTwo.js
+++ b/site/gatsby-site/src/components/forms/SubmissionWizard/StepTwo.js
@@ -62,6 +62,8 @@ const StepTwo = (props) => {
           validateAndSubmitForm={props.validateAndSubmitForm}
           submissionFailed={props.submissionFailed}
           setSavingInLocalStorage={props.setSavingInLocalStorage}
+          submissionComplete={props.submissionComplete}
+          submissionReset={props.submissionReset}
         />
       </Formik>
     </StepContainer>
@@ -75,6 +77,8 @@ const FormDetails = ({
   submitForm,
   validateAndSubmitForm,
   submissionFailed,
+  submissionComplete,
+  submissionReset,
   setSavingInLocalStorage,
 }) => {
   const { t } = useTranslation(['submit']);
@@ -95,6 +99,7 @@ const FormDetails = ({
     setFieldTouched,
     isValid,
     validateForm,
+    resetForm,
   } = useFormikContext();
 
   useEffect(() => {
@@ -108,10 +113,15 @@ const FormDetails = ({
   }, [values.image_url]);
 
   useEffect(() => {
-    if (submissionFailed) {
+    if (submissionFailed || submissionComplete || submissionReset.reset) {
       setIsSubmitting(false);
+      setSubmitCount(0);
     }
-  }, [submissionFailed]);
+
+    if (submissionComplete || submissionReset.reset) {
+      resetForm();
+    }
+  }, [submissionFailed, submissionComplete, submissionReset]);
 
   const saveInLocalStorage = useRef(
     debounce((values) => {


### PR DESCRIPTION
- closes #2126 

This was happening on steps 2 and 3. Form should now clear on any step once you submit, and always return the step one on submission.