### PR TITLE
Wait for response to make sure route interception is executed

### DIFF
--- a/site/gatsby-site/playwright/utils.ts
+++ b/site/gatsby-site/playwright/utils.ts
@@ -95,7 +95,11 @@ export async function conditionalIntercept(
 
     assert(!waitForRequestMap.has(alias), `Alias ${alias} already exists`);
 
-    waitForRequestMap.set(alias, page.waitForRequest((req) => minimatch(req.url(), url) && condition(req)));
+    const promise = page
+        .waitForResponse((res) => minimatch(res.request().url(), url) && condition(res.request()))
+        .then((response) => response.request());
+
+    waitForRequestMap.set(alias, promise);
 }
 
 export async function waitForRequest(alias: string) {


### PR DESCRIPTION
Some mocks weren't working because of a race condition where the `page.route` calls were being cleaned up by Playwright before the mock was executed, allowing requests to hit the server.