### PR TITLE
Fix Report Card markdown text styling

### DIFF
--- a/site/gatsby-site/src/tailwind.css
+++ b/site/gatsby-site/src/tailwind.css
@@ -748,6 +748,11 @@
     margin-top: 45px !important;
   }
 
+  .react-markdown p {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
   .prose a {
     @apply text-blue-500 no-underline hover:underline !important;
   }

--- a/site/gatsby-site/src/tailwind.css
+++ b/site/gatsby-site/src/tailwind.css
@@ -749,8 +749,7 @@
   }
 
   .react-markdown p {
-    display: flex;
-    flex-wrap: wrap;
+    overflow-wrap: anywhere;
   }
 
   .prose a {


### PR DESCRIPTION
This closes https://github.com/responsible-ai-collaborative/aiid/issues/2270

The issue found is on the Report Card markdown text when this text contains multiple consecutive `<a>` tags and it doesn't wrap into the card max width.
It's an edge case that happens with the report number `2846` from Incident `492`.

<img width="886" alt="image" src="https://github.com/responsible-ai-collaborative/aiid/assets/6564809/534519d0-b2f9-4ae4-9025-40cd6c8e7991">


## Before

<img width="426" alt="image" src="https://github.com/responsible-ai-collaborative/aiid/assets/6564809/490f94fd-34df-4292-94a1-09e26e4ab637">

## After

<img width="440" alt="image" src="https://github.com/responsible-ai-collaborative/aiid/assets/6564809/566a0001-fbf5-47b0-a532-96f0e2e32ef7">

