### PR TITLE
Add dependabot configuration to target staging branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Configure Dependabot to target the staging branch of this repository.
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "staging"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,6 @@
 # Configure Dependabot to target the staging branch of this repository.
+# See configuration options:
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:


### PR DESCRIPTION
Dependabot PRs currently target the repository default branch, which is `main`. Instead, all changes should go through `staging`, which is our development trunk.