### PR TITLE
Add migration to mark all pending notifications as processed

### DIFF
--- a/site/gatsby-site/migrations/2023.12.07T20.45.09.mark-pending-notifications-as-processed.js
+++ b/site/gatsby-site/migrations/2023.12.07T20.45.09.mark-pending-notifications-as-processed.js
@@ -1,0 +1,16 @@
+const config = require('../config');
+
+/** @type {import('umzug').MigrationFn<any>} */
+exports.up = async ({ context: { client } }) => {
+  const db = client.db(config.realm.production_db.db_custom_data);
+
+  const notifications = db.collection('notifications');
+
+  // Mark all pending notifications as processed
+  const result = await notifications.updateMany(
+    { processed: false },
+    { $set: { processed: true } }
+  );
+
+  console.log(`All pending notifications marked as processed. Total: ${result.modifiedCount}`);
+};


### PR DESCRIPTION
This PR includes a migration that mark all pending notifications (`processed:false`) as processed (`processed:true`)
By doing that, we can start notifications from scratch again.

Original issue: https://github.com/responsible-ai-collaborative/aiid/issues/2404