### PR TITLE
Taxonomy page looks / readability

### DIFF
--- a/site/gatsby-site/src/components/taxa/FacetTaxonomyPage.js
+++ b/site/gatsby-site/src/components/taxa/FacetTaxonomyPage.js
@@ -51,6 +51,7 @@ export default function FacetTaxonomyPage(props) {
         rehypePlugins={[rehypeRaw]}
         className="
           taxonomy-markdown 
+          prose
           [&_.footnotes]:mt-6
           [&_.footnotes]:pt-4
           [&_.footnotes]:pl-4
@@ -64,7 +65,7 @@ export default function FacetTaxonomyPage(props) {
       <h2 className="heading1">
         <Trans>Taxonomy Fields</Trans>
       </h2>
-      <div className="flex gap-9 flex-col">
+      <div className="flex gap-9 flex-col max-w-prose text-[1rem]">
         {sortedFieldsArray
           .filter((f) => f.short_name !== 'Publish')
           .map(({ long_name, long_description, permitted_values, short_name, instant_facet }) => (
@@ -190,7 +191,7 @@ const FacetList = ({ namespace, instant_facet, short_name, stats, geocodes }) =>
             <Trans>{`Show ${showAllStats ? 'fewer stats' : 'more stats'}`}</Trans>
           </Button>
         )}
-        <div className="my-3 h-[320px]">
+        <div className="my-3 h-[500px] [&>div]:h-full">
           {short_name == 'Location' ? (
             <LocationMap
               data={{ columns: sortedStatsArray.map((a) => [a.item, a.value]) }}


### PR DESCRIPTION
Resolves https://github.com/responsible-ai-collaborative/aiid/issues/2913.

Narrows the text width with prose styling.

![image](https://github.com/responsible-ai-collaborative/aiid/assets/25443411/2706e0bf-f95c-498d-9b58-59710174e0a4)

Also makes the charts bigger and aligned with the text width.

![image](https://github.com/responsible-ai-collaborative/aiid/assets/25443411/06d3463d-3336-42ce-a2ff-50c9ac2e001a)
