### PR TITLE
Re-enable notifications plugin

### DIFF
--- a/site/gatsby-site/deploy-netlify.toml
+++ b/site/gatsby-site/deploy-netlify.toml
@@ -8,8 +8,8 @@
 [[plugins]]
   package = "/plugins/netlify-plugin-create-admin-user"
 
-# [[plugins]]
-#   package = "/plugins/netlify-plugin-process-notifications"
+[[plugins]]
+  package = "/plugins/netlify-plugin-process-notifications"
 
 [build.processing.html]
   pretty_urls = false


### PR DESCRIPTION
closes #2733 

There aren't any notifications with `processed:false,` so there is no need to clear the notifications queue.