### PR TITLE
Fix owner name on checklist form

### DIFF
--- a/site/gatsby-site/src/components/checklists/CheckListForm.js
+++ b/site/gatsby-site/src/components/checklists/CheckListForm.js
@@ -36,7 +36,7 @@ export default function CheckListForm({
 
   const userIsOwner = values.owner_id == user.id;
 
-  const owner = users.find((u) => (u.userId = values.owner_id));
+  const owner = users.find((u) => u.userId == values.owner_id);
 
   const [deleteChecklist] = useMutation(DELETE_CHECKLIST);
 


### PR DESCRIPTION
Resolves https://github.com/responsible-ai-collaborative/aiid/issues/2477.

It turns out that the owner name on the checklists form was incorrect because I apparently still sometimes mistakenly use `=` in place of `==`:

```javascript
const owner = users.find((u) => u.userId = values.owner_id);
                                        ^^^
```

That would set `u.userId` to `value.owner_id`, then coerce it to a boolean, which would always be `true` for our userIds, meaning that that `owner` would always resolve to the first user in the list. That happened to be correct when I tested it, so it slipped through.

Hot take: [every other way](https://en.wikipedia.org/wiki/Assignment_(computer_science)#Assignment_versus_equality) of spelling the assignment operator is better than `=`.