### PR TITLE
Add Atlas deploy to new workflows

### DIFF
--- a/.github/workflows/realm.yml
+++ b/.github/workflows/realm.yml
@@ -1,24 +1,36 @@
-name: Realm Deploy Staging
+name: Realm Deploy
 
 on:
-  push:
-    branches:
-      - staging
+  workflow_call:
+    inputs:
+      environment:
+        description: The Github environment to load secrets from
+        type: string
+        required: true
+      sha:
+        description: The commit SHA to deploy
+        type: string
+        required: true
 
 jobs:
   push:
     runs-on: ubuntu-latest
-    environment: staging
+    environment: ${{ inputs.environment }}
     steps:
-      - uses: actions/checkout@v2
-      - name: "Install the Realm CLI"
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
+
+      - name: "Install the Realm (Atlas) CLI"
         run: |
           npm install -g mongodb-realm-cli
+
       - name: Login
         run: |
           realm-cli login --api-key="${{ secrets.REALM_API_PUBLIC_KEY }}" --private-api-key="${{ secrets.REALM_API_PRIVATE_KEY }}" --realm-url https://realm.mongodb.com --atlas-url https://cloud.mongodb.com
+
       - name: Push
         run: |
           cd site/realm
           realm-cli push --remote="${{ secrets.GATSBY_REALM_APP_ID }}" -y
-

--- a/.github/workflows/realm.yml
+++ b/.github/workflows/realm.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Push
         run: |
           cd site/realm
-          realm-cli push --remote="${{ secrets.GATSBY_REALM_APP_ID }}" -y
+          realm-cli push --remote="${{ vars.GATSBY_REALM_APP_ID }}" -y

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -17,6 +17,7 @@ jobs:
   call-test-build:
     uses: ./.github/workflows/test-build.yml
     secrets: inherit
+    needs: call-atlas
     with:
       sha: ${{ github.sha }}
       environment: staging

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -7,6 +7,13 @@ on:
 
 jobs:
 
+  call-atlas:
+    uses: ./.github/workflows/realm.yml
+    secrets: inherit
+    with:
+      sha: ${{ github.sha }}
+      environment: staging
+
   call-test-build:
     uses: ./.github/workflows/test-build.yml
     secrets: inherit


### PR DESCRIPTION
Makes realm push part of the new workflows.

(After confirming this is working properly we should do the same for `production` and `empty` envs)


working here: https://github.com/aiidtest/aiid/actions/runs/7661942832
