### PR TITLE
Make subscribe button left-margin consistent

### DIFF
--- a/site/gatsby-site/src/components/ui/Header.js
+++ b/site/gatsby-site/src/components/ui/Header.js
@@ -181,7 +181,7 @@ const Header = ({ location = null }) => {
                 />
               </div>
               <LoginSignup
-                className="hidden lg:flex ml-2"
+                className="hidden lg:flex ml-4"
                 logoutClassName="text-white hover:text-primary-blue"
                 loginClassName="text-white hover:text-primary-blue"
                 location={location}


### PR DESCRIPTION
Currently, all of the top-level header items are 1rem apart, except for the gap between the social media buttons and the subscribe/account button, which is 0.5rem. That's the same as the gap between the social media buttons, but those are meant to be grouped as one header item, whereas the subscribe button is separate.

Before:

![image](https://github.com/responsible-ai-collaborative/aiid/assets/25443411/4d9e779c-47c5-42b6-8d8f-458003d66000)


After:

![image](https://github.com/responsible-ai-collaborative/aiid/assets/25443411/56667e4f-c42a-44b3-b9a1-952edb2e5049)
