### PR TITLE
[Hotfix] hide landing page carousel on mobile screens

### DIFF
--- a/site/gatsby-site/src/templates/landingPage.js
+++ b/site/gatsby-site/src/templates/landingPage.js
@@ -81,7 +81,8 @@ const LandingPage = (props) => {
 
         {latestIncidents.length > 0 && (
           <div className="mb-5 md:mb-10">
-            <div>
+            {/* https://github.com/responsible-ai-collaborative/aiid/issues/2956 */}
+            <div className="hidden md:block">
               <LatestReports latestIncidents={latestIncidentsTranslated} />
             </div>
           </div>


### PR DESCRIPTION
Address ongoing #2956. Hide the carousel container on mobile. Doesn't fix all layout issues but triages the worst behavior.

![Screenshot 2024-07-08 at 11 01 34 PM](https://github.com/responsible-ai-collaborative/aiid/assets/4238598/98e97f94-3217-4b9c-ad73-ac21c4424c58)


![Screenshot 2024-07-08 at 10 59 01 PM](https://github.com/responsible-ai-collaborative/aiid/assets/4238598/70c5db27-0179-44f9-b590-d850e0bf7a19)

![Screenshot 2024-07-08 at 10 58 57 PM](https://github.com/responsible-ai-collaborative/aiid/assets/4238598/22fd4725-4757-4612-8eee-bf0af5090f97)
