### PR TITLE
Only start web server on CI

### DIFF
--- a/site/gatsby-site/playwright.config.ts
+++ b/site/gatsby-site/playwright.config.ts
@@ -74,9 +74,9 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  webServer: {
+  webServer: process.env.Ci ? {
     command: 'npx -y pm2 start npm --name "web-server" -- run serve && npx pm2 logs "web-server"',
     url: 'http://localhost:8000',
     reuseExistingServer: !process.env.CI,
-  },
+  } : undefined,
 });

--- a/site/gatsby-site/playwright.config.ts
+++ b/site/gatsby-site/playwright.config.ts
@@ -74,7 +74,7 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  webServer: process.env.Ci ? {
+  webServer: process.env.CI ? {
     command: 'npx -y pm2 start npm --name "web-server" -- run serve && npx pm2 logs "web-server"',
     url: 'http://localhost:8000',
     reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
This prevents Playwright from starting a web server during local development.