### PR TITLE
Only create an 'incident' notification if whitelistead field updated

### DIFF
--- a/site/realm/functions/onIncidentUpdate.js
+++ b/site/realm/functions/onIncidentUpdate.js
@@ -15,7 +15,7 @@ exports = async function (changeEvent) {
   }
 
   const updatedFields = Object.keys(updateDescription.updatedFields);
-  
+
   const incidentId = fullDocument.incident_id;
 
   console.log(`Processing updates on incident ${incidentId}`);

--- a/site/realm/functions/onIncidentUpdate.js
+++ b/site/realm/functions/onIncidentUpdate.js
@@ -14,17 +14,8 @@ exports = async function (changeEvent) {
     return;
   }
 
-  const notificationWhitelistedFields = [`title`, `description`, `date`, `Alleged deployer of AI system`, `Alleged developer of AI system`, `Alleged harmed or nearly harmed parties`, `reports`, `editors`, `editor_notes`];
-
   const updatedFields = Object.keys(updateDescription.updatedFields);
-
-  const willNotifyIncidentUpdate = updatedFields.some(field => notificationWhitelistedFields.includes(field));
   const incidentId = fullDocument.incident_id;
-
-  if (!willNotifyIncidentUpdate) {
-    console.log(`The incident ${incidentId} update will not notify any subscribers, since a non whitelisted field has been updated.`);
-    return;
-  };
 
   console.log(`Processing updates on incident ${incidentId}`);
   console.log('updateDescription', JSON.stringify(updateDescription));

--- a/site/realm/functions/onIncidentUpdate.js
+++ b/site/realm/functions/onIncidentUpdate.js
@@ -14,12 +14,17 @@ exports = async function (changeEvent) {
     return;
   }
 
-  const notificationWhitelistedFields = ['title', 'description', 'date', 'Alleged deployer of AI system', 'Alleged developer of AI system', 'Alleged harmed or nearly harmed parties', 'reports', 'editors', 'editor_notes'];
+  const notificationWhitelistedFields = [`title`, `description`, `date`, `Alleged deployer of AI system`, `Alleged developer of AI system`, `Alleged harmed or nearly harmed parties`, `reports`, `editors`, `editor_notes`];
 
   const updatedFields = Object.keys(updateDescription.updatedFields);
 
   const willNotifyIncidentUpdate = updatedFields.some(field => notificationWhitelistedFields.includes(field));
   const incidentId = fullDocument.incident_id;
+
+  if (!willNotifyIncidentUpdate) {
+    console.log(`The incident ${incidentId} update will not notify any subscribers, since a non whitelisted field has been updated.`);
+    return;
+  };
 
   console.log(`Processing updates on incident ${incidentId}`);
   console.log('updateDescription', JSON.stringify(updateDescription));
@@ -71,16 +76,12 @@ exports = async function (changeEvent) {
         }
       }
       else {
-        if (willNotifyIncidentUpdate) {
-          // If any other Incident field is updated > Insert a pending notification to process in the next build
-          notification = {
-            type: 'incident-updated',
-            incident_id: incidentId,
-            processed: false,
-          };
-        } else {
-          console.log(`The incident ${incidentId} update will not notify any subscribers, since a non whitelisted field has been updated.`);
-        }
+        // If any other Incident field is updated > Insert a pending notification to process in the next build
+        notification = {
+          type: 'incident-updated',
+          incident_id: incidentId,
+          processed: false,
+        };
       }
 
       if (notification) {

--- a/site/realm/functions/onIncidentUpdate.js
+++ b/site/realm/functions/onIncidentUpdate.js
@@ -15,6 +15,7 @@ exports = async function (changeEvent) {
   }
 
   const updatedFields = Object.keys(updateDescription.updatedFields);
+  
   const incidentId = fullDocument.incident_id;
 
   console.log(`Processing updates on incident ${incidentId}`);

--- a/site/realm/functions/onIncidentUpdate.js
+++ b/site/realm/functions/onIncidentUpdate.js
@@ -34,6 +34,8 @@ exports = async function (changeEvent) {
   const reportsCollection = context.services.get('mongodb-atlas').db('aiidprod').collection("reports");
   const subscriptionsToIncident = await subscriptionsCollection.find({ type: 'incident', incident_id: incidentId }).toArray();
 
+  console.log(`There are ${subscriptionsToIncident.length} subscribers to Incident: ${incidentId}`);
+
   // Process subscriptions to Incident updates
   try {
     if (subscriptionsToIncident.length > 0) {

--- a/site/realm/triggers/onIncidentUpdate.json
+++ b/site/realm/triggers/onIncidentUpdate.json
@@ -61,11 +61,6 @@
                     "updateDescription.updatedFields.editors": {
                         "$exists": true
                     }
-                },
-                {
-                    "updateDescription.updatedFields.editor_notes": {
-                        "$exists": true
-                    }
                 }
             ]
         },

--- a/site/realm/triggers/onIncidentUpdate.json
+++ b/site/realm/triggers/onIncidentUpdate.json
@@ -20,6 +20,53 @@
                         "$exists": false
                     }
                 }
+            ],
+            "$or": [
+                {
+                    "updateDescription.updatedFields.title": {
+                        "$exists": true
+                    }
+                },
+                {
+                    "updateDescription.updatedFields.description": {
+                        "$exists": true
+                    }
+                },
+                {
+                    "updateDescription.updatedFields.date": {
+                        "$exists": true
+                    }
+                },
+                {
+                    "updateDescription.updatedFields.\"Alleged deployer of AI system\"": {
+                        "$exists": true
+                    }
+                },
+                {
+                    "updateDescription.updatedFields.\"Alleged developer of AI system\"": {
+                        "$exists": true
+                    }
+                },
+                {
+                    "updateDescription.updatedFields.\"Alleged harmed or nearly harmed parties\"": {
+                        "$exists": true
+                    }
+                },
+                {
+                    "updateDescription.updatedFields.reports": {
+                        "$exists": true
+                    }
+                },
+                {
+                    "updateDescription.updatedFields.editors": {
+                        "$exists": true
+                    }
+                },
+                {
+                    "updateDescription.updatedFields.editor_notes": {
+                        "$exists": true
+                    }
+                }
             ]
         },
         "project": {},


### PR DESCRIPTION
- closes #2676 

Whitelisted fields: `title`, `description`, `date`, `Alleged deployer of AI system`, `Alleged developer of AI system`, `Alleged harmed or nearly harmed parties`, `reports`, `editors` and `editor_notes`

How to test:

- Fork this branch to your repo and update realm
- Manually update an incident from the DB - **Note:** the incident must have an `incident` type subscription
- Check the Realm logs for function `onIncidentUpdate`
- If you've updated a field that is **not** whitelisted you should see the trigger executed in the logs
- If you've update a field that is whitelisted you should **not** see the trigger executed in the logs