### PR TITLE
Add full e2e workflows to production and staging

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -77,8 +77,8 @@ jobs:
     needs: [cache-modifier]
     secrets: inherit
     with:
-      sha: ${{ github.event.pull_request.head.sha }}
-      environment: staging
+      sha: ${{ github.sha }}
+      environment: production
       runner-label: ${{ vars.PREVIEW_RUNNER_LABEL }}
 
   call-deploy:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -71,6 +71,16 @@ jobs:
       environment: production
       runner-label: ${{ vars.PRODUCTION_RUNNER_LABEL }}
 
+  call-test-playwright-full:
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/test-playwright-full.yml
+    needs: [cache-modifier]
+    secrets: inherit
+    with:
+      sha: ${{ github.event.pull_request.head.sha }}
+      environment: staging
+      runner-label: ${{ vars.PREVIEW_RUNNER_LABEL }}
+
   call-deploy:
     if: (inputs.force-deploy == true || success()) && !cancelled()
     uses: ./.github/workflows/deploy.yml

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -76,7 +76,7 @@ jobs:
     needs: [cache-modifier]
     secrets: inherit
     with:
-      sha: ${{ github.event.pull_request.head.sha }}
+      sha: ${{ github.sha }}
       environment: staging
       runner-label: ${{ vars.PREVIEW_RUNNER_LABEL }}
 

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -12,10 +12,10 @@ on:
         default: true
         type: boolean
       force-deploy:
-          description: "Deploy even if tests fail"
-          required: true
-          default: false
-          type: boolean
+        description: "Deploy even if tests fail"
+        required: true
+        default: false
+        type: boolean
 
 jobs:
   cache-modifier:
@@ -59,8 +59,8 @@ jobs:
       sha: ${{ github.sha }}
       environment: staging
       runner-label: ${{ vars.STAGING_RUNNER_LABEL }}
-      
-  call-test: 
+
+  call-test:
     uses: ./.github/workflows/test.yml
     needs: [cache-modifier, call-test-build]
     secrets: inherit
@@ -69,6 +69,16 @@ jobs:
       environment: staging
       runner-label: ${{ vars.STAGING_RUNNER_LABEL }}
       cache-modifier: ${{ needs.cache-modifier.outputs.cache-modifier  }}
+
+  call-test-playwright-full:
+    if: ${{ !failure() && !cancelled() }}
+    uses: ./.github/workflows/test-playwright-full.yml
+    needs: [cache-modifier]
+    secrets: inherit
+    with:
+      sha: ${{ github.event.pull_request.head.sha }}
+      environment: staging
+      runner-label: ${{ vars.PREVIEW_RUNNER_LABEL }}
 
   call-deploy:
     if: (inputs.force-deploy == true || success()) && !cancelled()


### PR DESCRIPTION
Should probably work on better names later, but this should be enough to get them running here: https://github.com/responsible-ai-collaborative/aiid/actions/workflows/staging.yml (without having to get them on `main`.)