### PR TITLE
Email templates – Fallback to sans-serif, reduce horizontal padding

### DIFF
--- a/site/gatsby-site/server/emails/templates/shared.ts
+++ b/site/gatsby-site/server/emails/templates/shared.ts
@@ -35,7 +35,7 @@ const insertContent= (content: string, variables: any): string  => {
 						AI INCIDENT DATABASE
 					</div>
 				</div>
-				<div style="padding: 32px;">
+				<div style="padding: 32px 8px;">
           ${content}
 				</div>
 			</div>

--- a/site/gatsby-site/server/emails/templates/shared.ts
+++ b/site/gatsby-site/server/emails/templates/shared.ts
@@ -47,7 +47,7 @@ const insertContent= (content: string, variables: any): string  => {
 // These styles will be used across multiple email templates,
 // so they get defined outside the getTemplate function.
 const bodyStyle: string = ignoreWhitespace(`
-  font-family: karla; 
+  font-family: karla, sans-serif; 
   padding: 16px;
 `);
 

--- a/site/gatsby-site/src/scripts/sendEmailTest.js
+++ b/site/gatsby-site/src/scripts/sendEmailTest.js
@@ -1,4 +1,4 @@
-import { sendEmail } from '../../server/fields/common.ts';
+import { sendEmail } from '../../server/emails';
 
 // from site/gatsby-site, run with
 // TEST_EMAIL_TO_ADDRESS=<address> dotenv run <path to>/npx ts-node src/scripts/sendEmailTest.js


### PR DESCRIPTION
Was previously falling back to a serif font when it was the default, and it had enough padding to look weird on mobile.