### PR TITLE
Migration: remove BNH from report submitter names

### DIFF
--- a/site/gatsby-site/migrations/2023.08.14T15.28.31.migration-bnh-submissions.js
+++ b/site/gatsby-site/migrations/2023.08.14T15.28.31.migration-bnh-submissions.js
@@ -1,0 +1,42 @@
+const config = require('../config');
+
+const submittersMap = {
+  'Daniel Atherton (BNH.ai)': 'Daniel Atherton',
+  'Patrick Hall (BNH.ai)': 'Patrick Hall',
+};
+
+/**
+ * @type {import('umzug').MigrationFn<any>}
+ * @param {{context: {client: import('mongodb').MongoClient}}} context
+ */
+exports.up = async ({ context: { client } }) => {
+  await client.connect();
+
+  const reportsCollection = client.db(config.realm.production_db.db_name).collection('reports');
+
+  // Select reports where target submitter name is present.
+  const targetReports = reportsCollection.find({
+    submitters: { $elemMatch: { $in: Object.keys(submittersMap) } },
+  });
+
+  for await (const report of targetReports) {
+    const originalSubmitters = report.submitters;
+
+    // Map target submitter names to new versions and maintain non-target names.
+    const updatedSubmitters = originalSubmitters.map((s) =>
+      s in submittersMap ? submittersMap[s] : s
+    );
+
+    const updateResult = await reportsCollection.updateOne(
+      { _id: report._id },
+      { $set: { submitters: updatedSubmitters } }
+    );
+
+    console.log(
+      `${report.report_number}: ${originalSubmitters} -> ${updatedSubmitters}, ${updateResult.modifiedCount}`
+    );
+  }
+};
+
+/** @type {import('umzug').MigrationFn<any>} */
+exports.down = async () => {};


### PR DESCRIPTION
Addresses https://github.com/responsible-ai-collaborative/aiid/issues/2234

Confirmed there are 542 target rows in the `reports` collection via:
`{submitters: {$elemMatch: { $in: ["Daniel Atherton (BNH.ai)", "Patrick Hall (BNH.ai)"] } }`

and the more expansive query for all appearances of "bnh" in submitter strings:
`{submitters: {$elemMatch: { $in: [/bnh/i] } } }`

Run against my dev instance, logs exactly 542 hits.

Open to suggestions for more testing. How have migrations been tested previously?