### PR TITLE
Make report card images rounded

### DIFF
--- a/site/gatsby-site/src/components/reports/ReportCard.js
+++ b/site/gatsby-site/src/components/reports/ReportCard.js
@@ -128,7 +128,7 @@ const ReportCard = ({
           ref={imageRef}
         >
           <CloudinaryImage
-            className={`img-fluid h-full w-full max-w-full object-cover max-h-full`}
+            className={`img-fluid h-full w-full max-w-full object-cover max-h-full rounded-lg`}
             publicID={item.cloudinary_id ? item.cloudinary_id : `legacy/${md5(item.image_url)}`}
             alt={item.title}
             transformation={fill().height(480)}


### PR DESCRIPTION
I've been bothered by the way the sharp corner of the image doesn't match the rounded corner of the card.

Before:

![image](https://github.com/responsible-ai-collaborative/aiid/assets/25443411/38751abc-f91c-4f1f-a836-1cf5c465287d)

After:

![image](https://github.com/responsible-ai-collaborative/aiid/assets/25443411/513d169c-803c-48a8-8839-4dc395cc06b8)
