### PR TITLE
If excerpt doesn't exist use body as preview removing markdown

### DIFF
--- a/site/gatsby-site/blog/deepfakes-child-safety/index.es.mdx
+++ b/site/gatsby-site/blog/deepfakes-child-safety/index.es.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Deepfakes y seguridad infantil: encuesta y análisis de incidentes y respuestas de 2023'
 metaTitle: 'Deepfakes y seguridad infantil: encuesta y análisis de incidentes y respuestas de 2023'
-metaDescription: ""
+metaDescription: "Preocupaciones crecientes y desafíos legales en relación a la creación y distribución de materiales de abuso sexual infantil generados por IA en 2023."
 date: '2024-01-09'
 image: './images/image_doj.jpg'
 author: 'Daniel Atherton'

--- a/site/gatsby-site/blog/deepfakes-child-safety/index.fr.mdx
+++ b/site/gatsby-site/blog/deepfakes-child-safety/index.fr.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Deepfakes et sécurité des enfants : une enquête et une analyse des incidents et des réponses de 2023'
 metaTitle: 'Deepfakes et sécurité des enfants : une enquête et une analyse des incidents et des réponses de 2023'
-metaDescription: ""
+metaDescription: "Préoccupations croissantes et défis juridiques concernant la création et la distribution de matériaux d'abus sexuels sur enfants générés par IA en 2023."
 date: '2024-01-09'
 image: './images/image_doj.jpg'
 author: 'Daniel Atherton'

--- a/site/gatsby-site/blog/deepfakes-child-safety/index.mdx
+++ b/site/gatsby-site/blog/deepfakes-child-safety/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Deepfakes and Child Safety: A Survey and Analysis of 2023 Incidents and Responses'
 metaTitle: 'Deepfakes and Child Safety: A Survey and Analysis of 2023 Incidents and Responses'
-metaDescription: ""
+metaDescription: "Rising concerns and legal challenges regarding the creation and distribution of AI-generated child sexual abuse materials in 2023."
 date: '2024-01-09'
 image: './images/image_doj.jpg'
 author: 'Daniel Atherton'

--- a/site/gatsby-site/gatsby-node.js
+++ b/site/gatsby-site/gatsby-node.js
@@ -158,6 +158,12 @@ exports.onCreateNode = async ({ node, getNode, actions }) => {
       node,
       value: node.frontmatter.title || startCase(parent.name),
     });
