### PR TITLE
Deploy to Production

### DIFF
--- a/site/gatsby-site/src/global.css
+++ b/site/gatsby-site/src/global.css
@@ -709,3 +709,9 @@ div .bytemd {
   color: #9b1c1c;
   text-decoration: none;
 }
+
+@-moz-document url-prefix() {
+    #content {
+        overflow: hidden !important;
+    }
+}


### PR DESCRIPTION
Quick fix for #2252 

The reason to use `overflow:clip` is to be able to use `position:sticky` and not have to resort to Intersection Observers and the like. It is not working correctly on Firefox, as it does on Chrome and Safari.

related: #2254 

@kepae 