### PR TITLE
Update actions/cache to v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Read node modules from cache
         id: cache-nodemodules
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         env:
           cache-name: cache-install-folder
         with:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Read node modules from cache
         id: cache-nodemodules
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         env:
           cache-name: cache-install-folder
         with:
@@ -91,7 +91,7 @@ jobs:
           GATSBY_COMMIT_SHA: ${{ inputs.sha }}
 
       - name: Cache build
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         env:
           cache-name: cache-build-folder
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Read node modules from cache
         id: cache-nodemodules
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         env:
           cache-name: cache-install-folder
         with:
@@ -116,6 +116,6 @@ jobs:
           REALM_GRAPHQL_API_KEY: ${{ secrets.REALM_GRAPHQL_API_KEY }}
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Eliminates a Node 16 deprecation warning annotation in our workflows:

> `call-test-build / Build site for testing`
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache/restore@v3, actions/cache/save@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

actions/cache v4: https://github.com/actions/cache?tab=readme-ov-file#v4
> * Updated to node 20
> * Added a save-always flag to save the cache even if a prior step fails
