### PR TITLE
Add `force-deploy` workflow input to force the deploy even is the tests fail

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -44,7 +44,7 @@ jobs:
 
   call-deploy:
     uses: ./.github/workflows/deploy.yml
-    if: ${{ github.event.inputs.force-deploy }}
+    if: github.event.inputs.force-deploy || success()
     needs: call-test
     secrets: inherit
     permissions:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -7,6 +7,12 @@ on:
   schedule:
     - cron: "0 6,18 * * *"
   workflow_dispatch:
+    inputs:
+      force-deploy:
+        description: "Force deploy"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   call-atlas:
@@ -38,7 +44,7 @@ jobs:
 
   call-deploy:
     uses: ./.github/workflows/deploy.yml
-    if: ${{ vars.FORCE_DEPLOY == 'true' }}
+    if: ${{ github.event.inputs.force-deploy }}
     needs: call-test
     secrets: inherit
     permissions:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -6,6 +6,7 @@ on:
       - master
   schedule:
     - cron: "0 6,18 * * *"
+  workflow_dispatch:
 
 jobs:
   call-atlas:
@@ -37,6 +38,7 @@ jobs:
 
   call-deploy:
     uses: ./.github/workflows/deploy.yml
+    if: ${{ vars.FORCE_DEPLOY == 'true' }}
     needs: call-test
     secrets: inherit
     permissions:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -43,7 +43,7 @@ jobs:
 
   call-deploy:
     uses: ./.github/workflows/deploy.yml
-    if: ${{ github.event.inputs.force-deploy }}
+    if: github.event.inputs.force-deploy || success()
     needs: call-test
     secrets: inherit
     permissions:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - staging
+  workflow_dispatch:
 
 jobs:
 
@@ -36,6 +37,7 @@ jobs:
 
   call-deploy:
     uses: ./.github/workflows/deploy.yml
+    if: ${{ vars.FORCE_DEPLOY == 'true' }}
     needs: call-test
     secrets: inherit
     permissions:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - staging
   workflow_dispatch:
+    inputs:
+      force-deploy:
+        description: "Force deploy"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
 
@@ -37,7 +43,7 @@ jobs:
 
   call-deploy:
     uses: ./.github/workflows/deploy.yml
-    if: ${{ vars.FORCE_DEPLOY == 'true' }}
+    if: ${{ github.event.inputs.force-deploy }}
     needs: call-test
     secrets: inherit
     permissions:


### PR DESCRIPTION
On Staging and Production:

We can now re-run the deploy manually and force deploy even if the tests fail.

![image](https://github.com/responsible-ai-collaborative/aiid/assets/6564809/2dfded80-ec38-4d14-b1d5-2f611935acdb)

Closes https://github.com/responsible-ai-collaborative/aiid/issues/2631