### PR TITLE
Update schema to handle reports linked to classifications

### DIFF
--- a/site/gatsby-site/cypress/e2e/integration/apps/csettool.cy.js
+++ b/site/gatsby-site/cypress/e2e/integration/apps/csettool.cy.js
@@ -239,12 +239,12 @@ describe('CSET tool', () => {
 
     cy.wait('@UpsertClassification').then((xhr) => {
       expect(xhr.request.body.variables.query).to.deep.eq({
-        incident_id: '52',
+        issue_type: 'incident',
+        issue_id: '52',
         namespace: 'CSETv1',
       });
 
       expect(xhr.request.body.variables.data).to.deep.eq({
-        incident_id: '52',
         notes:
           'Annotator 1: \n\n This a note from the annotator 1\n\nAnnotator 2: \n\n This a note from the annotator 2',
         namespace: 'CSETv1',

--- a/site/gatsby-site/cypress/e2e/integration/tsneVisualization.cy.js
+++ b/site/gatsby-site/cypress/e2e/integration/tsneVisualization.cy.js
@@ -14,7 +14,7 @@ const styleObject = (styleString) => {
 describe('TSNE Visualization', () => {
   const url = '/summaries/spatial';
 
-  it.skip('Should render the TSNE visualization', () => {
+  it('Should render the TSNE visualization', () => {
     cy.visit(url);
     cy.get('[data-cy="tsne-visualization"] [data-cy="tsne-plotpoint"]').should('exist');
   });
@@ -26,7 +26,7 @@ describe('TSNE Visualization', () => {
       .should('be.visible');
   });
 
-  it.skip('Should show an incident card on hover', () => {
+  it('Should show an incident card on hover', () => {
     cy.visit(url);
     cy.get('[data-cy="tsne-visualization"] #spatial-incident-1').trigger('mouseover');
     cy.get('[data-cy="tsne-visualization"] #spatial-incident-1 + [data-cy="incident-card"]').should(
@@ -34,7 +34,7 @@ describe('TSNE Visualization', () => {
     );
   });
 
-  it.skip('Incident card should show title', () => {
+  it('Incident card should show title', () => {
     cy.visit(url);
     cy.get('[data-cy="tsne-visualization"] #spatial-incident-1').trigger('mouseover');
     cy.get(

--- a/site/gatsby-site/cypress/e2e/unit/AlgoliaUpdater.cy.js
+++ b/site/gatsby-site/cypress/e2e/unit/AlgoliaUpdater.cy.js
@@ -64,7 +64,8 @@ const reports = [
 const classifications = [
   {
     _id: '60dd465f80935bc89e6f9b00',
-    incident_id: 1,
+    issue_type: 'incident',
+    issue_id: 1,
     namespace: 'CSET',
     attributes: [
       { short_name: 'Annotator', value_json: '"1"' },

--- a/site/gatsby-site/cypress/fixtures/call/classifications.json
+++ b/site/gatsby-site/cypress/fixtures/call/classifications.json
@@ -172,7 +172,8 @@
             "value_json": "true"
           }
         ],
-        "incident_id": 2,
+        "issue_id": 2,
+        "issue_type": "incident",
         "namespace": "CSET",
         "notes": "{}"
       },
@@ -347,7 +348,8 @@
             "value_json": null
           }
         ],
-        "incident_id": 3,
+        "issue_id": 3,
+        "issue_type": "incident",
         "namespace": "CSET",
         "notes": ""
       }

--- a/site/gatsby-site/cypress/fixtures/classifications/cssettool.json
+++ b/site/gatsby-site/cypress/fixtures/classifications/cssettool.json
@@ -311,7 +311,8 @@
                         "value_json": "\"\""
                     }
                 ],
-                "incident_id": 52,
+                "issue_id": 52,
+                "issue_type": "incident",
                 "namespace": "CSETv1_Annotator-1",
                 "notes": "This a note from the annotator 1",
                 "publish": false
@@ -626,7 +627,8 @@
                         "value_json": null
                     }
                 ],
-                "incident_id": 52,
+                "issue_id": 52,
+                "issue_type": "incident",
                 "namespace": "CSETv1_Annotator-2",
                 "notes": "This a note from the annotator 2",
                 "publish": false

--- a/site/gatsby-site/cypress/fixtures/classifications/incident97Classifications.json
+++ b/site/gatsby-site/cypress/fixtures/classifications/incident97Classifications.json
@@ -66,7 +66,8 @@
                     ],
                     "__typename": "ClassificationClassification"
                 },
-                "incident_id": 97,
+                "issue_id": 97,
+                "issue_type": "incident",
                 "namespace": "CSET",
                 "notes": ""
             }

--- a/site/gatsby-site/cypress/fixtures/classifications/upsertCSET.json
+++ b/site/gatsby-site/cypress/fixtures/classifications/upsertCSET.json
@@ -85,7 +85,8 @@
                 ],
                 "__typename": "ClassificationClassification"
             },
-            "incident_id": 10,
+            "issue_id": 10,
+            "issue_type": "incident",
             "namespace": "CSET",
             "notes": "This is an updated note"
         }

--- a/site/gatsby-site/cypress/fixtures/classifications/upsertCSETv1merge.json
+++ b/site/gatsby-site/cypress/fixtures/classifications/upsertCSETv1merge.json
@@ -310,7 +310,8 @@
                     "value_json": "\"\""
                 }
             ],
-            "incident_id": 52,
+            "issue_id": 52,
+            "issue_type": "incident",
             "namespace": "CSETv1",
             "notes": "Annotator 1: \n\n This a note from the annotator 1\n\nAnnotator 2: \n\n This a note from the annotator 2",
             "publish": null

--- a/site/gatsby-site/gatsby-node.js
+++ b/site/gatsby-site/gatsby-node.js
@@ -245,7 +245,8 @@ exports.createSchemaCustomization = ({ actions }) => {
     }
     
     type mongodbAiidprodClassifications implements Node {
-      incident_id: Int
+      issue_id: Int
+      issue_type: String
       namespace: String
       attributes: [mongodbAiidprodClassificationsAttribute]
     }

--- a/site/gatsby-site/migrations/2023.07.13T19.27.03.multi-classifications.js
+++ b/site/gatsby-site/migrations/2023.07.13T19.27.03.multi-classifications.js
@@ -1,0 +1,31 @@
+const config = require('../config');
+
+/**
+ *
+ * @param {{context: {client: import('mongodb').MongoClient}}} context
+ */
+exports.up = async ({ context: { client } }) => {
+  await client.connect();
+
+  const classificationsCollection = client
+    .db(config.realm.production_db.db_name)
+    .collection('classifications');
+
+  const classifications = classificationsCollection.find({});
+
+  while (await classifications.hasNext()) {
+    const classification = await classifications.next();
+
+    const result = await classificationsCollection.updateOne(
+      { _id: classification._id },
+      {
+        $set: { issue_type: 'incident', issue_id: classification.incident_id },
+        $unset: { incident_id: '' },
+      }
+    );
+
+    console.log(
+      `Updated ${classification.namespace} ${classification.incident_id} : ${result.modifiedCount}`
+    );
+  }
+};

--- a/site/gatsby-site/page-creators/createTsneVisualizationPage.js
+++ b/site/gatsby-site/page-creators/createTsneVisualizationPage.js
@@ -41,9 +41,9 @@ const createTsneVisualizationPage = async (graphql, createPage) => {
 
   const classificationsQuery = await graphql(`
     query Classifications {
-      allMongodbAiidprodClassifications(filter: { incident_id: { in: [${incidentIds}] } }) {
+      allMongodbAiidprodClassifications(filter: { issue_id: { in: [${incidentIds}] }, issue_type: { eq: "incident" } }) {
         nodes {
-          incident_id
+          issue_id
           namespace
           attributes {
             short_name

--- a/site/gatsby-site/src/components/cite/TsneVisualization.js
+++ b/site/gatsby-site/src/components/cite/TsneVisualization.js
@@ -206,7 +206,7 @@ function VisualizationView({
                   <PlotPoint
                     classifications={
                       classifications.filter(
-                        (classification) => classification.incident_id == incident.incident_id
+                        (classification) => classification.issue_id == incident.incident_id
                       ) || []
                     }
                     key={incident.incident_id}

--- a/site/gatsby-site/src/components/classifications/CsetTable.js
+++ b/site/gatsby-site/src/components/classifications/CsetTable.js
@@ -408,7 +408,6 @@ export default function CsetTable({ data, taxa, incident_id, ...props }) {
       const attributes = serializeClassification(values, taxa.field_list);
 
       const data = {
-        incident_id,
         notes: tableData.find((row) => row.short_name == 'notes').result,
         namespace: 'CSETv1',
         attributes: attributes.map((a) => a),
@@ -417,7 +416,8 @@ export default function CsetTable({ data, taxa, incident_id, ...props }) {
       await updateClassification({
         variables: {
           query: {
-            incident_id,
+            issue_type: 'incident',
+            issue_id: incident_id,
             namespace: 'CSETv1',
           },
           data,

--- a/site/gatsby-site/src/components/taxa/TaxonomyForm.js
+++ b/site/gatsby-site/src/components/taxa/TaxonomyForm.js
@@ -44,7 +44,7 @@ const TaxonomyForm = forwardRef(function TaxonomyForm(
   }));
 
   const { data: classificationsData } = useQuery(FIND_CLASSIFICATION, {
-    variables: { query: { incident_id: incidentId } },
+    variables: { query: { issue_id: incidentId, issue_type: '' } },
     skip: !active,
   });
 
@@ -160,7 +160,6 @@ const TaxonomyForm = forwardRef(function TaxonomyForm(
 
       const data = {
         __typename: undefined,
-        incident_id: incidentId,
         notes: values.notes,
         publish: values.publish,
         attributes: attributes.map((a) => a),
@@ -170,7 +169,8 @@ const TaxonomyForm = forwardRef(function TaxonomyForm(
       await updateClassification({
         variables: {
           query: {
-            incident_id: incidentId,
+            issue_type: 'incident',
+            issue_id: incidentId,
             namespace,
           },
           data,

--- a/site/gatsby-site/src/components/ui/Header.js
+++ b/site/gatsby-site/src/components/ui/Header.js
@@ -11,10 +11,123 @@ import {
 import LoginSignup from 'components/loginSignup';
 import logoImg from '../images/logo.svg';
 import Link from './Link';
-import config from '../../../config.js';
 
 import Sidebar from '../sidebar';
 import LanguageSwitcher from 'components/i18n/LanguageSwitcher';
+
+const Divider = ({ className = '' }) => (
+  <span className={`divider hidden md:inline-block w-px h-[30px] bg-gray-400 ${className}`} />
+);
+
+const SocialMediaIcons = ({ githubUrl, facebookUrl, linkedInUrl }) => {
+  return (
+    <div className="hidden md:flex wrap-0 gap-2 items-center">
+      <a href={'https://twitter.com/IncidentsDB'} target="_blank" rel="noreferrer">
+        <FontAwesomeIcon
+          titleId="twitter"
+          icon={faTwitterSquare}
+          color={'white'}
+          className="pointer fa fa-twitter-square fa-lg"
+          title="Open Twitter"
+        />
+      </a>
+      <a href={'/rss.xml'} target="_blank" rel="noopener noreferrer">
+        <FontAwesomeIcon
+          titleId="rss"
+          icon={faRssSquare}
+          color={'white'}
+          className="pointer fa fa-rss-square fa-lg"
+          title="Open RSS Feed"
+        />
+      </a>
+      <a
+        className="paddingAround hiddenMobile"
+        href={facebookUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <FontAwesomeIcon
+          titleId="facebook"
+          icon={faFacebookSquare}
+          color={'white'}
+          className="pointer fa fa-rss-square fa-lg"
+          title="Open RSS Feed"
+        />
+      </a>
+      <a
+        className="paddingAround hiddenMobile"
+        href={linkedInUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <FontAwesomeIcon
+          titleId="linkedin"
+          icon={faLinkedin}
+          color={'white'}
+          className="pointer fa fa-rss-square fa-lg"
+          title="Open RSS Feed"
+        />
+      </a>
+      <a href={githubUrl} target="_blank" rel="noreferrer" className="pr-2">
+        <FontAwesomeIcon
+          titleId="github"
+          icon={faGithubSquare}
+          color={'white'}
+          className="pointer fa fa-github-square fa-lg -mr-2"
+          title="Open GitHub"
+        />
+      </a>
+    </div>
+  );
+};
+
+const SkipToContent = ({ className }) => (
+  <a
+    href="#content"
+    className={`
+      ${className}
+      relative 
+      overflow-hidden
+      text-white
+      bg-transparent 
+      text-xs
+      opacity-0 focus:opacity-100
+      w-0       focus:w-[unset]
+      h-0       focus:h-[unset]
+                focus:px-[1ch]   
+    `}
+  >
+    Skip to Content
+  </a>
+);
+
+const HeaderLink = ({ className, headerTitle, logo }) => {
+  const finalLogoLink = logo.link !== '' ? logo.link : 'https://incidentdatabase.ai/';
+
+  return (
+    <Link to={finalLogoLink} className={`hover:no-underline flex items-center ${className}`}>
+      <div className="md:w-64 text-center">
+        <img
+          className={'hidden md:inline ml-[10px] mr-[10px] w-[200px]'}
+          src={logo.image !== '' ? logo.image : logoImg}
+          alt={'logo'}
+          loading="lazy"
+        />
+        <img
+          className="md:hidden w-[50px]"
+          src={logo.mobile !== '' ? logo.mobile : logoImg}
+          alt={'logo'}
+          loading="lazy"
+        />
+      </div>
+      <Divider />
+      <span
+        className="inline-block ml-4 md:ml-10 font-semibold text-xs  md:text-base md:uppercase"
+        dangerouslySetInnerHTML={{ __html: headerTitle }}
+      />
+    </Link>
+  );
+};
 
 const Header = ({ location = null }) => {
   const [navCollapsed, setNavCollapsed] = useState(true);
@@ -22,7 +135,7 @@ const Header = ({ location = null }) => {
   return (
     <StaticQuery
       query={graphql`
-        query headerTitleQuery {
+        query {
           site {
             siteMetadata {
               headerTitle
@@ -47,119 +160,12 @@ const Header = ({ location = null }) => {
           },
         } = data;
 
-        const finalLogoLink = logo.link !== '' ? logo.link : 'https://incidentdatabase.ai/';
-
-        var SocialMediaIcons = () =>
-          config.header.social && (
-            <div className="hidden md:flex wrap-0 gap-2 items-center">
-              <a href={'https://twitter.com/IncidentsDB'} target="_blank" rel="noreferrer">
-                <FontAwesomeIcon
-                  titleId="twitter"
-                  icon={faTwitterSquare}
-                  color={'white'}
-                  className="pointer fa fa-twitter-square fa-lg"
-                  title="Open Twitter"
-                />
-              </a>
-              <a href={'/rss.xml'} target="_blank" rel="noopener noreferrer">
-                <FontAwesomeIcon
-                  titleId="rss"
-                  icon={faRssSquare}
-                  color={'white'}
-                  className="pointer fa fa-rss-square fa-lg"
-                  title="Open RSS Feed"
-                />
-              </a>
-              <a
-                className="paddingAround hiddenMobile"
-                href={facebookUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <FontAwesomeIcon
-                  titleId="facebook"
-                  icon={faFacebookSquare}
-                  color={'white'}
-                  className="pointer fa fa-rss-square fa-lg"
-                  title="Open RSS Feed"
-                />
-              </a>
-              <a
-                className="paddingAround hiddenMobile"
-                href={linkedInUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <FontAwesomeIcon
-                  titleId="linkedin"
-                  icon={faLinkedin}
-                  color={'white'}
-                  className="pointer fa fa-rss-square fa-lg"
-                  title="Open RSS Feed"
-                />
-              </a>
-              <a href={githubUrl} target="_blank" rel="noreferrer" className="pr-2">
-                <FontAwesomeIcon
-                  titleId="github"
-                  icon={faGithubSquare}
-                  color={'white'}
-                  className="pointer fa fa-github-square fa-lg -mr-2"
-                  title="Open GitHub"
-                />
-              </a>
-            </div>
-          );
-
-        var HeaderLink = ({ className }) => (
-          <Link to={finalLogoLink} className={`hover:no-underline flex items-center ${className}`}>
-            <div className="md:w-64 text-center">
-              <img
-                className={'hidden md:inline ml-[10px] mr-[10px] w-[200px]'}
-                src={logo.image !== '' ? logo.image : logoImg}
-                alt={'logo'}
-                loading="lazy"
-              />
-              <img
-                className="md:hidden w-[50px]"
-                src={logo.mobile !== '' ? logo.mobile : logoImg}
-                alt={'logo'}
-                loading="lazy"
-              />
-            </div>
-            <Divider />
-            <span
-              className="inline-block ml-4 md:ml-10 font-semibold text-xs  md:text-base md:uppercase"
-              dangerouslySetInnerHTML={{ __html: headerTitle }}
-            />
-          </Link>
-        );
-
-        var SkipToContent = ({ className }) => (
-          <a
-            href="#content"
-            className={`
-              ${className}
-              relative 
-              overflow-hidden
-              text-white
-              bg-transparent 
-              text-xs
-              opacity-0 focus:opacity-100
-              w-0       focus:w-[unset]
-              h-0       focus:h-[unset]
-                        focus:px-[1ch]   
-            `}
-          >
-            Skip to Content
-          </a>
-        );
-
         return (
           <nav id="navBarDefault" className="bg-[#001934] shadow">
             <div className=" text-white flex flex-row items-center w-full p-4 md:pl-0 h-[80px]">
               <SkipToContent className="-order-1 mx-2" />
 
-              <HeaderLink className="-order-3" />
+              <HeaderLink className="-order-3" headerTitle={headerTitle} logo={logo} />
 
               <div className="mx-auto -order-2" />
 
@@ -167,7 +173,7 @@ const Header = ({ location = null }) => {
 
               <Divider className="mx-4" />
 
-              <SocialMediaIcons />
+              <SocialMediaIcons {...{ facebookUrl, githubUrl, linkedInUrl }} />
 
               <div className="block md:hidden">
                 <FontAwesomeIcon
@@ -203,9 +209,5 @@ const Header = ({ location = null }) => {
     />
   );
 };
-
-var Divider = ({ className }) => (
-  <span className={`divider hidden md:inline-block w-px h-[30px] bg-gray-400 ${className}`} />
-);
 
 export default Header;

--- a/site/gatsby-site/src/contexts/userContext/UserContextProvider.js
+++ b/site/gatsby-site/src/contexts/userContext/UserContextProvider.js
@@ -42,7 +42,7 @@ const getApolloCLient = (getValidAccessToken) =>
           keyFields: ['userId'],
         },
         Classification: {
-          keyFields: ['incident_id', 'namespace'],
+          keyFields: ['issue_id', 'issue_type', 'namespace'],
         },
       },
     }),

--- a/site/gatsby-site/src/graphql/classifications.js
+++ b/site/gatsby-site/src/graphql/classifications.js
@@ -4,7 +4,8 @@ export const FIND_CLASSIFICATION = gql`
   query FindClassifications($query: ClassificationQueryInput) {
     classifications(query: $query) {
       _id
-      incident_id
+      issue_id
+      issue_type
       notes
       namespace
       attributes {
@@ -23,7 +24,8 @@ export const UPDATE_CLASSIFICATION = gql`
   ) {
     upsertOneClassification(query: $query, data: $data) {
       _id
-      incident_id
+      issue_id
+      issue_type
       notes
       namespace
       attributes {

--- a/site/gatsby-site/src/pages/apps/classifications.js
+++ b/site/gatsby-site/src/pages/apps/classifications.js
@@ -260,7 +260,7 @@ export default function ClassificationsDbView(props) {
       const classificationsToRowsMap = (cObj) => {
         const row = {};
 
-        row['IncidentId'] = cObj.incident_id;
+        row['IncidentId'] = cObj.issue_id;
         for (const key in cObj.classifications) {
           row[key.split(' ').join('')] = cObj.classifications[key];
         }

--- a/site/gatsby-site/src/pages/apps/csettool/{mongodbAiidprodIncidents.incident_id}.js
+++ b/site/gatsby-site/src/pages/apps/csettool/{mongodbAiidprodIncidents.incident_id}.js
@@ -16,7 +16,9 @@ const ToolPage = (props) => {
   } = props;
 
   const { data, loading } = useQuery(FIND_CLASSIFICATION, {
-    variables: { query: { incident_id, namespace_in: allNamespaces } },
+    variables: {
+      query: { issue_type: 'incident', issue_id: incident_id, namespace_in: allNamespaces },
+    },
   });
 
   const [tableData, setTableData] = useState([]);

--- a/site/gatsby-site/src/pages/cite/[id].js
+++ b/site/gatsby-site/src/pages/cite/[id].js
@@ -41,7 +41,7 @@ function CiteDynamicPage(props) {
     if (incidentData?.incident) {
       const incidentTemp = { ...incidentData.incident };
 
-      const sortedIncidentReports = sortIncidentsByDatePublished(incidentTemp.reports);
+      const sortedIncidentReports = sortIncidentsByDatePublished([...incidentTemp.reports]);
 
       const sortedReports = sortedIncidentReports.filter((report) => isCompleteReport(report));
 

--- a/site/gatsby-site/src/pages/taxonomies.js
+++ b/site/gatsby-site/src/pages/taxonomies.js
@@ -88,7 +88,8 @@ export const pageQuery = graphql`
     }
     allMongodbAiidprodClassifications {
       nodes {
-        incident_id
+        issue_id
+        issue_type
         namespace
         attributes {
           short_name

--- a/site/gatsby-site/src/templates/cite.js
+++ b/site/gatsby-site/src/templates/cite.js
@@ -138,10 +138,10 @@ export const query = graphql`
     $translate_fr: Boolean!
     $translate_en: Boolean!
   ) {
-    allMongodbAiidprodClassifications(filter: { incident_id: { eq: $incident_id } }) {
+    allMongodbAiidprodClassifications(filter: { issue_id: { eq: $incident_id } }) {
       nodes {
-        incident_id
-        id
+        issue_type
+        issue_id
         namespace
         notes
         attributes {

--- a/site/gatsby-site/src/templates/cite.js
+++ b/site/gatsby-site/src/templates/cite.js
@@ -52,7 +52,7 @@ function CitePage(props) {
     locale,
   });
 
-  const sortedIncidentReports = sortIncidentsByDatePublished(incidentReports);
+  const sortedIncidentReports = sortIncidentsByDatePublished([...incidentReports]);
 
   const sortedReports = sortedIncidentReports.filter((report) => isCompleteReport(report));
 

--- a/site/gatsby-site/src/templates/citeDynamicTemplate.js
+++ b/site/gatsby-site/src/templates/citeDynamicTemplate.js
@@ -54,7 +54,7 @@ function CiteDynamicTemplate({
   });
 
   const { data: classificationsData } = useQuery(FIND_CLASSIFICATION, {
-    variables: { query: { incident_id, publish: true } },
+    variables: { query: { issue_id: incident_id, issue_type: 'incident', publish: true } },
   });
 
   useEffect(() => {

--- a/site/gatsby-site/src/templates/citeDynamicTemplate.js
+++ b/site/gatsby-site/src/templates/citeDynamicTemplate.js
@@ -89,7 +89,7 @@ function CiteDynamicTemplate({
         locale,
       });
 
-      const sortedIncidentReports = sortIncidentsByDatePublished(incidentReports);
+      const sortedIncidentReports = sortIncidentsByDatePublished([...incidentReports]);
 
       const sortedReports = sortedIncidentReports.filter((report) => isCompleteReport(report));
 
@@ -129,6 +129,9 @@ function CiteDynamicTemplate({
           <Spinner />
         </div>
       )}
+      <div>
+        {String(loading)} : {String(loadingIncident)}
+      </div>
       {!loading && !loadingIncident && !incident ? (
         <Trans>Incident {{ incident_id }} not found</Trans>
       ) : (

--- a/site/gatsby-site/src/templates/citeDynamicTemplate.js
+++ b/site/gatsby-site/src/templates/citeDynamicTemplate.js
@@ -129,9 +129,6 @@ function CiteDynamicTemplate({
           <Spinner />
         </div>
       )}
-      <div>
-        {String(loading)} : {String(loadingIncident)}
-      </div>
       {!loading && !loadingIncident && !incident ? (
         <Trans>Incident {{ incident_id }} not found</Trans>
       ) : (

--- a/site/gatsby-site/src/templates/taxonomy.js
+++ b/site/gatsby-site/src/templates/taxonomy.js
@@ -328,7 +328,7 @@ export default Taxonomy;
 export const pageQuery = graphql`
   query ($namespace: String!) {
     allMongodbAiidprodClassifications(
-      filter: { namespace: { eq: $namespace }, incident_id: { lt: 1000 } }
+      filter: { namespace: { eq: $namespace }, issue_id: { lt: 1000 } }
     ) {
       nodes {
         namespace

--- a/site/gatsby-site/src/utils/AlgoliaUpdater.js
+++ b/site/gatsby-site/src/utils/AlgoliaUpdater.js
@@ -150,9 +150,9 @@ class AlgoliaUpdater {
     classifications.forEach((classification) => {
       const taxonomy = taxa.find((t) => t.namespace == classification.namespace);
 
-      classificationsHash[classification.incident_id] ||= [];
-      classificationsHash[classification.incident_id] = classificationsHash[
-        classification.incident_id
+      classificationsHash[classification.issue_id] ||= [];
+      classificationsHash[classification.issue_id] = classificationsHash[
+        classification.issue_id
       ].concat(getClassificationArray({ classification, taxonomy }));
     });
 
@@ -191,7 +191,7 @@ class AlgoliaUpdater {
     const classifications = await this.mongoClient
       .db('aiidprod')
       .collection(`classifications`)
-      .find({ publish: true })
+      .find({ publish: true, issue_type: 'incident' })
       .toArray();
 
     return classifications;

--- a/site/realm/data_sources/mongodb-atlas/aiidprod/classifications/schema.json
+++ b/site/realm/data_sources/mongodb-atlas/aiidprod/classifications/schema.json
@@ -17,8 +17,11 @@
                 }
             }
         },
-        "incident_id": {
+        "issue_id": {
             "bsonType": "int"
+        },
+        "issue_type": {
+            "bsonType": "string"
         },
         "namespace": {
             "bsonType": "string"

--- a/site/realm/data_sources/mongodb-atlas/aiidprod/classifications/schema.json
+++ b/site/realm/data_sources/mongodb-atlas/aiidprod/classifications/schema.json
@@ -34,7 +34,8 @@
         }
     },
     "required": [
-        "incident_id",
+        "issue_id",
+        "issue_type",
         "namespace"
     ],
     "title": "classification"


### PR DESCRIPTION
This tweaks the classifications schema to allow linking a classification to an incident or a report, or something else.

Before, `classifications` had `incident_id`.

Now `classifications` have two fields:

- `issue_id`, the incident  ID, report number, or something else.
- `issue_type` specifies the target type (`incident`, `report`, etc.)



part of #2047 


Tests passed here: https://github.com/cesarvarela/aiid/pull/54

Successful deploy: https://deploy-preview-54--cesarvarela-staging.netlify.app/