+
+    createNodeField({
+      name: 'previewText',
+      node,
+      value: node.frontmatter.previewText || startCase(parent.name),
+    });
   }
 
   if (node.internal.type == 'mongodbAiidprodClassifications') {

--- a/site/gatsby-site/src/components/blog/PostPreview.js
+++ b/site/gatsby-site/src/components/blog/PostPreview.js
@@ -9,8 +9,8 @@ function PostPreview({ post, latestPost = false }) {
 
   if (post.excerpt) {
     previewText = post.excerpt;
-  } else if (post.frontmatter.metaDescription && post.frontmatter.metaDescription !== '') {
-    previewText = post.frontmatter.metaDescription;
+  } else if (post.frontmatter.previewText && post.frontmatter.previewText !== '') {
+    previewText = post.frontmatter.previewText;
   } else {
     // Remove HTML tags
     previewText = post?.body.replace(/<[^>]*>?/gm, '');

--- a/site/gatsby-site/src/components/blog/PostPreview.js
+++ b/site/gatsby-site/src/components/blog/PostPreview.js
@@ -7,7 +7,7 @@ import DateLabel from 'components/ui/DateLabel';
 function PostPreview({ post, latestPost = false }) {
   let previewText = '';
 
-  if (post.excerpt) {
+  if (post.excerpt && post.excerpt !== '') {
     previewText = post.excerpt;
   } else if (post.frontmatter.previewText && post.frontmatter.previewText !== '') {
     previewText = post.frontmatter.previewText;

--- a/site/gatsby-site/src/components/blog/PostPreview.js
+++ b/site/gatsby-site/src/components/blog/PostPreview.js
@@ -9,6 +9,8 @@ function PostPreview({ post, latestPost = false }) {
 
   if (post.excerpt) {
     previewText = post.excerpt;
+  } else if (post.frontmatter.metaDescription && post.frontmatter.metaDescription !== '') {
+    previewText = post.frontmatter.metaDescription;
   } else {
     // Remove HTML tags
     previewText = post?.body.replace(/<[^>]*>?/gm, '');

--- a/site/gatsby-site/src/components/blog/PostPreview.js
+++ b/site/gatsby-site/src/components/blog/PostPreview.js
@@ -5,6 +5,25 @@ import { Trans } from 'react-i18next';
 import DateLabel from 'components/ui/DateLabel';
 
 function PostPreview({ post, latestPost = false }) {
+  let previewText = '';
+
+  if (post.excerpt) {
+    previewText = post.excerpt;
+  } else {
+    // Remove HTML tags
+    previewText = post?.body.replace(/<[^>]*>?/gm, '');
+
+    // Remove Markdown image syntax
+    previewText = previewText.replace(/!\[.*?\]\(.*?\)/g, '');
+
+    // Remove Markdown
+    previewText = previewText.replace(/!\[.*?\]\(.*?\)|\]\(.*?\)/g, '$1');
+
+    previewText = previewText.substring(0, 200);
+
+    previewText = previewText.trim();
+  }
+
   return (
     <>
       <div className="flex flex-col w-full h-full bg-white rounded-lg border border-gray-200 shadow-md dark:bg-gray-800 dark:border-gray-700">
@@ -35,7 +54,7 @@ function PostPreview({ post, latestPost = false }) {
           <p className="text-sm text-muted-gray">
             <DateLabel date={new Date(post.frontmatter.date)} />
           </p>
-          <p className="mb-3 font-normal text-gray-700 dark:text-gray-400">{post.excerpt}... </p>
+          <p className="mb-3 font-normal text-gray-700 dark:text-gray-400">{previewText}... </p>
         </div>
         <div className="flex items-end flex-1 p-6">
           <a

--- a/site/gatsby-site/src/components/doc/PrismicDocPost.js
+++ b/site/gatsby-site/src/components/doc/PrismicDocPost.js
@@ -19,6 +19,8 @@ const PrismicDocPost = ({ doc, location }) => {
     Sponsors: <Sponsors />,
   };
 
+  if (!doc) return <></>;
+
   const metaTitle = doc.data.metatitle;
 
   const metaDescription = doc.data.metadescription;

--- a/site/gatsby-site/src/pages/blog/index.js
+++ b/site/gatsby-site/src/pages/blog/index.js
@@ -61,6 +61,7 @@ export const IndexQuery = graphql`
         fields {
           slug
           title
+          previewText
         }
         body
         excerpt

--- a/site/gatsby-site/src/pages/blog/index.js
+++ b/site/gatsby-site/src/pages/blog/index.js
@@ -62,6 +62,7 @@ export const IndexQuery = graphql`
           slug
           title
         }
+        body
         excerpt
         frontmatter {
           date

--- a/site/gatsby-site/src/pages/blog/index.js
+++ b/site/gatsby-site/src/pages/blog/index.js
@@ -65,6 +65,7 @@ export const IndexQuery = graphql`
         body
         excerpt
         frontmatter {
+          metaDescription
           date
           author
           slug

--- a/site/gatsby-site/src/templates/landingPage.js
+++ b/site/gatsby-site/src/templates/landingPage.js
@@ -27,9 +27,9 @@ const LandingPage = (props) => {
 
   let latestBlogPost = null;
 
-  if (!latestPostOld) {
+  if (!latestPostOld || latestPostOld.nodes.length === 0) {
     latestBlogPost = latestPrismicPost;
-  } else if (!latestPrismicPost) {
+  } else if (!latestPrismicPost || latestPrismicPost.nodes.length === 0) {
     latestBlogPost = latestPostOld;
   } else {
     const mdxDate = new Date(latestPostOld?.nodes[0]?.frontmatter?.date);

--- a/site/gatsby-site/src/templates/landingPage.js
+++ b/site/gatsby-site/src/templates/landingPage.js
@@ -25,11 +25,20 @@ const LandingPage = (props) => {
 
   let { latestPrismicPost, latestPostOld, latestReportIncidents } = data;
 
-  const mdxDate = new Date(latestPostOld?.nodes[0]?.frontmatter?.date);
+  let latestBlogPost = null;
 
-  const prismicDate = new Date(latestPrismicPost?.nodes[0]?.data.date);
+  if (!latestPostOld) {
+    latestBlogPost = latestPrismicPost;
+  } else if (!latestPrismicPost) {
+    latestBlogPost = latestPostOld;
+  } else {
+    const mdxDate = new Date(latestPostOld?.nodes[0]?.frontmatter?.date);
 
-  const latestPost = mdxDate > prismicDate ? latestPostOld : latestPrismicPost;
+    const prismicDate = new Date(latestPrismicPost?.nodes[0]?.data.date);
+
+    // Display prismic post if it's the latest post or if it's newer than the latest mdx post
+    latestBlogPost = mdxDate > prismicDate ? latestPostOld : latestPrismicPost;
+  }
 
   let { sponsors } = props.pageContext;
 
@@ -92,12 +101,12 @@ const LandingPage = (props) => {
           <div className="flex-1 max-w-full sm:max-w-[50%] md:max-w-full lg:max-w-[50%]">
             <AboutDatabase />
           </div>
-          {(latestPost?.edges?.length > 0 || latestPost?.nodes?.length > 0) && (
+          {(latestBlogPost?.edges?.length > 0 || latestBlogPost?.nodes?.length > 0) && (
             <div className="flex-1 max-w-full sm:max-w-[50%] md:max-w-full lg:max-w-[50%]">
-              {latestPost.nodes.length > 0 && latestPost.nodes[0].data ? (
-                <PostPreviewNew post={latestPost.nodes[0]} latestPost={true} />
-              ) : latestPost.nodes.length > 0 ? (
-                <Blog post={latestPost.nodes[0]} />
+              {latestBlogPost.nodes.length > 0 && latestBlogPost.nodes[0].data ? (
+                <PostPreviewNew post={latestBlogPost.nodes[0]} latestBlogPost={true} />
+              ) : latestBlogPost.nodes.length > 0 ? (
+                <Blog post={latestBlogPost.nodes[0]} />
               ) : (
                 <></>
               )}

--- a/site/gatsby-site/src/templates/landingPage.js
+++ b/site/gatsby-site/src/templates/landingPage.js
@@ -297,6 +297,7 @@ export const query = graphql`
         body
         excerpt
         frontmatter {
+          metaDescription
           slug
           date
           author

--- a/site/gatsby-site/src/templates/landingPage.js
+++ b/site/gatsby-site/src/templates/landingPage.js
@@ -294,6 +294,7 @@ export const query = graphql`
           title
           locale
         }
+        body
         excerpt
         frontmatter {
           slug

--- a/site/gatsby-site/src/templates/landingPage.js
+++ b/site/gatsby-site/src/templates/landingPage.js
@@ -302,6 +302,7 @@ export const query = graphql`
           slug
           title
           locale
+          previewText
         }
         body
         excerpt


### PR DESCRIPTION
Resolves https://github.com/responsible-ai-collaborative/aiid/pull/2565#issuecomment-1893992366

If excerpt is available it's used to preview the description, otherwise it falls back first to the metaDescription and then to the markdown, removing html and markdown tags.
I also added some metaDescription for the latest blog post. Please check if it's ok.

Test URL: https://pr-42--clarayoudale-staging.netlify.app/

