### PR TITLE
Change Playwright reports' names

### DIFF
--- a/.github/workflows/test-playwright-full.yml
+++ b/.github/workflows/test-playwright-full.yml
@@ -173,6 +173,6 @@ jobs:
       - name: Upload HTML report
         uses: actions/upload-artifact@v4
         with:
-          name: html-report--attempt-${{ github.run_attempt }}
+          name: playwright-report-full-attempt-${{ github.run_attempt }}
           path: playwright-report-full
           retention-days: 7

--- a/.github/workflows/test-playwright.yml
+++ b/.github/workflows/test-playwright.yml
@@ -117,6 +117,6 @@ jobs:
       - name: Upload HTML report
         uses: actions/upload-artifact@v4
         with:
-          name: html-report--attempt-${{ github.run_attempt }}
+          name: playwright-report-attempt-${{ github.run_attempt }}
           path: playwright-report
           retention-days: 7


### PR DESCRIPTION
This fixes https://github.com/responsible-ai-collaborative/aiid/actions/runs/11000236884/job/30543812633

<img width="1239" alt="image" src="https://github.com/user-attachments/assets/3cfdf100-bb95-46a8-8b9f-7e5d41fc2c82">


Working run https://github.com/pdcp1/aiid/actions/runs/11001588645