### PR TITLE
Follow link to source incident in TSNE test

### DIFF
--- a/site/gatsby-site/playwright/e2e/tsneVisualization.spec.ts
+++ b/site/gatsby-site/playwright/e2e/tsneVisualization.spec.ts
@@ -22,9 +22,11 @@ test.describe('TSNE visualization page', () => {
 
   });
 
-  // TODO: Fix this test
-  test.skip('Should highlight source incident when one exists', async ({ page, skipOnEmptyEnvironment }) => {
-      await page.goto(url + '?incident=1');
+  test('Should highlight source incident when one exists', async ({ page, skipOnEmptyEnvironment }) => {
+    
+      await page.goto('/cite/1/');
+
+      await page.locator('#similar-incidents:above(a)').last().click();
 
       page.locator('[data-cy="tsne-visualization"] #spatial-incident-1').dispatchEvent('mouseover');
 
@@ -33,7 +35,6 @@ test.describe('TSNE visualization page', () => {
           '[data-cy="tsne-visualization"] [data-cy="tsne-plotpoint"].current'
         )
       ).toBeVisible();
-
   });
 
   test('Incident card should show title', async ({ page, skipOnEmptyEnvironment }) => {


### PR DESCRIPTION
Weirdly, the `.current` class only appears when we actually navigate from the citation page to the tsne visualization; it doesn't appear if we load the visualization with `?incident=` directly. I think this is a result of static rendering. This updates the test to follow the link from the citation page.