### PR TITLE
Editors should be able to edit incidents

### DIFF
--- a/site/realm/data_sources/mongodb-atlas/translations/reports_ja/rules.json
+++ b/site/realm/data_sources/mongodb-atlas/translations/reports_ja/rules.json
@@ -27,7 +27,7 @@
                 "tags": {}
             },
             "write": true,
-            "insert": false,
+            "insert": true,
             "delete": false,
             "search": true,
             "additional_fields": {}


### PR DESCRIPTION
If a user only has `incident_editor` role, they couldn't edit an incident because of an issue on the realm rule for japanese reports.

This issue needs more tests but I'm going to work on that in another PR, because it involves testing with a `incident_editor` test user which we currently don't have, and I haven't found a way to mock that yet. (view issue #2813)

So in order to fix this quick, I'll work on it separatly.