### PR TITLE
Add rule to allow editors and admins to create subscriptions

### DIFF
--- a/site/realm/data_sources/mongodb-atlas/customData/subscriptions/rules.json
+++ b/site/realm/data_sources/mongodb-atlas/customData/subscriptions/rules.json
@@ -5,7 +5,19 @@
         {
             "name": "Owner of the document",
             "apply_when": {
-                "userId": "%%user.id"
+                "%or": [
+                    {
+                        "%%root.userId": "%%user.id"
+                    },
+                    {
+                        "%%user.custom_data.roles": {
+                            "%in": [
+                                "admin",
+                                "incident_editor"
+                            ]
+                        }
+                    }
+                ]
             },
             "read": true,
             "write": true,


### PR DESCRIPTION
Add rule to allow editors and admins to create subscriptions.
This allows submissions authors to receive notifications when their submission has been approved