### PR TITLE
Skip incident updates subscription test for authenticated users

### DIFF
--- a/site/gatsby-site/playwright/e2e-full/cite.spec.ts
+++ b/site/gatsby-site/playwright/e2e-full/cite.spec.ts
@@ -417,7 +417,7 @@ test.describe('Cite pages', () => {
         await expect(page.locator('head meta[property="twitter:image"]')).toHaveAttribute('content');
     });
 
-    test('Should subscribe to incident updates (user authenticated)', async ({ page, login }) => {
+    test.skip('Should subscribe to incident updates (user authenticated)', async ({ page, login }) => {
 
         await init();
 


### PR DESCRIPTION
Skipping `Should subscribe to incident updates (user authenticated)` until we figure out why it fails so much