### PR TITLE
Fix input being passed as string when merging feature branches

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -91,4 +91,5 @@ jobs:
     secrets: inherit
     with:
       environment: staging
-      force-deploy: ${{ inputs.force-deploy }}
+      # inputs from the workflow_dispatch event come as strings even if they are explicitly defined as boolean
+      force-deploy: ${{ inputs.force-deploy == 'true' }}


### PR DESCRIPTION
failed run:
https://github.com/responsible-ai-collaborative/aiid/actions/runs/12040444471

<img width="789" alt="image" src="https://github.com/user-attachments/assets/2634659f-0deb-4fd3-bf38-5dcdaeb0e4e7">
