### PR TITLE
Add `call-test-playwright-full` step dependency to `call-deploy`

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -73,7 +73,13 @@ jobs:
   call-deploy:
     if: (inputs.force-deploy == true || success()) && !cancelled()
     uses: ./.github/workflows/deploy.yml
-    needs: [cache-modifier, call-test-playwright, call-test-api]
+    needs: 
+      [
+        cache-modifier,
+        call-test-api,
+        call-test-playwright,
+        call-test-playwright-full,
+      ]
     secrets: inherit
     permissions:
       pull-requests: write


### PR DESCRIPTION
This PR avoids Staging deploys if a Playwright test fails.

Example run:
https://github.com/pdcp1/aiid/actions/runs/12776870045