### PR TITLE
Fetch articles from sites using cookies

### DIFF
--- a/site/gatsby-site/cypress/e2e/integration/submit.cy.js
+++ b/site/gatsby-site/cypress/e2e/integration/submit.cy.js
@@ -1798,4 +1798,44 @@ describe('The Submit form', () => {
 
     cy.contains('Please review. Some data is missing.').should('exist');
   });
+
+  it('Should fetch article', () => {
+    cy.visit(url);
+
+    cy.intercept('GET', parserURL).as('parseNews');
+
+    cy.get('input[name="url"]').type(
+      `https://www.arstechnica.com/gadgets/2017/11/youtube-to-crack-down-on-inappropriate-content-masked-as-kids-cartoons/`
+    );
+
+    cy.get('button').contains('Fetch info').click();
+
+    cy.wait('@parseNews');
+
+    cy.get('.tw-toast')
+      .contains('Please verify all information programmatically pulled from the report')
+      .should('exist');
+
+    cy.get('.tw-toast').contains('Error fetching news.').should('not.exist');
+  });
+
+  it('Should fetch article from site using cookies', () => {
+    cy.visit(url);
+
+    cy.intercept('GET', parserURL).as('parseNews');
+
+    cy.get('input[name="url"]').type(
+      'https://www.washingtonpost.com/technology/2023/02/16/microsoft-bing-ai-chatbot-sydney/'
+    );
+
+    cy.get('button').contains('Fetch info').click();
+
+    cy.wait('@parseNews');
+
+    cy.get('.tw-toast')
+      .contains('Please verify all information programmatically pulled from the report')
+      .should('exist');
+
+    cy.get('.tw-toast').contains('Error fetching news.').should('not.exist');
+  });
 });

--- a/site/gatsby-site/cypress/e2e/integration/submit.cy.js
+++ b/site/gatsby-site/cypress/e2e/integration/submit.cy.js
@@ -1819,7 +1819,7 @@ describe('The Submit form', () => {
     cy.get('.tw-toast').contains('Error fetching news.').should('not.exist');
   });
 
-  it('Should fetch article from site using cookies', () => {
+  it('Should fetch article from site using cookies as fallback', () => {
     cy.visit(url);
 
     cy.intercept('GET', parserURL).as('parseNews');

--- a/site/gatsby-site/src/api/parseNews.js
+++ b/site/gatsby-site/src/api/parseNews.js
@@ -23,6 +23,8 @@ export default async function handler(req, res) {
   res.status(200).json(response);
 }
 
+// Runs first with { cookies: false },
+// then on error recurs with { cookies: true } as a fallback.
 const getArticle = async (url, config) => {
   try {
     const parserConfig = { contentType: 'markdown' };

--- a/site/gatsby-site/src/api/parseNews.js
+++ b/site/gatsby-site/src/api/parseNews.js
@@ -24,7 +24,7 @@ export default async function handler(req, res) {
 }
 
 // Runs first with { cookies: false },
-// then on error recurs with { cookies: true } as a fallback.
+// then on error recurses with { cookies: true } as a fallback.
 const getArticle = async (url, config) => {
   try {
     const parserConfig = { contentType: 'markdown' };


### PR DESCRIPTION
Resolves #2421. Fetching articles from https://www.washingtonpost.com was failing because the initial request sets some cookies and then redirects to the same page. Without those cookies, the page content is not served. As far as I can tell, the parser we're using [is supposed to accept cookies](https://github.com/postlight/parser/blob/main/src/resource/utils/fetch-resource.js#L95) but in fact does not, so this handles fetching the HTML and setting the cookies manually when fetching from The Washington Post. Probably other sites will do a similar thing, but I'm not certain that this won't break parsing other sites if we enable it across the board.