### PR TITLE
Add migration to unset null `user` values from `history.reports`

### DIFF
--- a/site/gatsby-site/migrations/2023.08.19T00.17.14.fix-report-history-users.js
+++ b/site/gatsby-site/migrations/2023.08.19T00.17.14.fix-report-history-users.js
@@ -1,0 +1,26 @@
+const config = require('../config');
+
+/**
+ *
+ * @param {{context: {client: import('mongodb').MongoClient}}} context
+ */
+
+exports.up = async ({ context: { client } }) => {
+  await client.connect();
+
+  const reportHistoryCollection = client
+    .db(config.realm.production_db.db_history_name)
+    .collection('reports');
+
+  const updateResult = await reportHistoryCollection.updateMany(
+    {
+      user: undefined,
+    },
+    { $unset: { user: '' } }
+  );
+
+  console.log('Update result:', updateResult);
+};
+
+/** @type {import('umzug').MigrationFn<any>} */
+exports.down = async () => {};


### PR DESCRIPTION
This fix this error on `history.reports` data:  https://github.com/responsible-ai-collaborative/aiid/pull/2221#pullrequestreview-1577361338

The same logic that we applied on this migration for the `reports` collection: `2023.08.17T15.56.33.fix-report-users.js`