### PR TITLE
Add missing translations in discover page

### DIFF
--- a/site/gatsby-site/i18n/locales/es/translation.json
+++ b/site/gatsby-site/i18n/locales/es/translation.json
@@ -319,5 +319,6 @@
   "Creation Date": "Fecha de Creación",
   "Last modified": "Última modificación",
   "Save": "Guardar",
-  "Language": "Idioma"
+  "Language": "Idioma",
+  "Read the Source": "Leer la Fuente"
 }

--- a/site/gatsby-site/i18n/locales/es/translation.json
+++ b/site/gatsby-site/i18n/locales/es/translation.json
@@ -318,5 +318,6 @@
   "Name": "Nombre",
   "Creation Date": "Fecha de Creación",
   "Last modified": "Última modificación",
-  "Save": "Guardar"
+  "Save": "Guardar",
+  "Language": "Idioma"
 }

--- a/site/gatsby-site/i18n/locales/fr/translation.json
+++ b/site/gatsby-site/i18n/locales/fr/translation.json
@@ -306,5 +306,6 @@
   "Name": "Nom",
   "Creation Date": "Date de création",
   "Last modified": "Dernière modification",
-  "Save": "Enregistrer"
+  "Save": "Enregistrer",
+  "Read the Source": "Lire la source"
 }

--- a/site/gatsby-site/i18n/locales/ja/translation.json
+++ b/site/gatsby-site/i18n/locales/ja/translation.json
@@ -296,5 +296,6 @@
   "More filters": "さらにフィルタ",
   "Fewer filters": "フィルタを減らす",
   "Tags": "タグ",
-  "Language": "言語"
+  "Language": "言語",
+  "Read the Source": "情報源を読む"
 }

--- a/site/gatsby-site/i18n/locales/ja/translation.json
+++ b/site/gatsby-site/i18n/locales/ja/translation.json
@@ -291,5 +291,10 @@
   "Name": "名前",
   "Creation Date": "作成日",
   "Last modified": "最終更新",
-  "Save": "保存"
+  "Save": "保存",
+  "results found": "件の結果が見つかりました",
+  "More filters": "さらにフィルタ",
+  "Fewer filters": "フィルタを減らす",
+  "Tags": "タグ",
+  "Language": "言語"
 }

--- a/site/gatsby-site/src/components/discover/Actions.js
+++ b/site/gatsby-site/src/components/discover/Actions.js
@@ -203,7 +203,7 @@ export default function Actions({ item, toggleFilterByIncidentId = null }) {
             titleId="report-hashtag"
             icon={faHashtag}
             className="fa-hashtag"
-            title="Incident ID"
+            title={t('Incident ID')}
           />
           {item.incident_id}
         </CustomButton>

--- a/site/gatsby-site/src/components/discover/Actions.js
+++ b/site/gatsby-site/src/components/discover/Actions.js
@@ -110,7 +110,7 @@ export default function Actions({ item, toggleFilterByIncidentId = null }) {
           titleId="report-source"
           icon={faNewspaper}
           className="fa-newspaper"
-          title="Read the Source"
+          title={t('Read the Source')}
         />
       </WebArchiveLink>
 


### PR DESCRIPTION
- part of #2709 

Fixes the following
| URL | Text | Missing language | PR |
|------------|-----------|-----------|-----------|
| https://pr-2718--staging-aiid.netlify.app/apps/discover | results found |  | https://github.com/responsible-ai-collaborative/aiid/pull/2718 |
| https://pr-2718--staging-aiid.netlify.app/apps/discover | More filters |  | https://github.com/responsible-ai-collaborative/aiid/pull/2718 |
| https://pr-2718--staging-aiid.netlify.app/apps/discover | Fewer filters |  | https://github.com/responsible-ai-collaborative/aiid/pull/2718 |
| https://pr-2718--staging-aiid.netlify.app/apps/discover | Tags |  | https://github.com/responsible-ai-collaborative/aiid/pull/2718 |
| https://pr-2718--staging-aiid.netlify.app/apps/discover | Language |  | https://github.com/responsible-ai-collaborative/aiid/pull/2718 |
| https://pr-2718--staging-aiid.netlify.app/apps/discover | Incident ID (when hovering incident number on result card) |  | https://github.com/responsible-ai-collaborative/aiid/pull/2718 |
| https://pr-2718--staging-aiid.netlify.app/apps/discover | Read the Source | All | https://github.com/responsible-ai-collaborative/aiid/pull/2718 |