### PR TITLE
Set max width for carousel and citation page content

### DIFF
--- a/site/gatsby-site/src/templates/citeTemplate.js
+++ b/site/gatsby-site/src/templates/citeTemplate.js
@@ -232,8 +232,8 @@ function CiteTemplate({
           </div>
         </div>
       </div>
-      <div className="flex mt-6">
-        <div className="shrink-1">
+      <div className="flex mt-6 justify-between">
+        <div className="shrink-1 max-w-screen-xl">
           <Row>
             <Col>
               <div>
@@ -350,7 +350,7 @@ function CiteTemplate({
 
             <Row className="mt-6">
               <Col>
-                <Card>
+                <Card className="max-w-3xl mx-auto">
                   <ImageCarousel nodes={sortedReports} />
                 </Card>
               </Col>


### PR DESCRIPTION
Resolves https://github.com/responsible-ai-collaborative/aiid/issues/3151

![image](https://github.com/user-attachments/assets/001df30e-a9e0-4379-b9fd-842318c615c6)

Now the main body content is limited to 1280px, and the carousel to 768px.