### PR TITLE
Add `--output playwright-report-full` path to Playwright `e2e-full` tests

### DIFF
--- a/.github/workflows/test-playwright-full.yml
+++ b/.github/workflows/test-playwright-full.yml
@@ -165,7 +165,7 @@ jobs:
           merge-multiple: true
 
       - name: Merge into HTML Report
-        run: npx playwright merge-reports --reporter html ./all-blob-reports
+        run: npx playwright merge-reports --reporter html --output playwright-report-full ./all-blob-reports
 
       - name: Upload HTML report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This PR fixes the `Warning: No files were found with the provided path: playwright-report-full. No artifacts will be uploaded.` on the [call-test-playwright-full / merge-reports](https://github.com/responsible-ai-collaborative/aiid/actions/runs/10935338833/job/30357203329#logs) job