### PR TITLE
Fix taxonomy form crash on add GMF snippet label

### DIFF
--- a/site/gatsby-site/src/components/taxa/TaxonomyForm.js
+++ b/site/gatsby-site/src/components/taxa/TaxonomyForm.js
@@ -398,7 +398,7 @@ function FormField({
     if (field?.complete_from?.current) {
       for (const key of field.complete_from.current) {
         if (formikValues[key]) {
-          combinedAttributedValues.push(formikValues[key]);
+          combinedAttributedValues = combinedAttributedValues.concat(formikValues[key]);
         }
       }
     }


### PR DESCRIPTION
Resolves https://github.com/responsible-ai-collaborative/aiid/issues/2728.