### PR TITLE
Improve all taxonomies (CSET and GMF) CSV export

### DIFF
--- a/site/db-backup/bin/taxonomy_csv_export.py
+++ b/site/db-backup/bin/taxonomy_csv_export.py
@@ -1,0 +1,72 @@
+import sys
+import json
+import csv
+import os
+
+def taxonomy_csv_export(namespace, taxa_file, classification_file, target_folder):
+
+    print(f"Processing namespace '{namespace}'...")
+
+    # Read data from the JSON file for "taxa"
+    with open(taxa_file, 'r', encoding='utf-8') as f:
+        taxa_items = json.load(f)
+        
+        # Filter taxa items for the current namespace
+        filtered_taxa_items = [item for item in taxa_items if item['namespace'] == namespace]
+        
+        # Get the list of fields from the first filtered item
+        field_list = [{'short_name': field['short_name']} for field in filtered_taxa_items[0]['field_list']]
+
+    # Read data from the JSON file for "classifications"
+    with open(classification_file, 'r', encoding='utf-8') as f:
+        classification_items = json.load(f)
+    
+    # Prepare CSV headers from "field_list.short_name"
+    headers = [field['short_name'] for field in field_list]
+
+    # Ensure the target folder exists
+    os.makedirs(target_folder, exist_ok=True)
+
+    # Create a CSV file for the "namespace" in the target folder
+    csv_filename = os.path.join(target_folder, f"classifications_{namespace}.csv")
+    
+    with open(csv_filename, mode='w', newline='', encoding='utf-8') as csvfile:
+        writer = csv.writer(csvfile)
+        
+        # Write the header row to the CSV
+        writer.writerow(['Namespace', 'Incident ID', 'Published'] + headers)
+        
+        # Iterate over the "classification" documents and write rows to the CSV
+        for classification_item in classification_items:
+            if classification_item['namespace'] != namespace:
+                continue
+            
+            incidents = classification_item.get('incidents', [])
+            incident_value = incidents[0] if incidents else ''
+            
+            attributes = classification_item['attributes']
+
+            published_value = classification_item.get('publish', '')
+            
+            # Create a dictionary to quickly access attribute values by "short_name"
+            attribute_dict = {attr['short_name']: json.loads(attr['value_json']) if 'value_json' in attr else '' for attr in attributes}
+            
+            # Get the corresponding values for each header
+            row = [attribute_dict.get(header, '') for header in headers]
+            
+            # Write the row to the CSV file
+            writer.writerow([namespace, incident_value, published_value] + row)
+
+    print(f"CSV file '{csv_filename}' generated successfully.")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 5:
+        print("Usage: python process_namespace.py <namespace> <taxa_file> <classification_file> <target_folder>")
+        sys.exit(1)
+
+    namespace = sys.argv[1]
+    taxa_file = sys.argv[2]
+    classification_file = sys.argv[3]
+    target_folder = sys.argv[4]
+
+    taxonomy_csv_export(namespace, taxa_file, classification_file, target_folder)

--- a/site/db-backup/bin/taxonomy_csv_export.py
+++ b/site/db-backup/bin/taxonomy_csv_export.py
@@ -49,7 +49,12 @@ def taxonomy_csv_export(namespace, taxa_file, classification_file, target_folder
             published_value = classification_item.get('publish', '')
             
             # Create a dictionary to quickly access attribute values by "short_name"
-            attribute_dict = {attr['short_name']: json.loads(attr['value_json']) if 'value_json' in attr else '' for attr in attributes}
+            attribute_dict = {}
+            for attr in attributes:
+                value = json.loads(attr['value_json']) if 'value_json' in attr else ''
+                if isinstance(value, list):
+                    value = ', '.join(map(str, value))
+                attribute_dict[attr['short_name']] = value
             
             # Get the corresponding values for each header
             row = [attribute_dict.get(header, '') for header in headers]


### PR DESCRIPTION
Part of https://github.com/responsible-ai-collaborative/aiid/issues/3023
On top of https://github.com/responsible-ai-collaborative/aiid/pull/3030

This PR changes the way that we export taxonomies CSV files.
Now it iterates through all taxonomies on the taxa collection, dynamically generating a CSV file based on the fields of each taxonomy and the data from the classifications collection.

Based on the current data, it will produce these 5 CSV files:

- classifications_CSETv0.csv
- classifications_CSETv1.csv
- classifications_CSETv1_Annotator-1.csv
- classifications_CSETv1_Annotator-2.csv
- classifications_CSETv1_Annotator-3.csv
- classifications_GMF.csv

## Testing

To test these changes, please go to the Pablo's fork repository and run the GitHub Action manually:
https://github.com/pdcp1/aiid/actions/workflows/db-backup.yml

The backup file will be uploaded to a public test Cloudflare bucket account. To access the backup file use the public URL `https://pub-daddb16dc28841779b83690f75eb5c57.r2.dev/[backup file]`
i.e.: https://pub-daddb16dc28841779b83690f75eb5c57.r2.dev/backup-20240905204113.tar.bz2