### PR TITLE
Limit the number of reports to translate by filtering by submission date

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,12 @@ The dry run is disabled through an environment variable as follows:
 TRANSLATE_DRY_RUN=false
 ```
 
+In addition to the Dry Run mode, you can also limit the number of reports to translate by setting the following environment variable. This variable sets the date from which the reports will be translated (using the `date_submitted` report field):
+
+```
+TRANSLATE_SUBMISSION_DATE_START=2024-01-01
+```
+
 ### Geocoding
 If the feature you are working on depends on Google's Geocoding API, please add the following environment variable with the appropriate value to your .env file.
 

--- a/site/gatsby-site/src/utils/Translator.js
+++ b/site/gatsby-site/src/utils/Translator.js
@@ -130,6 +130,14 @@ class Translator {
     let reportsQuery = {};
 
     if (this.submissionDateStart) {
+      // Check if the date is valid
+      if (isNaN(Date.parse(this.submissionDateStart))) {
+        const errorMessage = `Translation process error: Invalid date format for TRANSLATE_SUBMISSION_DATE_START env variable: [${this.submissionDateStart}]`;
+
+        this.reporter.error(errorMessage);
+        throw errorMessage;
+      }
+
       this.reporter.log(
         `Translating incident reports submitted after [${this.submissionDateStart}]`
       );


### PR DESCRIPTION
From this https://github.com/responsible-ai-collaborative/aiid/pull/2562#issuecomment-1969214657

This PR:

- Adds `TRANSLATE_SUBMISSION_DATE_START` optional env variable. Variable format `yyyy-mm-dd`
E.g.: `TRANSLATE_SUBMISSION_DATE_START=2024-02-15`
This variable sets the date from which the reports will be translated