### PR TITLE
Mark notification as processed before send the email

### DIFF
--- a/site/gatsby-site/cypress/e2e/unit/functions/processNotifications.cy.js
+++ b/site/gatsby-site/cypress/e2e/unit/functions/processNotifications.cy.js
@@ -789,7 +789,7 @@ describe('Functions', () => {
         expect(notificationsCollection.updateOne.getCall(i).args[1].$set.processed).to.be.equal(
           true
         );
-        expect(notificationsCollection.updateOne.getCall(i).args[1].$set).not.to.have.ownProperty(
+        expect(notificationsCollection.updateOne.getCall(i).args[1].$set).to.have.ownProperty(
           'sentDate'
         );
       }
@@ -808,9 +808,9 @@ describe('Functions', () => {
         expect(notificationsCollection.updateOne.getCall(i + 2).args[1].$set.processed).to.be.equal(
           true
         );
-        expect(
-          notificationsCollection.updateOne.getCall(i + 2).args[1].$set
-        ).not.to.have.ownProperty('sentDate');
+        expect(notificationsCollection.updateOne.getCall(i + 2).args[1].$set).to.have.ownProperty(
+          'sentDate'
+        );
       }
 
       for (let i = 0; i < pendingNotificationsToIncidentUpdates.length; i++) {
@@ -827,9 +827,9 @@ describe('Functions', () => {
         expect(notificationsCollection.updateOne.getCall(i + 4).args[1].$set.processed).to.be.equal(
           true
         );
-        expect(
-          notificationsCollection.updateOne.getCall(i + 4).args[1].$set
-        ).not.to.have.ownProperty('sentDate');
+        expect(notificationsCollection.updateOne.getCall(i + 4).args[1].$set).to.have.ownProperty(
+          'sentDate'
+        );
       }
 
       expect(


### PR DESCRIPTION
This is a fix for https://github.com/responsible-ai-collaborative/aiid/issues/2404

## Changes
- We mark the notification individually as `processed=true` before send the email
- In case of error, we mark the individual notification as `processed=false`