### PR TITLE
Mark all pending notifications as processed

### DIFF
--- a/site/gatsby-site/migrations/2024.09.19T18.12.21.mark-pending-notifications-as-processed.js
+++ b/site/gatsby-site/migrations/2024.09.19T18.12.21.mark-pending-notifications-as-processed.js
@@ -1,0 +1,16 @@
+const config = require('../config');
+
+/** @type {import('umzug').MigrationFn<any>} */
+exports.up = async ({ context: { client } }) => {
+  const db = client.db(config.realm.production_db.db_custom_data);
+
+  const notifications = db.collection('notifications');
+
+  // Mark all pending notifications as processed
+  const result = await notifications.updateMany(
+    { processed: false },
+    { $set: { processed: true } }
+  );
+
+  console.log(`All pending notifications marked as processed. Total: ${result.modifiedCount}`);
+};


### PR DESCRIPTION
We should merge this PR into the production right before https://github.com/responsible-ai-collaborative/aiid/pull/3104 to avoid sending all the old pending email notifications at once.