### PR TITLE
Use eg (for example), not ie (that is) in readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,8 +709,8 @@ To disable all email noticications, fill the following `SendGridApiKey` secret v
 SendGridApiKey = [SendGrid API key from https://app.sendgrid.com/settings/api_keys]
 publicApiKey = [Public API key from the Atlas Organization. See comment below for more information]
 privateApiKey = [Private API key from the Atlas Organization. See comment below for more information]
-groupId = [Atlas Service App group ID, ie: "62cc90978bc4600cafdcf16e"]
-appId = [Atlas Service App ID, ie: "62cc98647e6a26c53d5b4b53"]
+groupId = [Atlas Service App group ID, eg: "62cc90978bc4600cafdcf16e"]
+appId = [Atlas Service App ID, eg: "62cc98647e6a26c53d5b4b53"]
 ```
 
 To get your Public and Private API Key, follow these [instructions](https://www.mongodb.com/docs/atlas/configure-api-access/#std-label-create-org-api-key).


### PR DESCRIPTION
Minor language thing I encountered while trying to set up email notifications, but when where it says

> groupId = [Atlas Service App group ID, **ie**: "62cc90978bc4600cafdcf16e"]  

"ie" (= *id est* = "it is") would mean that you should enter exactly "62cc90978bc4600cafdcf16e". But this is just giving an example of a value like the one you would get for your own Atlas service, so it should use "eg" (= *exempli gratia* = for example). 