### PR TITLE
remove option `sizeByPixelDensity` to address warning

### DIFF
--- a/site/gatsby-site/gatsby-config.js
+++ b/site/gatsby-site/gatsby-config.js
@@ -32,7 +32,6 @@ const plugins = [
           resolve: 'gatsby-remark-images',
           options: {
             maxWidth: 1035,
-            sizeByPixelDensity: true,
           },
         },
         {


### PR DESCRIPTION
Addresses build warning:
```
Warning: there are unknown plugin options for "gatsby-remark-images": sizeByPixelDensity
```
The option has been removed for some time now: https://github.com/gatsbyjs/gatsby/issues/20262