### PR TITLE
Fix setting staging environment label

### DIFF
--- a/site/gatsby-site/static/rollbar.js
+++ b/site/gatsby-site/static/rollbar.js
@@ -4,7 +4,7 @@ let environment = 'other';
 if (location.hostname == 'incidentdatabase.ai') {
   environment = 'production';
 } else if (location.hostname == 'staging-aiid.netlify.app') {
-  environment == 'staging';
+  environment = 'staging';
 } else if (location.hostname == 'localhost') {
   environment = 'localhost';
 }


### PR DESCRIPTION
Related: #585, #2312

Currently, errors from staging are being logged with the environment `other`. I don't see a convenient way to test _all_ environment label options in tests – but I'd rather put the fix into staging now.