### PR TITLE
Default to "en" doc if prismic doc is missing

### DIFF
--- a/site/gatsby-site/src/templates/prismicDoc.js
+++ b/site/gatsby-site/src/templates/prismicDoc.js
@@ -23,7 +23,7 @@ export const Head = (props) => {
     location: { pathname },
   } = props;
 
-  const doc = props?.data?.doc;
+  const doc = props?.data?.doc || props?.data?.enDoc;
 
   const metaTitle = doc?.data?.metatitle;
 


### PR DESCRIPTION
When prismic document is missing in a certain language, the OG tags were not being completed.
This fixes this by defaulting the the "en" document when missing in another language.