### PR TITLE
Delete dummy translations

### DIFF
--- a/site/gatsby-site/migrations/2024.04.16T20.04.34.delete-dummy-translations.js
+++ b/site/gatsby-site/migrations/2024.04.16T20.04.34.delete-dummy-translations.js
@@ -1,0 +1,24 @@
+const languages = require('../i18n/config.json');
+
+/**
+ *
+ * @param {{context: {client: import('mongodb').MongoClient}}} context
+ */
+
+exports.up = async ({ context: { client } }) => {
+  const db = client.db('translations');
+
+  for (const language of languages) {
+    const name = `reports_${language.code}`;
+
+    console.log(`Deleting dummy translations from ${name}`);
+
+    const translations = db.collection(name);
+
+    const result = await translations.deleteMany({
+      text: /^translated-/,
+    });
+
+    console.log(`Deleted ${result.deletedCount} dummy translations for ${language.code}`);
+  }
+};


### PR DESCRIPTION
Closes #2701 

Result from current production DB:
```
Deleted 0 dummy translations for en
Deleted 202 dummy translations for es
Deleted 202 dummy translations for fr
Deleted 63 dummy translations for ja
```

`TRANSLATE_DRY_RUN` needs to be set explicitly to `false`