### PR TITLE
Fix fallback blog page without translation

### DIFF
--- a/site/gatsby-site/playwright/e2e/translationBadge.spec.ts
+++ b/site/gatsby-site/playwright/e2e/translationBadge.spec.ts
@@ -9,6 +9,13 @@ test.describe('Translation Badges', () => {
     await expect(page.locator('a', { hasText: 'Ver Original' })).toHaveAttribute('href', '/blog/using-ai-to-connect-ai-incidents/');
   });
 
+  test('Should be visible on Prismic blog post', async ({ page }) => {
+    await page.goto('/es/blog/ai-incident-journalism-analysis');
+    await expect(page.locator('[data-cy="translation-badge"]').getByText('Traducido por IA')).toBeVisible();
+    await expect(page.locator('a', { hasText: 'Ver Original' })).toBeVisible();
+    await expect(page.locator('a', { hasText: 'Ver Original' })).toHaveAttribute('href', '/blog/ai-incident-journalism-analysis');
+  });
+
   test('Should be visible on the discover app', async ({ page, skipOnEmptyEnvironment }) => {
     await page.goto('/es/apps/discover?display=details&incident_id=1&page=1&source_domain=today.com');
     await expect(page.locator('[data-cy="5d34b8c29ced494f010ed45c"]').locator('[data-cy="translation-badge"]').getByText('Traducido por IA')).toBeVisible();

--- a/site/gatsby-site/playwright/e2e/translationBadge.spec.ts
+++ b/site/gatsby-site/playwright/e2e/translationBadge.spec.ts
@@ -9,11 +9,10 @@ test.describe('Translation Badges', () => {
     await expect(page.locator('a', { hasText: 'Ver Original' })).toHaveAttribute('href', '/blog/using-ai-to-connect-ai-incidents/');
   });
 
-  test('Should be visible on Prismic blog post', async ({ page }) => {
+  test('Should not be visible on Prismic blog post without translation', async ({ page }) => {
     await page.goto('/es/blog/ai-incident-journalism-analysis');
-    await expect(page.locator('[data-cy="translation-badge"]').getByText('Traducido por IA')).toBeVisible();
-    await expect(page.locator('a', { hasText: 'Ver Original' })).toBeVisible();
-    await expect(page.locator('a', { hasText: 'Ver Original' })).toHaveAttribute('href', '/blog/ai-incident-journalism-analysis');
+    await expect(page.locator('[data-cy="translation-badge"]').getByText('Traducido por IA')).not.toBeVisible();
+    await expect(page.locator('a', { hasText: 'Ver Original' })).not.toBeVisible();
   });
 
   test('Should be visible on the discover app', async ({ page, skipOnEmptyEnvironment }) => {

--- a/site/gatsby-site/src/components/blog/PrismicBlogPost.js
+++ b/site/gatsby-site/src/components/blog/PrismicBlogPost.js
@@ -61,7 +61,7 @@ const PrismicBlogPost = ({ post, location }) => {
         {post.data.aitranslated && (
           <>
             <TranslationBadge className="ml-2" />
-            <Link className="ml-2" to={post.data.slug}>
+            <Link className="mx-2" to={`/blog/${post.data.slug}`}>
               <Trans>View Original</Trans>
             </Link>
           </>

--- a/site/gatsby-site/src/templates/post.js
+++ b/site/gatsby-site/src/templates/post.js
@@ -59,7 +59,7 @@ export default function Post(props) {
         {mdx.frontmatter.aiTranslated && (
           <>
             <TranslationBadge className="ml-2" />
-            <Link className="ml-2" to={mdx.frontmatter.slug}>
+            <Link className="mx-2" to={mdx.frontmatter.slug}>
               <Trans>View Original</Trans>
             </Link>
           </>

--- a/site/gatsby-site/src/templates/prismicBlogPost.js
+++ b/site/gatsby-site/src/templates/prismicBlogPost.js
@@ -1,12 +1,28 @@
 import React from 'react';
 import { graphql } from 'gatsby';
 import PrismicBlogPost from 'components/blog/PrismicBlogPost';
+import { Link } from 'gatsby';
 import HeadContent from 'components/HeadContent';
+import { Trans } from 'react-i18next';
 
 export default function BlogPost(props) {
   const post = props?.data?.post;
 
-  return <>{post && <PrismicBlogPost post={post} location={props.location} />}</>;
+  const originalPost = props?.data?.originalPost;
+
+  if (post) {
+    return <PrismicBlogPost post={post} location={props.location} />;
+  } else if (originalPost) {
+    return <PrismicBlogPost post={originalPost} location={props.location} />;
+  } else if (props?.pageContext?.originalPath) {
+    return (
+      <Link className="mx-2" to={`${props.pageContext.originalPath}`}>
+        <Trans>View Original</Trans>
+      </Link>
+    );
+  } else {
+    return <></>;
+  }
 }
 
 export const Head = (props) => {
@@ -35,6 +51,30 @@ export const pageQuery = graphql`
       }
     }
     post: prismicBlog(data: { language: { eq: $locale }, slug: { eq: $slug } }) {
+      uid
+      data {
+        metatitle
+        metadescription
+        slug
+        aitranslated
+        language
+        title {
+          text
+        }
+        content {
+          richText
+          text
+          html
+        }
+        image {
+          url
+          gatsbyImageData
+        }
+        date
+        author
+      }
+    }
+    originalPost: prismicBlog(data: { language: { eq: "en" }, slug: { eq: $slug } }) {
       uid
       data {
         metatitle


### PR DESCRIPTION
This PR:
-  Fixes the empty fallback blog page for Prismic blog items without translation. e.g.: https://incidentdatabase.ai/es/blog/ai-incident-journalism-analysis
- Fix the "View Original" link on blog pages. e.g.: https://incidentdatabase.ai/es/blog/researching-ai-incidents-to-build-a-safer-future

### Preview link
https://pr-3239--staging-aiid.netlify.app