### PR TITLE
Prevent cset tool from crashing if the classification is missing attributes.

### DIFF
--- a/site/gatsby-site/src/pages/apps/csettool/{mongodbAiidprodIncidents.incident_id}.js
+++ b/site/gatsby-site/src/pages/apps/csettool/{mongodbAiidprodIncidents.incident_id}.js
@@ -34,13 +34,15 @@ const ToolPage = (props) => {
         };
 
         for (const classification of data.classifications) {
-          const json = classification.attributes.find(
-            (a) => a.short_name == attribute.short_name
-          ).value_json;
+          const item = classification.attributes.find((a) => a.short_name == attribute.short_name);
 
-          const value = JSON.parse(json);
+          if (item) {
+            const value = JSON.parse(item.value_json);
 
-          row[classification.namespace] = value;
+            row[classification.namespace] = value;
+          } else {
+            row[classification.namespace] = null;
+          }
         }
 
         rows.push(row);


### PR DESCRIPTION
Closes #2286

I'm not totally happy with this fix because it hides what might be an underlying issue: that there are classifications with `null` attributes. If this is not the case, this is the best fix ever.