### PR TITLE
Add migration and fix function to add created_at

### DIFF
--- a/site/gatsby-site/migrations/2024.02.01T20.03.56.set-incidents-submissions-reports-created_at.js
+++ b/site/gatsby-site/migrations/2024.02.01T20.03.56.set-incidents-submissions-reports-created_at.js
@@ -7,7 +7,7 @@ const config = require('../config');
 exports.up = async ({ context: { client } }) => {
   await client.connect();
 
-  // New created_at field on incidents and submissions collections
+  // New created_at field on incidents, reports, submissions collections from production db and history db
   const incidentsCollection = client.db(config.realm.production_db.db_name).collection('incidents');
 
   const submissionsCollection = client

--- a/site/realm/functions/setCreatedAtField.js
+++ b/site/realm/functions/setCreatedAtField.js
@@ -1,9 +1,9 @@
 exports = async function ({ changeEvent, dbName }) {
     const newDocument = changeEvent.fullDocument;
     const collectionName = changeEvent.ns.coll; // Get collection name from the event
-    newDocument.created_at = new Date();
     const collection = context.services.get("mongodb-atlas").db(dbName).collection(collectionName);
     if (!newDocument.created_at) {
+        newDocument.created_at = new Date();
         collection.updateOne({ _id: newDocument._id }, { $set: { created_at: newDocument.created_at } });
     }
 };


### PR DESCRIPTION
- closes #2611 

Before merging this to staging we need to pause the created_at triggers and do a DB restore from PROD to STAGING (because right now all entries on staging have false created_at values due to last restore).

Steps:

1. Disable `onNewEntry_customData`, `onNewEntry_history`, `onNewEntry_aiidprod` and `onNewEntry_translations` triggers.
2. Restore Staging DB from PROD - this will restore entries without `created_at`
3. Verify triggers are still disabled
4. Merge PR
5. Check if triggers are enabled (they should be automatically re-enable when merging the PR)

The collections `incidents`, `submissions` and `reports` should have correct values in `created_at`

### Default `created_at` values
- For `incidents` collection: Incident `date` field
- For `submissions` collection: Submission `date_submitted` field
- For `reports` collection: Report `date_submitted` field
- For `history.incidents` collection: Incident `date` field
- For `history.submissions` collection: Submission `date_submitted` field
- For `history.reports` collection: Report `date_submitted` field