### PR TITLE
Fix news digest test

### DIFF
--- a/site/gatsby-site/cypress/e2e/integration/apps/newsdigest.cy.js
+++ b/site/gatsby-site/cypress/e2e/integration/apps/newsdigest.cy.js
@@ -63,6 +63,19 @@ describe('News Digest', () => {
         newsArticles
       );
 
+      cy.conditionalIntercept(
+        '**/graphql',
+        (req) => req.body.operationName == 'UpdateCandidate',
+        'UpdateCandidate',
+        {
+          data: {
+            updateOneCandidate: {
+              url: 'https://dummy.com',
+            },
+          },
+        }
+      );
+
       cy.visit(url);
 
       cy.get('[data-cy="results"] [data-cy="candidate-card"] [data-cy="candidate-dropdown"]', {


### PR DESCRIPTION
Mutation mocks were missing so the requests were hitting the server with mocked data:

```  
1) News Digest
       "after all" hook: generateReport for "Should dismiss and restore items":
     ApolloError: The following error originated from your application code, not from Cypress. It was caused by an unhandled promise rejection.

  > (WriteConflict) WriteConflict error: this operation conflicted with another operation. Please retry your operation or multi-document transaction.

When Cypress detects uncaught errors originating from your application it will automatically fail the current test.

This behavior is configurable, and you can choose to turn this off by listening to the `uncaught:exception` event.
```