### PR TITLE
Fix lookupbyurl endpoint handling of array parameters on Netlify

### DIFF
--- a/site/gatsby-site/cypress/e2e/integration/api/lookupbyurl.cy.js
+++ b/site/gatsby-site/cypress/e2e/integration/api/lookupbyurl.cy.js
@@ -109,7 +109,7 @@ describe('/api/lookupbyurl endpoint', () => {
     expect(req.query.urls).to.deep.eq(['https://url1.com']);
   });
 
-  it('Should left request unchanged', () => {
+  it('Should leave request unchanged', () => {
     const req = { query: { urls: ['https://url1.com'] } };
 
     normalizeRequest(req);

--- a/site/gatsby-site/cypress/e2e/integration/api/lookupbyurl.cy.js
+++ b/site/gatsby-site/cypress/e2e/integration/api/lookupbyurl.cy.js
@@ -1,3 +1,4 @@
+import normalizeRequest from '../../../../src/utils/normalizeRequest';
 import { conditionalIt } from '../../../support/utils';
 
 describe('/api/lookupbyurl endpoint', () => {
@@ -90,5 +91,29 @@ describe('/api/lookupbyurl endpoint', () => {
         ],
       });
     });
+  });
+
+  it('Should normalize request when on Netlify', () => {
+    const req = { query: { urls: 'https://url1.com, https://url2.com' } };
+
+    normalizeRequest(req);
+
+    expect(req.query.urls).to.deep.eq(['https://url1.com', 'https://url2.com']);
+  });
+
+  it('Should normalize request when running on node with only one param', () => {
+    const req = { query: { urls: 'https://url1.com' } };
+
+    normalizeRequest(req);
+
+    expect(req.query.urls).to.deep.eq(['https://url1.com']);
+  });
+
+  it('Should left request unchanged', () => {
+    const req = { query: { urls: ['https://url1.com'] } };
+
+    normalizeRequest(req);
+
+    expect(req.query.urls).to.deep.eq(['https://url1.com']);
   });
 });

--- a/site/gatsby-site/src/api/lookupbyurl.js
+++ b/site/gatsby-site/src/api/lookupbyurl.js
@@ -3,6 +3,7 @@ import siteConfig from '../../config';
 import OpenAPIRequestValidator from 'openapi-request-validator';
 import Cors from 'cors';
 import spec from '../../static/spec.json';
+import normalizeRequest from '../../src/utils/normalizeRequest';
 
 const requestValidator = new OpenAPIRequestValidator({
   parameters: spec.paths['/api/lookupbyurl'].get.parameters,
@@ -20,9 +21,7 @@ const isValidURL = (string) => {
 };
 
 async function handler(req, res) {
-  if (!Array.isArray(req.query.urls)) {
-    req.query.urls = [req.query.urls];
-  }
+  normalizeRequest(req);
 
   const errors = requestValidator.validateRequest(req);
 

--- a/site/gatsby-site/src/api/lookupbyurl.js
+++ b/site/gatsby-site/src/api/lookupbyurl.js
@@ -27,6 +27,9 @@ async function handler(req, res) {
   const errors = requestValidator.validateRequest(req);
 
   if (errors) {
+    console.warn(req.query, errors);
+    rollbar.warning(req.query, errors);
+
     res.status(400).json(errors);
 
     return;

--- a/site/gatsby-site/src/api/lookupbyurl.js
+++ b/site/gatsby-site/src/api/lookupbyurl.js
@@ -28,6 +28,8 @@ async function handler(req, res) {
 
   if (errors) {
     res.status(400).json(errors);
+
+    return;
   }
 
   const urls = req.query.urls;

--- a/site/gatsby-site/src/utils/normalizeRequest.js
+++ b/site/gatsby-site/src/utils/normalizeRequest.js
@@ -1,0 +1,14 @@
+// query strings in a function hosted on Netlify behave differently than on Node
+export default function normalizeRequest(req) {
+  //Netlify concatenates query string parameters sent as array into one string
+
+  if (typeof req.query.urls === 'string') {
+    req.query.urls = req.query.urls.split(', ');
+  }
+
+  // make sure the parameter is always an array even with only one element
+
+  if (!Array.isArray(req.query.urls)) {
+    req.query.urls = [req.query.urls];
+  }
+}


### PR DESCRIPTION
Netlify handles array query parameters differently than Node/Express environments:


`?urls=https://1.com&urls=https://2.com` 

When hosted on Netlify becomes `{query: {urls: 'https://1.com, https://2.com' }}`

When hosted on Node using Express: `{query: {urls: ['https://1.com', 'https://2.com'] }`


https://pr-2694--staging-aiid.netlify.app/api/lookupbyurl?urls=https%3A%2F%2Fjestjs.io%2Fdocs%2Fapi&urls=https%3A%2F%2Fwww.washingtonpost.com%2Ftechnology%2F2024%2F02%2F22%2Fx-twitter-bobbi-althoff-deepfake-porn-viral%2F



