### PR TITLE
Re-enable notifications plug-in

### DIFF
--- a/site/gatsby-site/netlify.toml
+++ b/site/gatsby-site/netlify.toml
@@ -19,9 +19,8 @@ TERM = "xterm"
     start = 'gatsby serve -p 8080'
     browser = 'chromium'
 
-# tmp disable
-# [[plugins]]
-#   package = "/plugins/netlify-plugin-process-notifications"
+[[plugins]]
+  package = "/plugins/netlify-plugin-process-notifications"
 
 [build.processing.html]
   pretty_urls = false


### PR DESCRIPTION
Following #2476 and #2441, we should be able to re-enable notifications. It might also be a good idea to wait for #2459 and #2473.

This should close #2404.