### PR TITLE
Prevent backups page creation from crashing if empty bucket

### DIFF
--- a/site/gatsby-site/page-creators/createBackupsPage.js
+++ b/site/gatsby-site/page-creators/createBackupsPage.js
@@ -19,7 +19,7 @@ const createBackupsPage = (_, createPage) => {
       resolve(
         S3.send(new ListObjectsV2Command({ Bucket: config.cloudflareR2.bucketName })).then(
           (result) => {
-            const backups = result.Contents;
+            const backups = result.Contents ?? [];
 
             backups.sort(function (a, b) {
               if (a.Key < b.Key) {


### PR DESCRIPTION
It just happened to me on a new Cloud Flare account it will happen to anyone setting up a new environment.