### PR TITLE
Limit workflows concurrency to 1 per branch

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -6,6 +6,10 @@ on:
       - staging
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   permissions-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Only applies to deploy previews