### PR TITLE
Don't restore the `user` report field

### DIFF
--- a/site/gatsby-site/cypress/e2e/integration/reportHistory.cy.js
+++ b/site/gatsby-site/cypress/e2e/integration/reportHistory.cy.js
@@ -252,6 +252,7 @@ describe('Report History', () => {
 
     delete updatedReport._id;
     delete updatedReport.modifiedBy;
+    delete updatedReport.user;
 
     cy.wait('@UpdateReport').then((xhr) => {
       expect(xhr.request.body.operationName).to.eq('UpdateReport');
@@ -270,6 +271,7 @@ describe('Report History', () => {
         };
 
         delete expectedReport._id;
+        delete expectedReport.user;
 
         expect(input).to.deep.eq(expectedReport);
       });

--- a/site/gatsby-site/cypress/e2e/integration/reportHistory.cy.js
+++ b/site/gatsby-site/cypress/e2e/integration/reportHistory.cy.js
@@ -253,6 +253,7 @@ describe('Report History', () => {
     delete updatedReport._id;
     delete updatedReport.modifiedBy;
     delete updatedReport.user;
+    delete updatedReport.embedding.__typename;
 
     cy.wait('@UpdateReport').then((xhr) => {
       expect(xhr.request.body.operationName).to.eq('UpdateReport');

--- a/site/gatsby-site/cypress/fixtures/history/reportHistory.json
+++ b/site/gatsby-site/cypress/fixtures/history/reportHistory.json
@@ -259,7 +259,13 @@
         "date_submitted": "2023-08-03",
         "description": null,
         "editor_notes": null,
-        "embedding": null,
+        "embedding": {
+          "__typename": "History_reportEmbedding",
+          "from_text_hash": "0cf0b5d5d39e3e9040ce8da9367364511c3e9532",
+          "vector": [
+            -0.09017669409513474, 0.049546271562576294, 0.038945719599723816, -0.1436443030834198
+          ]
+        },
         "epoch_date_downloaded": 1691020800,
         "epoch_date_modified": 1691107596,
         "epoch_date_published": 1691020800,

--- a/site/gatsby-site/src/pages/cite/history.js
+++ b/site/gatsby-site/src/pages/cite/history.js
@@ -127,6 +127,9 @@ function IncidentHistoryPage() {
           changes: undefined,
           epoch_date_modified: getUnixTime(new Date()),
           editor_notes: version.editor_notes ? version.editor_notes : '',
+          embedding: version.embedding
+            ? { ...version.embedding, __typename: undefined }
+            : undefined,
         };
 
         await updateReport({

--- a/site/gatsby-site/src/pages/cite/history.js
+++ b/site/gatsby-site/src/pages/cite/history.js
@@ -119,6 +119,7 @@ function IncidentHistoryPage() {
 
         const updatedReport = {
           ...version,
+          user: undefined,
           modifiedByUser: undefined,
           modifiedBy: undefined,
           __typename: undefined,

--- a/site/gatsby-site/src/pages/cite/history.js
+++ b/site/gatsby-site/src/pages/cite/history.js
@@ -147,6 +147,7 @@ function IncidentHistoryPage() {
 
         setRestoringVersion(false);
       } catch (error) {
+        setRestoringVersion(false);
         addToast({
           message: t('Error restoring Report version.'),
           severity: SEVERITY.danger,

--- a/site/gatsby-site/src/pages/cite/history.js
+++ b/site/gatsby-site/src/pages/cite/history.js
@@ -207,10 +207,13 @@ function IncidentHistoryPage() {
                           {format(fromUnixTime(version.epoch_date_modified), 'yyyy-MM-dd hh:mm a')}
                         </div>
                       )}
-                      <div>
-                        <Trans>Modified by</Trans>: {version.modifiedByUser?.first_name}{' '}
-                        {version.modifiedByUser?.last_name}
-                      </div>
+                      {(version.modifiedByUser?.first_name ||
+                        version.modifiedByUser?.last_name) && (
+                        <div>
+                          <Trans>Modified by</Trans>: {version.modifiedByUser?.first_name}{' '}
+                          {version.modifiedByUser?.last_name}
+                        </div>
+                      )}
                       {index > 0 && isRole('incident_editor') && (
                         <CustomButton
                           variant="link"

--- a/site/gatsby-site/src/pages/incidents/history.js
+++ b/site/gatsby-site/src/pages/incidents/history.js
@@ -198,6 +198,7 @@ function IncidentHistoryPage() {
 
         setRestoringVersion(false);
       } catch (error) {
+        setRestoringVersion(false);
         addToast({
           message: t('Error restoring Incident version.'),
           severity: SEVERITY.danger,


### PR DESCRIPTION
This fix an issue on this PR https://github.com/responsible-ai-collaborative/aiid/pull/2251 

- When you try to restore a Report's version with a `user` field set (edge case), it throws an error.
ie: https://deploy-preview-2251--staging-aiid.netlify.app/cite/history?report_number=3035&incident_id=543


<img width="351" alt="image" src="https://github.com/responsible-ai-collaborative/aiid/assets/6564809/38f363df-b116-4d10-9c43-f56097c96f5c">



- Another error occurs when the Report version entry has an `embedding` value. In this case, we should remove the `__typename` field from the `embedding` object