### PR TITLE
Re-enable process notifications plugin

### DIFF
--- a/site/gatsby-site/deploy-netlify.toml
+++ b/site/gatsby-site/deploy-netlify.toml
@@ -8,8 +8,8 @@
 [[plugins]]
   package = "/plugins/netlify-plugin-create-admin-user"
 
-# [[plugins]]
-#   package = "/plugins/netlify-plugin-process-notifications"
+[[plugins]]
+  package = "/plugins/netlify-plugin-process-notifications"
 
 [build.processing.html]
   pretty_urls = false

--- a/site/gatsby-site/migrations/2024.02.08T20.32.57.mark-pending-notifications-as-processed.js
+++ b/site/gatsby-site/migrations/2024.02.08T20.32.57.mark-pending-notifications-as-processed.js
@@ -1,0 +1,16 @@
+const config = require('../config');
+
+/** @type {import('umzug').MigrationFn<any>} */
+exports.up = async ({ context: { client } }) => {
+  const db = client.db(config.realm.production_db.db_custom_data);
+
+  const notifications = db.collection('notifications');
+
+  // Mark all pending notifications as processed
+  const result = await notifications.updateMany(
+    { processed: false },
+    { $set: { processed: true } }
+  );
+
+  console.log(`All pending notifications marked as processed. Total: ${result.modifiedCount}`);
+};


### PR DESCRIPTION
This closes https://github.com/responsible-ai-collaborative/aiid/issues/2622

This PR:
1. Run the migration to mark all pending notification as processed
2. Enable notification process plugin

------

2 pending notifications were processed on Staging as part of this PR workflow. Both emails were sent to Pablo.


<img width="622" alt="image" src="https://github.com/responsible-ai-collaborative/aiid/assets/6564809/e84130c5-4596-417b-b5ef-9ede47083773">

------

More details on https://github.com/responsible-ai-collaborative/aiid/actions/runs/7835189491/job/21380053392?pr=2625