### PR TITLE
Add login and empty environment Playwright fixtures

### DIFF
--- a/site/gatsby-site/playwright.config.ts
+++ b/site/gatsby-site/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   testDir: './playwright',
   globalTimeout: process.env.CI ? 60 * 60 * 1000 : undefined,
   expect: {
-    timeout: process.env.CI ? 30000 : 10000,
+    timeout: process.env.CI ? 30000 : undefined,
   },
   timeout: process.env.CI ? 60000 : undefined,
   /* Run tests in files in parallel */

--- a/site/gatsby-site/playwright.config.ts
+++ b/site/gatsby-site/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   testDir: './playwright',
   globalTimeout: process.env.CI ? 60 * 60 * 1000 : undefined,
   expect: {
-    timeout: process.env.CI ? 30000 : undefined,
+    timeout: process.env.CI ? 30000 : 10000,
   },
   timeout: process.env.CI ? 60000 : undefined,
   /* Run tests in files in parallel */

--- a/site/gatsby-site/playwright/config.ts
+++ b/site/gatsby-site/playwright/config.ts
@@ -1,4 +1,7 @@
 type ConfigType = {
+    E2E_ADMIN_PASSWORD: string;
+    E2E_ADMIN_USERNAME: string;
+    IS_EMPTY_ENVIRONMENT: string;
     [key: string]: string;
 };
 

--- a/site/gatsby-site/playwright/e2e/cite.spec.ts
+++ b/site/gatsby-site/playwright/e2e/cite.spec.ts
@@ -1,4 +1,4 @@
-import { conditionalIntercept, waitForRequest, query, login, maybeIt, mockDate } from '../utils';
+import { conditionalIntercept, waitForRequest, query, mockDate, test } from '../utils';
 import flaggedReport from '../fixtures/reports/flagged.json';
 import unflaggedReport from '../fixtures/reports/unflagged.json';
 import upsertDuplicateClassification from '../fixtures/classifications/upsertDuplicateClassification.json';
@@ -10,7 +10,7 @@ import incident50 from '../fixtures/incidents/fullIncident50.json';
 import { transformIncidentData, deleteIncidentTypenames } from '../../src/utils/cite';
 import { transformReportData, deleteReportTypenames } from '../../src/utils/reports';
 import { gql } from '@apollo/client';
