### PR TITLE
Fix/submission emails

### DIFF
--- a/site/gatsby-site/cypress/e2e/unit/functions/processNotifications.cy.js
+++ b/site/gatsby-site/cypress/e2e/unit/functions/processNotifications.cy.js
@@ -269,9 +269,14 @@ const stubEverything = () => {
           .returns({ toArray: () => subscriptionsToIncidentUpdates });
       }
 
+      const incidentIds = pendingNotificationsToPromotedIncidents.map(
+        (pendingNotification) => pendingNotification.incident_id
+      );
+
       stub
         .withArgs({
           type: SUBSCRIPTION_TYPE.submissionPromoted,
+          incident_id: { $in: incidentIds },
         })
         .as(`subscriptions.find("${SUBSCRIPTION_TYPE.submissionPromoted}")`)
         .returns({ toArray: () => subscriptionsToPromotedIncidents });
@@ -450,6 +455,7 @@ describe('Functions', () => {
 
       expect(subscriptionsCollection.find.getCall(5).args[0]).to.deep.equal({
         type: SUBSCRIPTION_TYPE.submissionPromoted,
+        incident_id: { $in: [217] },
       });
 
       for (const subscription of subscriptionsToPromotedIncidents) {
@@ -464,8 +470,6 @@ describe('Functions', () => {
         expect(incidentsCollection.findOne.getCall(i).args[0]).to.deep.equal({
           incident_id: pendingNotification.incident_id,
         });
-
-        console.log('subscriptionsToPromotedIncidents', global.context.functions);
 
         const userIds = subscriptionsToPromotedIncidents.map((subscription) => subscription.userId);
 

--- a/site/gatsby-site/src/templates/citeTemplate.js
+++ b/site/gatsby-site/src/templates/citeTemplate.js
@@ -248,6 +248,7 @@ function CiteTemplate({
                       reportCount: sortedReports.length,
                       incidentDate: incident.date,
                       editors: incident.editors
+                        .filter((editor) => editor && editor.first_name && editor.last_name)
                         .map(({ first_name, last_name }) => `${first_name} ${last_name}`)
                         .join(', '),
                     }}

--- a/site/realm/functions/processNotifications.js
+++ b/site/realm/functions/processNotifications.js
@@ -4,7 +4,7 @@ const getRecipients = async (userIds) => {
   for (const userId of userIds) {
     const userResponse = await context.functions.execute('getUser', { userId });
 
-    if (userResponse.email) {
+    if (userResponse?.email) {
       recipients.push({
         email: userResponse.email,
         userId,
@@ -262,13 +262,19 @@ exports = async function () {
 
   // Notifications to New Promotions
   try {
+
+    // Finds all pending notifications to New Promotions
     const pendingNotificationsToNewPromotions = await notificationsCollection.find({ processed: false, type: 'submission-promoted' }).toArray();
+
+    // Gets all incident ids from pending notifications to New Promotions
+    const pendingNotificationsIncidentIds = pendingNotificationsToNewPromotions.map((notification) => notification.incident_id);
 
     if (pendingNotificationsToNewPromotions.length > 0) {
 
       result += pendingNotificationsToNewPromotions.length;
 
-      const subscriptionsToNewPromotions = await subscriptionsCollection.find({ type: 'submission-promoted' }).toArray();
+      // Finds all subscriptions to New Promotions for those new incidents
+      const subscriptionsToNewPromotions = await subscriptionsCollection.find({ type: 'submission-promoted', incident_id: { $in: pendingNotificationsIncidentIds } }).toArray();
 
       // Process subscriptions to New Incidents
       if (subscriptionsToNewPromotions.length > 0) {


### PR DESCRIPTION
- closes #2404 

Emails are being sent to users that have submitted submissions in the past, even for new submissions.
They should only receive notifications for the ones they have created.

Test URL: https://deploy-preview-30--clarayoudale-staging.netlify.app/
test users:
clara@botsfactory.io
clara+3@botsfactory.io
clara+4@botsfactory.io
(If you want you can create your own test user(s))

How to test:

- Login with one of the users
- Submit a new report (or multiple reports if you want)
- Login with another user
- Submit a new report (or multiple reports if you want)
- On the submission page https://deploy-preview-30--clarayoudale-staging.netlify.app/apps/submitted/ review and add all your new submissions as incidents (for this you need to be logged in with clara@botsfactory.io)
- Trigger a postman request to `https://realm.mongodb.com/api/client/v2.0/app/aiidstitch2-qoueg/graphql`
with body
```
mutation ProcessNotifications {
      processNotifications
    }
```
(ask Clara for request's headers)
- Users should only receive email for the submission they've created and not both.