### PR TITLE
Use source branch name to create concurrency group name.

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -7,7 +7,7 @@ on:
     types: [opened, synchronize, reopened]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Because we are using the `pull_request_target` event, we have to pull the branch name from `head_ref` instead of `ref`