### PR TITLE
Increase pool size to reduce ESOCKETTIMEDOUT errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ on:
         type: string
         required: false
         default: ""
+        
+env:
+  UV_THREADPOOL_SIZE: 8
 
 jobs:
   test:


### PR DESCRIPTION
Tests in staging are randomly failing because of timout errors:

```
http://localhost:8000/es/about_apps

We attempted to make an http request to this URL but the request failed without a response.

We received this error at the network level:

  > Error: ESOCKETTIMEDOUT
```

The number of local DNS queries has probably increased now that the graphql queries point to the local API gateway.