### PR TITLE
Customizable runners on production and staging workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,13 +21,12 @@ on:
       runner-label:
         description: The label of the runner to use
         type: string
-        default: ubuntu-latest
 
 jobs:
   netlify-deploy:
     environment: ${{ inputs.environment }}
     runs-on:
-      labels: ${{ inputs.runner-label }}
+      labels: ${{ inputs.runner-label || 'ubuntu-latest' }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,11 +18,16 @@ on:
         description: The commit SHA to deploy
         type: string
         required: true
+      runner-label:
+        description: The label of the runner to use
+        type: string
+        default: ubuntu-latest
 
 jobs:
   netlify-deploy:
     environment: ${{ inputs.environment }}
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: ${{ inputs.runner-label }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -5,16 +5,16 @@ on:
     branches:
       - master
   schedule:
-    - cron:  '0 6,18 * * *'
+    - cron: "0 6,18 * * *"
 
 jobs:
-
   call-atlas:
     uses: ./.github/workflows/realm.yml
     secrets: inherit
     with:
       sha: ${{ github.sha }}
       environment: production
+      runner-label: ${{ vars.PRODUCTION_RUNNER_LABEL }}
 
   call-test-build:
     uses: ./.github/workflows/test-build.yml
@@ -24,6 +24,7 @@ jobs:
       sha: ${{ github.sha }}
       environment: production
       netlify-context: production
+      runner-label: ${{ vars.PRODUCTION_RUNNER_LABEL }}
 
   call-test:
     uses: ./.github/workflows/test.yml
@@ -32,6 +33,7 @@ jobs:
     with:
       sha: ${{ github.sha }}
       environment: production
+      runner-label: ${{ vars.PRODUCTION_RUNNER_LABEL }}
 
   call-deploy:
     uses: ./.github/workflows/deploy.yml
@@ -43,4 +45,5 @@ jobs:
       environment: production
       sha: ${{ github.sha }}
       netlify-context: production
-      netlify-alias: 
+      netlify-alias:
+      runner-label: ${{ vars.PRODUCTION_RUNNER_LABEL }}

--- a/.github/workflows/realm.yml
+++ b/.github/workflows/realm.yml
@@ -14,12 +14,11 @@ on:
       runner-label:
         description: The label of the runner to use
         type: string
-        default: ubuntu-latest
 
 jobs:
   push:
     runs-on:
-      labels: ${{ inputs.runner-label }}
+      labels: ${{ inputs.runner-label || 'ubuntu-latest' }}
     environment: ${{ inputs.environment }}
     steps:
       - name: Checkout

--- a/.github/workflows/realm.yml
+++ b/.github/workflows/realm.yml
@@ -11,10 +11,15 @@ on:
         description: The commit SHA to deploy
         type: string
         required: true
-
+      runner-label:
+        description: The label of the runner to use
+        type: string
+        default: ubuntu-latest
 jobs:
   push:
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: ${{ inputs.runner-label }}
+
     environment: ${{ inputs.environment }}
     steps:
       - name: Checkout

--- a/.github/workflows/realm.yml
+++ b/.github/workflows/realm.yml
@@ -15,11 +15,11 @@ on:
         description: The label of the runner to use
         type: string
         default: ubuntu-latest
+
 jobs:
   push:
     runs-on:
       labels: ${{ inputs.runner-label }}
-
     environment: ${{ inputs.environment }}
     steps:
       - name: Checkout

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -13,6 +13,7 @@ jobs:
     with:
       sha: ${{ github.sha }}
       environment: staging
+      runner-label: ${{ vars.STAGING_RUNNER_LABEL }}
 
   call-test-build:
     uses: ./.github/workflows/test-build.yml
@@ -22,6 +23,7 @@ jobs:
       sha: ${{ github.sha }}
       environment: staging
       netlify-context: production
+      runner-label: ${{ vars.STAGING_RUNNER_LABEL }}
 
   call-test:
     uses: ./.github/workflows/test.yml
@@ -30,6 +32,7 @@ jobs:
     with:
       sha: ${{ github.sha }}
       environment: staging
+      runner-label: ${{ vars.STAGING_RUNNER_LABEL }}
 
   call-deploy:
     uses: ./.github/workflows/deploy.yml
@@ -42,3 +45,4 @@ jobs:
       sha: ${{ github.sha }}
       netlify-context: production
       netlify-alias: 
+      runner-label: ${{ vars.STAGING_RUNNER_LABEL }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -3,11 +3,11 @@ on:
   workflow_call:
     inputs:
       environment:
-        description: 'The Github environment to load secrets from'
+        description: The Github environment to load secrets from
         type: string
         required: true
       sha:
-        description: 'The SHA of the commit to build'
+        description: The SHA of the commit to build
         type: string
         required: true
       netlify-context:
@@ -18,13 +18,14 @@ on:
         description: The label of the runner to use
         type: string
         required: false
+        default: ubuntu-latest
 
 jobs:
   test:
     name: Build site for testing
     environment: ${{ inputs.environment }}
-    runs-on: 
-      labels: ${{ inputs.runner-label || 'ubuntu-latest' }}
+    runs-on:
+      labels: ${{ inputs.runner-label }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,12 +51,12 @@ jobs:
           runTests: false
           install-command: npm ci
 
-      - name: Use tests specific netlify.toml  
+      - name: Use tests specific netlify.toml
         run: |
           rm -f netlify.toml
           mv tests-netlify.toml netlify.toml
         working-directory: site/gatsby-site
-      
+
       - name: Install Netlify CLI
         run: npm install netlify-cli -g
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -14,12 +14,17 @@ on:
         description: The Netlify context use when building
         type: string
         required: true
+      runner-label:
+        description: The label of the runner to use
+        type: string
+        required: false
 
 jobs:
   test:
     name: Build site for testing
     environment: ${{ inputs.environment }}
-    runs-on: ubuntu-latest
+    runs-on: 
+      labels: ${{ inputs.runner-label || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -17,7 +17,6 @@ on:
       runner-label:
         description: The label of the runner to use
         type: string
-        required: false
 
 jobs:
   test:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -18,14 +18,13 @@ on:
         description: The label of the runner to use
         type: string
         required: false
-        default: ubuntu-latest
 
 jobs:
   test:
     name: Build site for testing
     environment: ${{ inputs.environment }}
     runs-on:
-      labels: ${{ inputs.runner-label }}
+      labels: ${{ inputs.runner-label || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,14 +13,13 @@ on:
       runner-label:
         description: The label of the runner to use
         type: string
-        default: ubuntu-latest
 
 jobs:
   test:
     name: Run Cypress tests
     environment: ${{ inputs.environment }}
     runs-on: 
-      labels: ${{ inputs.runner-label }}
+      labels: ${{ inputs.runner-label || 'ubuntu-latest' }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,17 @@ on:
         description: "The commit SHA to run the tests against"
         type: string
         required: true
+      runner-label:
+        description: The label of the runner to use
+        type: string
+        default: ubuntu-latest
 
 jobs:
   test:
     name: Run Cypress tests
     environment: ${{ inputs.environment }}
-    runs-on: ubuntu-latest
+    runs-on: 
+      labels: ${{ inputs.runner-label }}
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Defines two new variables that let us set specific runner labels for production and staging deployments:

- PRODUCTION_RUNNER_LABEL 
- STAGING_RUNNER_LABEL

By default, `ubuntu-latest` is used, but it can be set to a label (the runner name)


Setting an 8 core box per job shaves some build and deploy minutes but seems to have no effect when running  tests:


Standard 4 core runners (~42 minutes):

<img width="833" alt="image" src="https://github.com/responsible-ai-collaborative/aiid/assets/1172479/51ff1e72-6dcc-472b-9d49-1dd039e90139">


8 cores (~28 minutes):

<img width="792" alt="image" src="https://github.com/responsible-ai-collaborative/aiid/assets/1172479/7482b97d-b82a-4256-913e-4a5732b67c3d">
