### PR TITLE
Add intercept for updating incident

### DIFF
--- a/site/gatsby-site/cypress/e2e/integration/cite.cy.js
+++ b/site/gatsby-site/cypress/e2e/integration/cite.cy.js
@@ -851,6 +851,13 @@ describe('Cite pages', () => {
 
     cy.conditionalIntercept(
       '**/graphql',
+      (req) => req.body.operationName == 'UpdateIncident',
+      'updateIncident',
+      updateIncident50
+    );
+
+    cy.conditionalIntercept(
+      '**/graphql',
       (req) =>
         req.body.operationName == 'UpdateIncidents' &&
         req.body.variables.set.editor_similar_incidents == 10,
@@ -881,7 +888,7 @@ describe('Cite pages', () => {
       }
     );
 
-    cy.visit('/incidents/edit/?incident_id=10');
+    cy.visit('/incidents/edit/?incident_id=50');
 
     cy.waitForStableDOM();
 
@@ -905,6 +912,8 @@ describe('Cite pages', () => {
     cy.waitForStableDOM();
 
     cy.get('button[type="submit"]').click();
+
+    cy.wait('@updateIncident', { timeout: 8000 });
 
     cy.wait('@updateSimilarIncidents', { timeout: 30000 }).then((xhr) => {
       expect(xhr.request.body.variables.query).deep.eq({ incident_id_in: [123] });

--- a/site/gatsby-site/cypress/e2e/integration/cite.cy.js
+++ b/site/gatsby-site/cypress/e2e/integration/cite.cy.js
@@ -860,7 +860,7 @@ describe('Cite pages', () => {
       '**/graphql',
       (req) =>
         req.body.operationName == 'UpdateIncidents' &&
-        req.body.variables.set.editor_similar_incidents == 10,
+        req.body.variables.set.editor_similar_incidents == 50,
       'updateSimilarIncidents',
       {
         data: {
@@ -876,7 +876,7 @@ describe('Cite pages', () => {
       '**/graphql',
       (req) =>
         req.body.operationName == 'UpdateIncidents' &&
-        req.body.variables.set.editor_dissimilar_incidents == 10,
+        req.body.variables.set.editor_dissimilar_incidents == 50,
       'updateDissimilarIncidents',
       {
         data: {
@@ -918,14 +918,14 @@ describe('Cite pages', () => {
     cy.wait('@updateSimilarIncidents', { timeout: 30000 }).then((xhr) => {
       expect(xhr.request.body.variables.query).deep.eq({ incident_id_in: [123] });
       expect(xhr.request.body.variables.set).to.deep.eq({
-        editor_similar_incidents: [10],
+        editor_similar_incidents: [50],
       });
     });
 
     cy.wait('@updateDissimilarIncidents', { timeout: 30000 }).then((xhr) => {
       expect(xhr.request.body.variables.query).deep.eq({ incident_id_in: [456] });
       expect(xhr.request.body.variables.set).to.deep.eq({
-        editor_dissimilar_incidents: [10],
+        editor_dissimilar_incidents: [50],
       });
     });
   });


### PR DESCRIPTION
Found an issue on my latest similar/dissimilar test, where an intercept was missing when updating incident