-import { test, expect } from '@playwright/test';
+import { expect } from '@playwright/test';
 import config from '../config';
 
 test.describe('Cite pages', () => {
@@ -53,8 +53,8 @@ test.describe('Cite pages', () => {
         await page.goto(url);
     });
 
-    maybeIt('Should show an edit link to users with the appropriate role', async ({ page }) => {
-        await login(page, config.E2E_ADMIN_USERNAME, config.E2E_ADMIN_PASSWORD);
+    test('Should show an edit link to users with the appropriate role', async ({ page, login }) => {
+        await login(config.E2E_ADMIN_USERNAME, config.E2E_ADMIN_PASSWORD);
 
         const id = 'r3';
 
@@ -327,8 +327,8 @@ test.describe('Cite pages', () => {
         await expect(page.locator('[data-cy="header-previous-incident-link"]')).toHaveAttribute('href', `/cite/${lastIncidentId - 1}`);
     });
 
-    maybeIt('Should show the edit incident form', async ({ page }) => {
-        await login(page, config.E2E_ADMIN_USERNAME, config.E2E_ADMIN_PASSWORD);
+    test('Should show the edit incident form', async ({ page, login }) => {
+        await login(config.E2E_ADMIN_USERNAME, config.E2E_ADMIN_PASSWORD);
 
         await page.goto(url);
 
@@ -405,8 +405,8 @@ test.describe('Cite pages', () => {
         await expect(page.locator('[data-cy="edit-similar-incidents"]')).not.toBeVisible();
     });
 
-    maybeIt('Should display edit link when logged in as editor', async ({ page }) => {
-        await login(page, config.E2E_ADMIN_USERNAME, config.E2E_ADMIN_PASSWORD);
+    test('Should display edit link when logged in as editor', async ({ page, login }) => {
+        await login(config.E2E_ADMIN_USERNAME, config.E2E_ADMIN_PASSWORD);
 
         await page.goto('/cite/9');
 
@@ -476,8 +476,8 @@ test.describe('Cite pages', () => {
         expect(input).toEqual(expectedIncident);
     });
 
-    maybeIt('Should flag an incident as not related (authenticated)', async ({ page }) => {
-        await login(page, config.E2E_ADMIN_USERNAME, config.E2E_ADMIN_PASSWORD);
+    test('Should flag an incident as not related (authenticated)', async ({ page, login }) => {
+        await login(config.E2E_ADMIN_USERNAME, config.E2E_ADMIN_PASSWORD);
 
         await conditionalIntercept(
             page,
@@ -583,8 +583,8 @@ test.describe('Cite pages', () => {
         await expect(page.locator('head meta[property="twitter:image"]')).toHaveAttribute('content');
     });
 
-    maybeIt('Should subscribe to incident updates (user authenticated)', async ({ page }) => {
-        await login(page, config.E2E_ADMIN_USERNAME, config.E2E_ADMIN_PASSWORD);
+    test('Should subscribe to incident updates (user authenticated)', async ({ page, login }) => {
+        await login(config.E2E_ADMIN_USERNAME, config.E2E_ADMIN_PASSWORD);
 
         await page.goto('/cite/51');
 
@@ -599,9 +599,12 @@ test.describe('Cite pages', () => {
                     },
                 },
             },
+            'upsertSubscription'
         );
 
         await page.locator('button:has-text("Notify Me of Updates")').click();
+
+        await waitForRequest('upsertSubscription');
 
         await expect(page.locator('[data-cy="toast"]')).toBeVisible();
 
@@ -659,8 +662,8 @@ test.describe('Cite pages', () => {
         await expect(page).toHaveURL(new RegExp('/cite/10'));
     });
 
-    maybeIt('Should link similar incidents', async ({ page }) => {
-        await login(page, config.E2E_ADMIN_USERNAME, config.E2E_ADMIN_PASSWORD);
+    test('Should link similar incidents', async ({ page, login }) => {
+        await login(config.E2E_ADMIN_USERNAME, config.E2E_ADMIN_PASSWORD);
 
         await conditionalIntercept(
             page,

--- a/site/gatsby-site/playwright/e2e/discover.spec.ts
+++ b/site/gatsby-site/playwright/e2e/discover.spec.ts
@@ -1,5 +1,5 @@
-import { test, expect, Page, Download } from '@playwright/test';
-import { conditionalIntercept, conditionalIt, mockDate, waitForRequest } from '../utils';
+import { expect, Page, Download } from '@playwright/test';
+import { conditionalIntercept, mockDate, waitForRequest, test } from '../utils';
 import flaggedReport from '../fixtures/reports/flagged.json';
 import unflaggedReport from '../fixtures/reports/unflagged.json';
 import { getUnixTime } from 'date-fns';
@@ -15,7 +15,7 @@ test.describe('The Discover app', () => {
         await page.goto(url);
     });
 
-    conditionalIt(process.env.isEmptyEnvironment === 'true', 'Should display empty state when no incidents are available', async ({ page }) => {
+    test('Should display empty state when no incidents are available', async ({ page, runOnlyOnEmptyEnvironment }) => {
         await page.goto(url);
 
         await expect(async () => {
@@ -27,7 +27,7 @@ test.describe('The Discover app', () => {
         await expect(page.locator('text=Your search returned no results.')).toBeVisible();
     });
 
-    conditionalIt(process.env.isEmptyEnvironment !== 'true', 'Should default to incident reports and show at least 30', async ({ page }) => {
+    test('Should default to incident reports and show at least 30', async ({ page, skipOnEmptyEnvironment }) => {
         await page.goto(url);
 
         await expect(async () => {
@@ -43,7 +43,7 @@ test.describe('The Discover app', () => {
         }).toPass();
     });
 
-    conditionalIt(process.env.isEmptyEnvironment !== 'true', 'Performs a search and filters results', async ({ page }) => {
+    test('Performs a search and filters results', async ({ page, skipOnEmptyEnvironment }) => {
         await page.goto(url);
 
         await page.fill('[data-cy="search-box"] input[placeholder="Type Here"]', 'starbucks');
@@ -59,7 +59,7 @@ test.describe('The Discover app', () => {
         }).toPass();
     });
 
-    conditionalIt(process.env.isEmptyEnvironment !== 'true', 'Filters by incident Id using top filters', async ({ page }) => {
+    test('Filters by incident Id using top filters', async ({ page, skipOnEmptyEnvironment }) => {
         await page.goto(url);
 
         await page.click('[data-cy=expand-filters]');
@@ -80,7 +80,7 @@ test.describe('The Discover app', () => {
         }).toPass();
     });
 
-    conditionalIt(process.env.isEmptyEnvironment !== 'true', 'Filters by Language using top filters', async ({ page }) => {
+    test('Filters by Language using top filters', async ({ page, skipOnEmptyEnvironment }) => {
         await page.goto(url);
 
         await page.click('[data-cy=expand-filters]');
@@ -101,7 +101,7 @@ test.describe('The Discover app', () => {
         }).toPass();
     });
 
-    conditionalIt(process.env.isEmptyEnvironment !== 'true', 'Shows expected filters', async ({ page }) => {
+    test('Shows expected filters', async ({ page, skipOnEmptyEnvironment }) => {
         await page.setViewportSize({ width: 1920, height: 1080 });
         await page.goto(url);
 
@@ -127,7 +127,7 @@ test.describe('The Discover app', () => {
         await expect(page.locator('button:has-text("Submitter")')).toBeVisible();
     });
 
-    conditionalIt(process.env.isEmptyEnvironment !== 'true', 'Filters by Tags using top filters', async ({ page }) => {
+    test('Filters by Tags using top filters', async ({ page, skipOnEmptyEnvironment }) => {
         await page.goto(url);
 
         await page.click('[data-cy=expand-filters]');
@@ -148,7 +148,7 @@ test.describe('The Discover app', () => {
         }).toPass();
     });
 
-    conditionalIt(process.env.isEmptyEnvironment !== 'true', 'Filters by incident Id using card button', async ({ page }) => {
+    test('Filters by incident Id using card button', async ({ page, skipOnEmptyEnvironment }) => {
         await page.goto(url);
 
         await page.click('[data-cy=expand-filters]');
@@ -167,13 +167,14 @@ test.describe('The Discover app', () => {
         }).toPass();
     });
 
-    conditionalIt(!process.env.isEmptyEnvironment, 'Should flag an incident', async ({ page }) => {
+    test('Should flag an incident', async ({ page, skipOnEmptyEnvironment }) => {
 
         await conditionalIntercept(
             page,
             '**/graphql',
             (req) => req.postDataJSON().operationName === 'FindReport',
-            unflaggedReport
+            unflaggedReport,
+            'findReport',
         );
 
 
@@ -245,7 +246,7 @@ test.describe('The Discover app', () => {
         await expect(modal).not.toBeVisible();
     });
 
-    conditionalIt(!process.env.isEmptyEnvironment, 'Opens an archive link', async ({ page }) => {
+    test('Opens an archive link', async ({ page, skipOnEmptyEnvironment }) => {
 
         await page.goto(url);
 
@@ -315,7 +316,7 @@ test.describe('The Discover app', () => {
         await expect(page.locator('button:has-text("Clear Filter")')).toBeDisabled();
     });
 
-    conditionalIt(!process.env.isEmptyEnvironment, 'Should sort by incident date', async ({ page }) => {
+    test('Should sort by incident date', async ({ page, skipOnEmptyEnvironment }) => {
         await page.goto(url);
 
         await page.locator('[data-cy="discover-sort"]').click();
@@ -336,7 +337,7 @@ test.describe('The Discover app', () => {
         }).toPass();
     });
 
-    conditionalIt(!process.env.isEmptyEnvironment, 'Should sort by published date', async ({ page }) => {
+    test('Should sort by published date', async ({ page, skipOnEmptyEnvironment }) => {
         await page.goto(url);
 
         await page.locator('[data-cy="discover-sort"]').click();
@@ -373,7 +374,7 @@ test.describe('The Discover app', () => {
         await expect(page).toHaveURL(/\?is_incident_report=true$/);
     });
 
-    conditionalIt(!process.env.isEmptyEnvironment, 'Should export results to a CSV file', async ({ page }) => {
+    test('Should export results to a CSV file', async ({ page, skipOnEmptyEnvironment }) => {
         await page.goto(url);
 
         await page.locator('[data-cy="search-box"] input[placeholder="Type Here"]').type('starbucks');
@@ -419,7 +420,7 @@ test.describe('The Discover app', () => {
         await expect(page.locator('[data-cy="discover-sort"]')).toHaveText('Newest Incident Date');
     });
 
-    conditionalIt(!process.env.isEmptyEnvironment, 'Should default to the featured incidents', async ({ page }) => {
+    test('Should default to the featured incidents', async ({ page, skipOnEmptyEnvironment }) => {
         await page.goto(url);
 
         for (const item of config.header.search.featured) {
@@ -428,7 +429,7 @@ test.describe('The Discover app', () => {
         }
     });
 
-    conditionalIt(!process.env.isEmptyEnvironment, 'Performs a search and filters results by source', async ({ page }) => {
+    test('Performs a search and filters results by source', async ({ page, skipOnEmptyEnvironment }) => {
         await page.goto(url);
 
         await page.locator('[data-cy="search-box"] input[placeholder="Type Here"]').fill('google');
@@ -454,7 +455,7 @@ test.describe('The Discover app', () => {
         }).toPass();
     });
 
-    conditionalIt(!process.env.isEmptyEnvironment, 'Loads filters based on URL', async ({ page }) => {
+    test('Loads filters based on URL', async ({ page, skipOnEmptyEnvironment }) => {
         await page.goto(url + '?is_incident_report=true&submitters=Anonymous&page=3&classifications=CSETv0%3AIntent%3AAccident');
 
         await expect(page.locator('button:has-text("Submitters") span.badge')).toContainText('1');
@@ -485,7 +486,7 @@ test.describe('The Discover app', () => {
         await expect(page.locator('[data-cy="display-mode-details"]')).toHaveClass(/selected/);
     });
 
-    conditionalIt(!process.env.isEmptyEnvironment, 'Search using the classifications filter', async ({ page }) => {
+    test('Search using the classifications filter', async ({ page, skipOnEmptyEnvironment }) => {
         await page.goto(url);
 
         await page.locator('[data-cy=expand-filters]').click();

--- a/site/gatsby-site/playwright/e2e/submit.spec.ts
+++ b/site/gatsby-site/playwright/e2e/submit.spec.ts
@@ -754,13 +754,6 @@ test.describe('The Submit form', () => {
 
             await conditionalIntercept(
                 page,
-                '**/parseNews**',
-                () => true,
-                parseNews,
-            );
-
-            await conditionalIntercept(
-                page,
                 '**/graphql',
                 (req) => req.postDataJSON().operationName == 'FindIncidentsTitles',
                 {
@@ -960,13 +953,6 @@ test.describe('The Submit form', () => {
 
     test('Should *not* show semantically related reports when the text is under 256 non-space characters', async ({ page }) => {
 
-        await conditionalIntercept(
-            page,
-            '**/parseNews**',
-            () => true,
-            parseNews,
-        );
-
         await page.goto(url);
 
         await setEditorText(
@@ -1129,14 +1115,6 @@ test.describe('The Submit form', () => {
     });
 
     test('Should show a popover', async ({ page }) => {
-
-        await conditionalIntercept(
-            page,
-            '**/parseNews**',
-            () => true,
-            parseNews,
-        );
-
         await page.goto(url);
 
         await page.locator('[data-cy="label-title"]').hover();

--- a/site/gatsby-site/playwright/e2e/submit.spec.ts
+++ b/site/gatsby-site/playwright/e2e/submit.spec.ts
@@ -1321,6 +1321,8 @@ test.describe('The Submit form', () => {
 
         await page.locator('[data-cy="submit-step-2"]').click();
 
+        await waitForRequest('insertSubmission');
+
         await expect(page.locator('.tw-toast:has-text("Report successfully added to review queue. You can see your submission")')).toBeVisible();
 
         const keys = ['url', 'title', 'authors', 'incident_date'];

--- a/site/gatsby-site/playwright/e2e/submit.spec.ts
+++ b/site/gatsby-site/playwright/e2e/submit.spec.ts
@@ -1,8 +1,8 @@
 import parseNews from '../fixtures/api/parseNews.json';
 import semanticallyRelated from '../fixtures/api/semanticallyRelated.json';
 import users from '../fixtures/users/users.json';
-import { conditionalIt, conditionalIntercept, waitForRequest, login, setEditorText } from '../utils';
-import { test, expect } from '@playwright/test';
+import { conditionalIntercept, waitForRequest, setEditorText, test } from '../utils';
+import { expect } from '@playwright/test';
 import config from '../config';
 import probablyRelatedIncidents from '../fixtures/incidents/probablyRelatedIncidents.json';
 import probablyRelatedReports from '../fixtures/reports/probablyRelatedReports.json';
@@ -110,7 +110,7 @@ test.describe('The Submit form', () => {
         await expect(page.locator(':text("Please review. Some data is missing.")')).not.toBeVisible();
     });
 
-    conditionalIt(!process.env.isEmptyEnvironment, 'Should autocomplete entities', async ({ page }) => {
+    test('Should autocomplete entities', async ({ page, skipOnEmptyEnvironment }) => {
 
         await conditionalIntercept(
             page,
@@ -190,287 +190,280 @@ test.describe('The Submit form', () => {
         await expect(page.locator(':text("Please review. Some data is missing.")')).not.toBeVisible();
     });
 
-    conditionalIt(
-        !config.IS_EMPTY_ENVIRONMENT && !!config.E2E_ADMIN_USERNAME && !!config.E2E_ADMIN_PASSWORD,
-        'As editor, should submit a new incident report, adding an incident title and editors.',
-        async ({ page }) => {
-            await login(page, config.E2E_ADMIN_USERNAME, config.E2E_ADMIN_PASSWORD);
+    test('As editor, should submit a new incident report, adding an incident title and editors.', async ({ page, login, skipOnEmptyEnvironment }) => {
+        await login(config.E2E_ADMIN_USERNAME, config.E2E_ADMIN_PASSWORD);
 
-            await conditionalIntercept(
-                page,
-                '**/parseNews**',
-                () => true,
-                parseNews,
-                'parseNews'
-            );
+        await conditionalIntercept(
+            page,
+            '**/parseNews**',
+            () => true,
+            parseNews,
+            'parseNews'
+        );
 
-            await conditionalIntercept(
-                page,
-                '**/graphql',
-                (req) => req.postDataJSON().operationName == 'InsertSubmission',
-                {
-                    data: {
-                        insertOneSubmission: { __typename: 'Submission', _id: '6272f2218933c7a9b512e13b' },
-                    },
+        await conditionalIntercept(
+            page,
+            '**/graphql',
+            (req) => req.postDataJSON().operationName == 'InsertSubmission',
+            {
+                data: {
+                    insertOneSubmission: { __typename: 'Submission', _id: '6272f2218933c7a9b512e13b' },
                 },
-                'insertSubmission'
-            );
+            },
+            'insertSubmission'
+        );
 
-            await conditionalIntercept(
-                page,
-                '**/graphql',
-                (req) => req.postDataJSON().operationName == 'FindUsers',
-                users,
-                'findUsers'
-            );
+        await conditionalIntercept(
+            page,
+            '**/graphql',
+            (req) => req.postDataJSON().operationName == 'FindUsers',
+            users,
+            'findUsers'
+        );
 
-            await conditionalIntercept(
-                page,
-                '**/graphql',
-                (req) => req.postDataJSON().operationName == 'FindSubmissions',
-                { data: { submissions: [] } },
-                'findSubmissions'
-            );
+        await conditionalIntercept(
+            page,
+            '**/graphql',
+            (req) => req.postDataJSON().operationName == 'FindSubmissions',
+            { data: { submissions: [] } },
+            'findSubmissions'
+        );
 
-            await page.goto(url);
+        await page.goto(url);
 
-            await waitForRequest('findSubmissions');
+        await waitForRequest('findSubmissions');
 
-            await page.locator('input[name="url"]').fill(
-                `https://www.arstechnica.com/gadgets/2017/11/youtube-to-crack-down-on-inappropriate-content-masked-as-kids-cartoons/`
-            );
+        await page.locator('input[name="url"]').fill(
+            `https://www.arstechnica.com/gadgets/2017/11/youtube-to-crack-down-on-inappropriate-content-masked-as-kids-cartoons/`
+        );
 
-            await page.locator('button:has-text("Fetch info")').click();
+        await page.locator('button:has-text("Fetch info")').click();
 
-            await waitForRequest('parseNews');
+        await waitForRequest('parseNews');
 
-            await page.locator('[name="incident_date"]').fill('2020-01-01');
+        await page.locator('[name="incident_date"]').fill('2020-01-01');
 
-            await expect(page.locator('.form-has-errors')).not.toBeVisible();
+        await expect(page.locator('.form-has-errors')).not.toBeVisible();
 
-            await page.locator('[data-cy="to-step-2"]').click();
+        await page.locator('[data-cy="to-step-2"]').click();
 
-            await page.locator('[name="language"]').selectOption('Spanish');
+        await page.locator('[name="language"]').selectOption('Spanish');
 
-            await page.locator('[data-cy="to-step-3"]').click();
+        await page.locator('[data-cy="to-step-3"]').click();
 
-            await waitForRequest('findUsers');
+        await waitForRequest('findUsers');
 
-            await page.locator('[name="incident_title"]').fill('Elsagate');
+        await page.locator('[name="incident_title"]').fill('Elsagate');
 
-            await page.locator('[name="description"]').fill('Description');
+        await page.locator('[name="description"]').fill('Description');
 
-            await page.locator('#input-incident_editors').fill('Test');
+        await page.locator('#input-incident_editors').fill('Test');
 
-            await page.locator('[aria-label="Test User"]').click();
+        await page.locator('[aria-label="Test User"]').click();
 
-            await page.locator('[name="tags"]').fill('New Tag');
-            await page.keyboard.press('Enter');
+        await page.locator('[name="tags"]').fill('New Tag');
+        await page.keyboard.press('Enter');
 
-            await page.locator('[name="editor_notes"]').fill('Here are some notes');
+        await page.locator('[name="editor_notes"]').fill('Here are some notes');
 
-            await page.locator('button[type="submit"]').click();
+        await page.locator('button[type="submit"]').click();
 
-            const insertSubmissionRequest = await waitForRequest('insertSubmission');
-            const variables = insertSubmissionRequest.postDataJSON().variables;
+        const insertSubmissionRequest = await waitForRequest('insertSubmission');
+        const variables = insertSubmissionRequest.postDataJSON().variables;
 
-            expect(variables.submission).toMatchObject({
-                title: 'YouTube to crack down on inappropriate content masked as kids’ cartoons',
-                submitters: ['Test User'],
-                authors: ['Valentina Palladino'],
-                incident_date: '2020-01-01',
-                incident_editors: { link: ['63320ce63ec803072c9f529c'] },
-                incident_title: 'Elsagate',
-                date_published: '2017-11-10',
-                image_url:
-                    'https://cdn.arstechnica.net/wp-content/uploads/2017/11/Screen-Shot-2017-11-10-at-9.25.47-AM-760x380.png',
-                tags: ['New Tag'],
-                incident_ids: [],
-                text: "## Recent news stories and blog\n\nposts _highlighted_ the underbelly of YouTube Kids, Google's children-friendly version. This is more text to reach the 256 charactrs minimum, becuase otherwise the text by similarity component doesnt fetch, which surprisingly is way more character that I initially imagined when I started writing this.",
-                plain_text:
-                    "Recent news stories and blog\n\nposts highlighted the underbelly of YouTube Kids, Google's children-friendly version. This is more text to reach the 256 charactrs minimum, becuase otherwise the text by similarity component doesnt fetch, which surprisingly is way more character that I initially imagined when I started writing this.\n",
-                url: `https://www.arstechnica.com/gadgets/2017/11/youtube-to-crack-down-on-inappropriate-content-masked-as-kids-cartoons/`,
-                source_domain: `arstechnica.com`,
-                language: 'es',
-                editor_notes: 'Here are some notes',
-                description: 'Description',
-            });
+        expect(variables.submission).toMatchObject({
+            title: 'YouTube to crack down on inappropriate content masked as kids’ cartoons',
+            submitters: ['Test User'],
+            authors: ['Valentina Palladino'],
+            incident_date: '2020-01-01',
+            incident_editors: { link: ['63320ce63ec803072c9f529c'] },
+            incident_title: 'Elsagate',
+            date_published: '2017-11-10',
+            image_url:
+                'https://cdn.arstechnica.net/wp-content/uploads/2017/11/Screen-Shot-2017-11-10-at-9.25.47-AM-760x380.png',
+            tags: ['New Tag'],
+            incident_ids: [],
+            text: "## Recent news stories and blog\n\nposts _highlighted_ the underbelly of YouTube Kids, Google's children-friendly version. This is more text to reach the 256 charactrs minimum, becuase otherwise the text by similarity component doesnt fetch, which surprisingly is way more character that I initially imagined when I started writing this.",
+            plain_text:
+                "Recent news stories and blog\n\nposts highlighted the underbelly of YouTube Kids, Google's children-friendly version. This is more text to reach the 256 charactrs minimum, becuase otherwise the text by similarity component doesnt fetch, which surprisingly is way more character that I initially imagined when I started writing this.\n",
+            url: `https://www.arstechnica.com/gadgets/2017/11/youtube-to-crack-down-on-inappropriate-content-masked-as-kids-cartoons/`,
+            source_domain: `arstechnica.com`,
+            language: 'es',
+            editor_notes: 'Here are some notes',
+            description: 'Description',
+        });
 
-            expect(variables.submission.user.link).toBeDefined();
+        expect(variables.submission.user.link).toBeDefined();
 
-            await expect(page.locator('.tw-toast:has-text("Report successfully added to review queue")')).toBeVisible();
+        await expect(page.locator('.tw-toast:has-text("Report successfully added to review queue")')).toBeVisible();
 
-            await expect(page.locator('.tw-toast a')).toHaveAttribute('href', '/apps/submitted/');
+        await expect(page.locator('.tw-toast a')).toHaveAttribute('href', '/apps/submitted/');
 
-            await expect(page.locator(':text("Please review. Some data is missing.")')).not.toBeVisible();
-        }
+        await expect(page.locator(':text("Please review. Some data is missing.")')).not.toBeVisible();
+    }
     );
 
-    conditionalIt(
-        !process.env.isEmptyEnvironment,
-        'Should submit a new report linked to incident 1 once all fields are filled properly',
-        async ({ page }) => {
+    test('Should submit a new report linked to incident 1 once all fields are filled properly', async ({ page, login, skipOnEmptyEnvironment }) => {
 
-            await conditionalIntercept(
-                page,
-                '**/parseNews**',
-                () => true,
-                parseNews,
-                'parseNews'
-            );
+        await conditionalIntercept(
+            page,
+            '**/parseNews**',
+            () => true,
+            parseNews,
+            'parseNews'
+        );
 
-            await conditionalIntercept(
-                page,
-                '**/graphql',
-                (req) => req.postDataJSON().operationName == 'FindIncidentsTitles',
-                {
-                    data: {
-                        incidents: [
-                            {
-                                __typename: 'Incident',
-                                incident_id: 1,
-                                title: 'Test title',
-                                date: '2016-03-13',
-                            },
-                        ],
-                    },
+        await conditionalIntercept(
+            page,
+            '**/graphql',
+            (req) => req.postDataJSON().operationName == 'FindIncidentsTitles',
+            {
+                data: {
+                    incidents: [
+                        {
+                            __typename: 'Incident',
+                            incident_id: 1,
+                            title: 'Test title',
+                            date: '2016-03-13',
+                        },
+                    ],
                 },
-                'findIncidentsTitles'
-            );
+            },
+            'findIncidentsTitles'
+        );
 
-            await conditionalIntercept(
-                page,
-                '**/graphql',
-                (req) => req.postDataJSON().operationName == 'InsertSubmission',
-                {
-                    data: {
-                        insertOneSubmission: { __typename: 'Submission', _id: '6272f2218933c7a9b512e13b' },
-                    },
+        await conditionalIntercept(
+            page,
+            '**/graphql',
+            (req) => req.postDataJSON().operationName == 'InsertSubmission',
+            {
+                data: {
+                    insertOneSubmission: { __typename: 'Submission', _id: '6272f2218933c7a9b512e13b' },
                 },
-                'insertSubmission'
-            );
+            },
+            'insertSubmission'
+        );
 
-            await conditionalIntercept(
-                page,
-                '**/semanticallyRelated**',
-                () => true,
-                semanticallyRelated,
-            );
+        await conditionalIntercept(
+            page,
+            '**/semanticallyRelated**',
+            () => true,
+            semanticallyRelated,
+            'semanticallyRelated',
+        );
 
-            await conditionalIntercept(
-                page,
-                '**/graphql',
-                (req) => req.postDataJSON().operationName == 'FindSubmissions',
-                { data: { submissions: [] } },
-                'findInitialSubmissions'
-            );
+        await conditionalIntercept(
+            page,
+            '**/graphql',
+            (req) => req.postDataJSON().operationName == 'FindSubmissions',
+            { data: { submissions: [] } },
+            'findInitialSubmissions'
+        );
 
-            await page.goto(url);
+        await page.goto(url);
 
-            await waitForRequest('findInitialSubmissions');
+        await waitForRequest('findInitialSubmissions');
 
-            await page.locator('input[name="url"]').fill(
-                `https://www.arstechnica.com/gadgets/2017/11/youtube-to-crack-down-on-inappropriate-content-masked-as-kids-cartoons/`
-            );
+        await page.locator('input[name="url"]').fill(
+            `https://www.arstechnica.com/gadgets/2017/11/youtube-to-crack-down-on-inappropriate-content-masked-as-kids-cartoons/`
+        );
 
-            await page.locator('button:has-text("Fetch info")').click();
+        await page.locator('button:has-text("Fetch info")').click();
 
-            await waitForRequest('parseNews');
+        await waitForRequest('parseNews');
 
-            await setEditorText(
-                page,
-                `Recent news stories and blog posts highlighted the underbelly of YouTube Kids, Google's children-friendly version of the wide world of YouTube. While all content on YouTube Kids is meant to be suitable for children under the age of 13, some inappropriate videos using animations, cartoons, and child-focused keywords manage to get past YouTube's algorithms and in front of kids' eyes. Now, YouTube will implement a new policy in an attempt to make the whole of YouTube safer: it will age-restrict inappropriate videos masquerading as children's content in the main YouTube app.`
-            );
+        await setEditorText(
+            page,
+            `Recent news stories and blog posts highlighted the underbelly of YouTube Kids, Google's children-friendly version of the wide world of YouTube. While all content on YouTube Kids is meant to be suitable for children under the age of 13, some inappropriate videos using animations, cartoons, and child-focused keywords manage to get past YouTube's algorithms and in front of kids' eyes. Now, YouTube will implement a new policy in an attempt to make the whole of YouTube safer: it will age-restrict inappropriate videos masquerading as children's content in the main YouTube app.`
+        );
 
-            await page.locator('[data-cy=related-byText] [data-cy=result] [data-cy=set-id]:has-text("#1")').first().click();
+        await page.locator('[data-cy=related-byText] [data-cy=result] [data-cy=set-id]:has-text("#1")').first().click();
 
-            await page.locator('[data-cy=related-byText] [data-cy=result] [data-cy="similar-selector"] [data-cy="similar"]').last().click();
+        await page.locator('[data-cy=related-byText] [data-cy=result] [data-cy="similar-selector"] [data-cy="similar"]').last().click();
 
-            await expect(page.locator('.form-has-errors')).not.toBeVisible();
+        await expect(page.locator('.form-has-errors')).not.toBeVisible();
 
-            await page.locator('[data-cy="to-step-2"]').click();
+        await page.locator('[data-cy="to-step-2"]').click();
 
-            await waitForRequest('findIncidentsTitles');
+        await waitForRequest('findIncidentsTitles');
 
-            await page.locator('[data-cy="to-step-3"]').click();
+        await page.locator('[data-cy="to-step-3"]').click();
 
-            await expect(page.locator('[name="incident_title"]')).not.toBeVisible();
+        await expect(page.locator('[name="incident_title"]')).not.toBeVisible();
 
-            await expect(page.locator('[name="description"]')).not.toBeVisible();
+        await expect(page.locator('[name="description"]')).not.toBeVisible();
 
-            await expect(page.locator('[name="incident_editors"]')).not.toBeVisible();
+        await expect(page.locator('[name="incident_editors"]')).not.toBeVisible();
 
-            await page.locator('[name="tags"]').fill('New Tag');
-            await page.keyboard.press('Enter');
+        await page.locator('[name="tags"]').fill('New Tag');
+        await page.keyboard.press('Enter');
 
-            await page.locator('[name="editor_notes"]').fill('Here are some notes');
+        await page.locator('[name="editor_notes"]').fill('Here are some notes');
 
-            await page.locator('button[type="submit"]').click();
+        await page.locator('button[type="submit"]').click();
 
-            const insertSubmissionRequest = await waitForRequest('insertSubmission');
-            const variables = insertSubmissionRequest.postDataJSON().variables;
+        const insertSubmissionRequest = await waitForRequest('insertSubmission');
+        const variables = insertSubmissionRequest.postDataJSON().variables;
 
-            expect(variables.submission).toMatchObject({
-                title: 'YouTube to crack down on inappropriate content masked as kids’ cartoons',
-                submitters: ['Anonymous'],
-                authors: ['Valentina Palladino'],
-                date_published: '2017-11-10',
-                image_url:
-                    'https://cdn.arstechnica.net/wp-content/uploads/2017/11/Screen-Shot-2017-11-10-at-9.25.47-AM-760x380.png',
-                cloudinary_id:
-                    'reports/cdn.arstechnica.net/wp-content/uploads/2017/11/Screen-Shot-2017-11-10-at-9.25.47-AM-760x380.png',
-                tags: ['New Tag'],
-                incident_ids: [1],
-                url: `https://www.arstechnica.com/gadgets/2017/11/youtube-to-crack-down-on-inappropriate-content-masked-as-kids-cartoons/`,
-                source_domain: `arstechnica.com`,
-                editor_notes: 'Here are some notes',
-            });
-            expect(variables.submission.editor_similar_incidents.length).toBe(1);
+        expect(variables.submission).toMatchObject({
+            title: 'YouTube to crack down on inappropriate content masked as kids’ cartoons',
+            submitters: ['Anonymous'],
+            authors: ['Valentina Palladino'],
+            date_published: '2017-11-10',
+            image_url:
+                'https://cdn.arstechnica.net/wp-content/uploads/2017/11/Screen-Shot-2017-11-10-at-9.25.47-AM-760x380.png',
+            cloudinary_id:
+                'reports/cdn.arstechnica.net/wp-content/uploads/2017/11/Screen-Shot-2017-11-10-at-9.25.47-AM-760x380.png',
+            tags: ['New Tag'],
+            incident_ids: [1],
+            url: `https://www.arstechnica.com/gadgets/2017/11/youtube-to-crack-down-on-inappropriate-content-masked-as-kids-cartoons/`,
+            source_domain: `arstechnica.com`,
+            editor_notes: 'Here are some notes',
+        });
+        expect(variables.submission.editor_similar_incidents.length).toBe(1);
 
-            await expect(page.locator(':text("Report successfully added to review queue")')).toBeVisible();
+        await expect(page.locator(':text("Report successfully added to review queue")')).toBeVisible();
 
-
-
-            await conditionalIntercept(
-                page,
-                '**/graphql',
-                (req) => req.postDataJSON().operationName == 'FindSubmissions',
-                {
-                    data: {
-                        submissions: [
-                            {
-                                __typename: 'Submission',
-                                _id: '6272f2218933c7a9b512e13b',
-                                text: 'Something',
-                                title: 'YouTube to crack down on inappropriate content masked as kids’ cartoons',
-                                submitters: ['Something'],
-                                authors: ['Valentina Palladino'],
-                                incident_date: '2021-09-21',
-                                date_published: '2017-11-10',
-                                image_url:
-                                    'https://cdn.arstechnica.net/wp-content/uploads/2017/11/Screen-Shot-2017-11-10-at-9.25.47-AM-760x380.png',
-                                tags: ['New Tag'],
-                                incident_ids: [1],
-                                url: `https://www.arstechnica.com/gadgets/2017/11/youtube-to-crack-down-on-inappropriate-content-masked-as-kids-cartoons/`,
-                                source_domain: 'arstechnica.com',
-                                language: 'en',
-                                description: 'Something',
-                                editor_notes: 'Here are some notes',
-                            },
-                        ],
-                    },
+        await conditionalIntercept(
+            page,
+            '**/graphql',
+            (req) => req.postDataJSON().operationName == 'FindSubmissions',
+            {
+                data: {
+                    submissions: [
+                        {
+                            __typename: 'Submission',
+                            _id: '6272f2218933c7a9b512e13b',
+                            text: 'Something',
+                            title: 'YouTube to crack down on inappropriate content masked as kids’ cartoons',
+                            submitters: ['Something'],
+                            authors: ['Valentina Palladino'],
+                            incident_date: '2021-09-21',
+                            date_published: '2017-11-10',
+                            image_url:
+                                'https://cdn.arstechnica.net/wp-content/uploads/2017/11/Screen-Shot-2017-11-10-at-9.25.47-AM-760x380.png',
+                            tags: ['New Tag'],
+                            incident_ids: [1],
+                            url: `https://www.arstechnica.com/gadgets/2017/11/youtube-to-crack-down-on-inappropriate-content-masked-as-kids-cartoons/`,
+                            source_domain: 'arstechnica.com',
+                            language: 'en',
+                            description: 'Something',
+                            editor_notes: 'Here are some notes',
+                        },
+                    ],
                 },
-                'findSubmissions'
-            );
+            },
+            'findSubmissions'
+        );
 
-            await login(page, config.E2E_ADMIN_USERNAME, config.E2E_ADMIN_PASSWORD);
+        await login(config.E2E_ADMIN_USERNAME, config.E2E_ADMIN_PASSWORD);
 
-            await page.goto('/apps/submitted');
+        await page.goto('/apps/submitted');
 
-            await waitForRequest('findSubmissions');
+        await waitForRequest('findSubmissions');
 
-            await expect(page.locator('[data-cy="row"]:has-text("YouTube to crack down on inappropriate content masked as kids’ cartoons")')).toBeVisible();
-        }
+        await expect(page.locator('[data-cy="row"]:has-text("YouTube to crack down on inappropriate content masked as kids’ cartoons")')).toBeVisible();
+    }
     );
 
     test('Should show a toast on error when failing to reach parsing endpoint', async ({ page }) => {
@@ -596,266 +589,261 @@ test.describe('The Submit form', () => {
         expect(variables.submission.user).toBeUndefined();
     });
 
-    conditionalIt(
-        !config.isEmptyEnvironment && !!config.E2E_ADMIN_USERNAME && !!config.E2E_ADMIN_PASSWORD,
-        'Should submit a submission and link it to the current user id',
-        async ({ page }) => {
-            await login(page, config.E2E_ADMIN_USERNAME, config.E2E_ADMIN_PASSWORD);
+    test('Should submit a submission and link it to the current user id', async ({ page, login, skipOnEmptyEnvironment }) => {
 
-            const values = {
-                url: 'https://incidentdatabase.ai',
+        await login(config.E2E_ADMIN_USERNAME, config.E2E_ADMIN_PASSWORD);
+
+        const values = {
+            url: 'https://incidentdatabase.ai',
+            title: 'test title',
+            authors: 'test author',
+            incident_date: '2022-01-01',
+            date_published: '2021-01-02',
+            date_downloaded: '2021-01-03',
+            image_url: 'https://incidentdatabase.ai/image.jpg',
+            incident_ids: [1],
+            text: '## Sit quo accusantium \n\n quia **assumenda**. Quod delectus similique labore optio quaease',
+            tags: 'test tag',
+            editor_notes: 'Here are some notes',
+        };
+
+        const params = new URLSearchParams(values);
+
+        await page.route(parserURL, route => route.fulfill({
+            body: JSON.stringify({
                 title: 'test title',
                 authors: 'test author',
-                incident_date: '2022-01-01',
                 date_published: '2021-01-02',
                 date_downloaded: '2021-01-03',
                 image_url: 'https://incidentdatabase.ai/image.jpg',
-                incident_ids: [1],
                 text: '## Sit quo accusantium \n\n quia **assumenda**. Quod delectus similique labore optio quaease',
-                tags: 'test tag',
-                editor_notes: 'Here are some notes',
-            };
+            })
+        }));
 
-            const params = new URLSearchParams(values);
-
-            await page.route(parserURL, route => route.fulfill({
-                body: JSON.stringify({
-                    title: 'test title',
-                    authors: 'test author',
-                    date_published: '2021-01-02',
-                    date_downloaded: '2021-01-03',
-                    image_url: 'https://incidentdatabase.ai/image.jpg',
-                    text: '## Sit quo accusantium \n\n quia **assumenda**. Quod delectus similique labore optio quaease',
-                })
-            }));
-
-            await conditionalIntercept(
-                page,
-                '**/graphql',
-                (req) => req.postDataJSON().operationName == 'InsertSubmission',
-                {
-                    data: {
-                        insertOneSubmission: { __typename: 'Submission', _id: '6272f2218933c7a9b512e13b' },
-                    },
+        await conditionalIntercept(
+            page,
+            '**/graphql',
+            (req) => req.postDataJSON().operationName == 'InsertSubmission',
+            {
+                data: {
+                    insertOneSubmission: { __typename: 'Submission', _id: '6272f2218933c7a9b512e13b' },
                 },
-                'insertSubmission'
-            );
+            },
+            'insertSubmission'
+        );
 
-            await conditionalIntercept(
-                page,
-                '**/graphql',
-                (req) => req.postDataJSON().operationName == 'FindIncidentsTitles',
-                {
-                    data: {
-                        incidents: [
-                            {
-                                __typename: 'Incident',
-                                incident_id: 1,
-                                title: 'Test title',
-                                date: '2022-01-01',
-                            },
-                        ],
-                    },
+        await conditionalIntercept(
+            page,
+            '**/graphql',
+            (req) => req.postDataJSON().operationName == 'FindIncidentsTitles',
+            {
+                data: {
+                    incidents: [
+                        {
+                            __typename: 'Incident',
+                            incident_id: 1,
+                            title: 'Test title',
+                            date: '2022-01-01',
+                        },
+                    ],
                 },
-                'findIncidentsTitles'
-            );
+            },
+            'findIncidentsTitles'
+        );
 
-            await page.goto(url + `?${params.toString()}`);
+        await page.goto(url + `?${params.toString()}`);
 
-            await waitForRequest('findIncidentsTitles');
+        await waitForRequest('findIncidentsTitles');
 
-            await expect(page.locator('.form-has-errors')).not.toBeVisible();
+        await expect(page.locator('.form-has-errors')).not.toBeVisible();
 
-            await page.locator('[data-cy="to-step-2"]').click();
+        await page.locator('[data-cy="to-step-2"]').click();
 
-            await page.locator('[data-cy="to-step-3"]').click();
+        await page.locator('[data-cy="to-step-3"]').click();
 
-            await page.locator('button[type="submit"]').click();
+        await page.locator('button[type="submit"]').click();
 
-            const insertSubmissionRequest = await waitForRequest('insertSubmission');
-            const variables = insertSubmissionRequest.postDataJSON().variables;
+        const insertSubmissionRequest = await waitForRequest('insertSubmission');
+        const variables = insertSubmissionRequest.postDataJSON().variables;
 
-            expect(variables.submission).toMatchObject({
-                ...values,
-                incident_ids: [1],
-                authors: [values.authors],
-                submitters: ['Test User'],
-                tags: [values.tags],
-                plain_text:
-                    'Sit quo accusantium\n\nquia assumenda. Quod delectus similique labore optio quaease\n',
-                source_domain: `incidentdatabase.ai`,
-                cloudinary_id: `reports/incidentdatabase.ai/image.jpg`,
-                editor_notes: 'Here are some notes',
-            });
+        expect(variables.submission).toMatchObject({
+            ...values,
+            incident_ids: [1],
+            authors: [values.authors],
+            submitters: ['Test User'],
+            tags: [values.tags],
+            plain_text:
+                'Sit quo accusantium\n\nquia assumenda. Quod delectus similique labore optio quaease\n',
+            source_domain: `incidentdatabase.ai`,
+            cloudinary_id: `reports/incidentdatabase.ai/image.jpg`,
+            editor_notes: 'Here are some notes',
+        });
 
-            expect(variables.submission.user.link).toBeDefined();
-        }
+        expect(variables.submission.user.link).toBeDefined();
+    }
     );
 
-    conditionalIt(
-        !process.env.isEmptyEnvironment,
-        'Should show a list of related reports',
-        async ({ page }) => {
+    test('Should show a list of related reports', async ({ page, skipOnEmptyEnvironment }) => {
 
-            const relatedReports = {
-                byURL: {
-                    data: {
-                        reports: [
-                            {
-                                __typename: 'Report',
-                                report_number: 1501,
-                                title: 'Zillow to exit its home buying business, cut 25% of staff',
-                                url: 'https://www.cnn.com/2021/11/02/homes/zillow-exit-ibuying-home-business/index.html',
-                            },
-                        ],
-                    },
+        const relatedReports = {
+            byURL: {
+                data: {
+                    reports: [
+                        {
+                            __typename: 'Report',
+                            report_number: 1501,
+                            title: 'Zillow to exit its home buying business, cut 25% of staff',
+                            url: 'https://www.cnn.com/2021/11/02/homes/zillow-exit-ibuying-home-business/index.html',
+                        },
+                    ],
                 },
-                byDatePublished: {
-                    data: {
-                        reports: [
-                            {
-                                __typename: 'Report',
-                                report_number: 810,
-                                title: "Google's Nest Stops Selling Its Smart Smoke Alarm For Now Due To Faulty Feature",
-                                url: 'https://www.forbes.com/sites/aarontilley/2014/04/03/googles-nest-stops-selling-its-smart-smoke-alarm-for-now',
-                            },
-                            {
-                                __typename: 'Report',
-                                report_number: 811,
-                                title: 'Why Nest’s Smoke Detector Fail Is Actually A Win For Everyone',
-                                url: 'https://readwrite.com/2014/04/04/nest-smoke-detector-fail/',
-                            },
-                        ],
-                    },
+            },
+            byDatePublished: {
+                data: {
+                    reports: [
+                        {
+                            __typename: 'Report',
+                            report_number: 810,
+                            title: "Google's Nest Stops Selling Its Smart Smoke Alarm For Now Due To Faulty Feature",
+                            url: 'https://www.forbes.com/sites/aarontilley/2014/04/03/googles-nest-stops-selling-its-smart-smoke-alarm-for-now',
+                        },
+                        {
+                            __typename: 'Report',
+                            report_number: 811,
+                            title: 'Why Nest’s Smoke Detector Fail Is Actually A Win For Everyone',
+                            url: 'https://readwrite.com/2014/04/04/nest-smoke-detector-fail/',
+                        },
+                    ],
                 },
-                byAuthors: {
-                    data: { reports: [] },
+            },
+            byAuthors: {
+                data: { reports: [] },
+            },
+            byIncidentId: {
+                data: {
+                    incidents: [
+                        {
+                            __typename: 'Incident',
+                            incident_id: 1,
+                            title: 'Google’s YouTube Kids App Presents Inappropriate Content',
+                            reports: [
+                                {
+                                    __typename: 'Report',
+                                    report_number: 10,
+                                    title: 'Google’s YouTube Kids App Presents Inappropriate Content',
+                                    url: 'https://www.change.org/p/remove-youtube-kids-app-until-it-eliminates-its-inappropriate-content',
+                                },
+                            ],
+                        },
+                    ],
                 },
-                byIncidentId: {
-                    data: {
-                        incidents: [
-                            {
-                                __typename: 'Incident',
-                                incident_id: 1,
-                                title: 'Google’s YouTube Kids App Presents Inappropriate Content',
-                                reports: [
-                                    {
-                                        __typename: 'Report',
-                                        report_number: 10,
-                                        title: 'Google’s YouTube Kids App Presents Inappropriate Content',
-                                        url: 'https://www.change.org/p/remove-youtube-kids-app-until-it-eliminates-its-inappropriate-content',
-                                    },
-                                ],
-                            },
-                        ],
-                    },
+            },
+        };
+
+        await conditionalIntercept(
+            page,
+            '**/graphql',
+            (req) => req.postDataJSON().operationName == 'FindIncidentsTitles',
+            {
+                data: {
+                    incidents: [
+                        {
+                            __typename: 'Incident',
+                            incident_id: 1,
+                            title: 'Test title',
+                            date: '2022-01-01',
+                        },
+                    ],
                 },
-            };
+            },
+            'findIncidentsTitles'
+        );
 
-            await conditionalIntercept(
-                page,
-                '**/graphql',
-                (req) => req.postDataJSON().operationName == 'FindIncidentsTitles',
-                {
-                    data: {
-                        incidents: [
-                            {
-                                __typename: 'Incident',
-                                incident_id: 1,
-                                title: 'Test title',
-                                date: '2022-01-01',
-                            },
-                        ],
-                    },
-                },
-                'findIncidentsTitles'
-            );
+        await conditionalIntercept(
+            page,
+            '**/graphql',
+            (req) => req.postDataJSON().operationName == 'FindSubmissions',
+            { data: { submissions: [] } },
+            'findSubmissions'
+        );
 
-            await conditionalIntercept(
-                page,
-                '**/graphql',
-                (req) => req.postDataJSON().operationName == 'FindSubmissions',
-                { data: { submissions: [] } },
-                'findSubmissions'
-            );
+        await page.goto(url);
 
-            await page.goto(url);
+        await waitForRequest('findIncidentsTitles');
+        await waitForRequest('findSubmissions');
 
-            await waitForRequest('findIncidentsTitles');
-            await waitForRequest('findSubmissions');
+        await conditionalIntercept(
+            page,
+            '**/graphql',
+            (req) =>
+                req.postDataJSON().operationName == 'ProbablyRelatedReports' &&
+                req.postDataJSON().variables.query?.url_in,
+            relatedReports.byURL,
+            'RelatedReportsByURL'
+        );
 
-            await conditionalIntercept(
-                page,
-                '**/graphql',
-                (req) =>
-                    req.postDataJSON().operationName == 'ProbablyRelatedReports' &&
-                    req.postDataJSON().variables.query?.url_in,
-                relatedReports.byURL,
-                'RelatedReportsByURL'
-            );
+        await conditionalIntercept(
+            page,
+            '**/graphql',
+            (req) =>
+                req.postDataJSON().operationName == 'ProbablyRelatedReports' &&
+                req.postDataJSON().variables.query?.epoch_date_published_gt &&
+                req.postDataJSON().variables.query?.epoch_date_published_lt,
+            relatedReports.byDatePublished,
+            'RelatedReportsByPublishedDate'
+        );
 
-            await conditionalIntercept(
-                page,
-                '**/graphql',
-                (req) =>
-                    req.postDataJSON().operationName == 'ProbablyRelatedReports' &&
-                    req.postDataJSON().variables.query?.epoch_date_published_gt &&
-                    req.postDataJSON().variables.query?.epoch_date_published_lt,
-                relatedReports.byDatePublished,
-                'RelatedReportsByPublishedDate'
-            );
+        await conditionalIntercept(
+            page,
+            '**/graphql',
+            (req) =>
+                req.postDataJSON().operationName == 'ProbablyRelatedReports' &&
+                req.postDataJSON().variables.query?.authors_in?.length,
+            relatedReports.byAuthors,
+            'RelatedReportsByAuthor'
+        );
 
-            await conditionalIntercept(
-                page,
-                '**/graphql',
-                (req) =>
-                    req.postDataJSON().operationName == 'ProbablyRelatedReports' &&
-                    req.postDataJSON().variables.query?.authors_in?.length,
-                relatedReports.byAuthors,
-                'RelatedReportsByAuthor'
-            );
+        const values = {
+            url: 'https://www.cnn.com/2021/11/02/homes/zillow-exit-ibuying-home-business/index.html',
+            authors: 'test author',
+            date_published: '2014-03-30',
+            incident_ids: 1,
+        };
 
-            const values = {
-                url: 'https://www.cnn.com/2021/11/02/homes/zillow-exit-ibuying-home-business/index.html',
-                authors: 'test author',
-                date_published: '2014-03-30',
-                incident_ids: 1,
-            };
-
-            for (const key in values) {
-                if (key == 'incident_ids') {
-                    await page.locator(`input[name="${key}"]`).fill(values[key].toString());
-                    await page.waitForSelector(`[role="option"]`);
-                    await page.locator(`[role="option"]`).first().click();
-                } else {
-                    await page.locator(`input[name="${key}"]`).fill(values[key]);
-                }
+        for (const key in values) {
+            if (key == 'incident_ids') {
+                await page.locator(`input[name="${key}"]`).fill(values[key].toString());
+                await page.waitForSelector(`[role="option"]`);
+                await page.locator(`[role="option"]`).first().click();
+            } else {
+                await page.locator(`input[name="${key}"]`).fill(values[key]);
             }
-
-            await waitForRequest('RelatedReportsByAuthor');
-            await waitForRequest('RelatedReportsByURL');
-            await waitForRequest('RelatedReportsByPublishedDate');
-
-            for (const key of ['byURL', 'byDatePublished']) {
-                const reports =
-                    key == 'byIncidentId'
-                        ? relatedReports[key].data.incidents[0].reports
-                        : relatedReports[key].data.reports;
-
-                const parentLocator = page.locator(`[data-cy="related-${key}"]`);
-
-                await expect(async () => {
-                    await expect(parentLocator.locator('[data-cy="result"]')).toHaveCount(reports.length);
-                }).toPass();
-
-                for (const report of reports) {
-                    await expect(parentLocator.locator('[data-cy="result"]', { hasText: report.title })).toBeVisible();
-                }
-
-            }
-
-            await expect(page.locator(`[data-cy="related-byAuthors"]`).locator('[data-cy="no-related-reports"]')).toHaveText('No related reports found.');
         }
+
+        await waitForRequest('RelatedReportsByAuthor');
+        await waitForRequest('RelatedReportsByURL');
+        await waitForRequest('RelatedReportsByPublishedDate');
+
+        for (const key of ['byURL', 'byDatePublished']) {
+            const reports =
+                key == 'byIncidentId'
+                    ? relatedReports[key].data.incidents[0].reports
+                    : relatedReports[key].data.reports;
+
+            const parentLocator = page.locator(`[data-cy="related-${key}"]`);
+
+            await expect(async () => {
+                await expect(parentLocator.locator('[data-cy="result"]')).toHaveCount(reports.length);
+            }).toPass();
+
+            for (const report of reports) {
+                await expect(parentLocator.locator('[data-cy="result"]', { hasText: report.title })).toBeVisible();
+            }
+
+        }
+
+        await expect(page.locator(`[data-cy="related-byAuthors"]`).locator('[data-cy="no-related-reports"]')).toHaveText('No related reports found.');
+    }
     );
 
     test('Should show a preliminary checks message', async ({ page }) => {
@@ -963,23 +951,20 @@ test.describe('The Submit form', () => {
         await expect(page.locator('[data-cy=related-byText]')).toContainText('Reports must have at least');
     });
 
-    conditionalIt(
-        !process.env.isEmptyEnvironment,
-        'Should *not* show related orphan reports',
-        async ({ page }) => {
-            await page.goto(url);
+    test('Should *not* show related orphan reports', async ({ page, skipOnEmptyEnvironment }) => {
+        await page.goto(url);
 
-            const values = {
-                authors: 'Ashley Belanger',
-            };
+        const values = {
+            authors: 'Ashley Belanger',
+        };
 
-            for (const key in values) {
-                await page.locator(`input[name="${key}"]`).fill(values[key]);
-            }
+        for (const key in values) {
+            await page.locator(`input[name="${key}"]`).fill(values[key]);
+        }
 
-            await expect(page.locator('[data-cy=related-byAuthors] [data-cy=result] a[data-cy=title]:has-text("Thousands scammed by AI voices mimicking loved ones in emergencies")'))
-                .not.toBeVisible();
-        });
+        await expect(page.locator('[data-cy=related-byAuthors] [data-cy=result] a[data-cy=title]:has-text("Thousands scammed by AI voices mimicking loved ones in emergencies")'))
+            .not.toBeVisible();
+    });
 
     test('Should show fallback preview image on initial load', async ({ page }) => {
         const values = {
@@ -1208,6 +1193,7 @@ test.describe('The Submit form', () => {
             '**/parseNews**',
             () => true,
             parseNews,
+            'parseNews',
         );
 
         await conditionalIntercept(
@@ -1389,9 +1375,19 @@ test.describe('The Submit form', () => {
             'findSubmissions'
         );
 
+        await conditionalIntercept(
+            page,
+            '**/parseNews**',
+            () => true,
+            parseNews,
+            'parseNews'
+        );
+
         await page.goto(url + `?${params.toString()}`);
 
         await waitForRequest('findSubmissions');
+
+        await waitForRequest('parseNews');
 
         await expect(page.locator('[data-cy="submit-form-title"]')).toHaveText('New Incident Response');
 
@@ -1696,7 +1692,7 @@ test.describe('The Submit form', () => {
         await expect(page.locator('.tw-toast:has-text("Please verify all information programmatically pulled from the report")')).toBeVisible();
     });
 
-    conditionalIt(!process.env.isEmptyEnvironment, 'Should load from localstorage', async ({ page }) => {
+    test('Should load from localstorage', async ({ page, skipOnEmptyEnvironment }) => {
         const values = {
             url: 'https://incidentdatabase.ai',
             authors: ['test author'],
@@ -1837,7 +1833,7 @@ test.describe('The Submit form', () => {
         }).toPass();
     });
 
-    conditionalIt(!process.env.isEmptyEnvironment, 'Should clear form', async ({ page }) => {
+    test('Should clear form', async ({ page, skipOnEmptyEnvironment }) => {
 
         const values = {
             url: 'https://incidentdatabase.ai',

--- a/site/gatsby-site/playwright/e2e/submit.spec.ts
+++ b/site/gatsby-site/playwright/e2e/submit.spec.ts
@@ -375,6 +375,8 @@ test.describe('The Submit form', () => {
 
             await page.locator('button:has-text("Fetch info")').click();
 
+            await waitForRequest('parseNews');
+
             await setEditorText(
                 page,
                 `Recent news stories and blog posts highlighted the underbelly of YouTube Kids, Google's children-friendly version of the wide world of YouTube. While all content on YouTube Kids is meant to be suitable for children under the age of 13, some inappropriate videos using animations, cartoons, and child-focused keywords manage to get past YouTube's algorithms and in front of kids' eyes. Now, YouTube will implement a new policy in an attempt to make the whole of YouTube safer: it will age-restrict inappropriate videos masquerading as children's content in the main YouTube app.`
@@ -917,14 +919,24 @@ test.describe('The Submit form', () => {
             'RelatedReportsByAuthor'
         );
 
+        await conditionalIntercept(
+            page,
+            '**/graphql',
+            (req) => req.postDataJSON().operationName == 'FindSubmissions',
+            { data: { submissions: [] } },
+            'findSubmissions'
+        );
+
+        await page.goto(url);
+
+        await waitForRequest('findSubmissions');
+
         const values = {
             url: 'https://www.cnn.com/2021/11/02/homes/zillow-exit-ibuying-home-business/index.html',
             authors: 'test author',
             date_published: '2021-01-02',
             incident_ids: '1',
         };
-
-        await page.goto(url);
 
         for (const key in values) {
             if (key == 'incident_ids') {

--- a/site/gatsby-site/playwright/utils.ts
+++ b/site/gatsby-site/playwright/utils.ts
@@ -28,7 +28,7 @@ export async function conditionalIntercept(
     url: string,
     condition: (request: Request) => boolean,
     response,
-    alias: string = null
+    alias: string,
 ) {
     await page.route(url, async (route: Route) => {
 
@@ -45,12 +45,11 @@ export async function conditionalIntercept(
         }
     });
 
-    if (alias) {
+    // every test should wait for every alias it defines, so we are sure no interception is missed
 
-        assert(!waitForRequestMap.has(alias), `Alias ${alias} already exists`);
+    assert(!waitForRequestMap.has(alias), `Alias ${alias} already exists`);
 
-        waitForRequestMap.set(alias, page.waitForRequest((req) => minimatch(req.url(), url) && condition(req)));
-    }
+    waitForRequestMap.set(alias, page.waitForRequest((req) => minimatch(req.url(), url) && condition(req)));
 }
 
 export async function waitForRequest(alias: string) {


### PR DESCRIPTION
This refactors the `conditionalIt` and `maybeIt` functions to work in the Playwright Way ™

Refactors the `login` steps as a fixture, that first checks that the credentials are available and then executes or skips the test accordingly, removing the need for the `maybeIt` function.

I suggest reading this to understand what Playwright means by fixtures:

https://playwright.dev/docs/test-fixtures

cc @pdcp1 @lmcnulty @kepae 