### PR TITLE
Change WebArchiveLink component to simplify snapshot URL fetching

### DIFF
--- a/site/gatsby-site/playwright/e2e/discover.spec.ts
+++ b/site/gatsby-site/playwright/e2e/discover.spec.ts
@@ -247,7 +247,7 @@ test.describe('The Discover app', () => {
         await expect(modal).not.toBeVisible();
     });
 
-    test.skip('Opens an archive link', async ({ page, skipOnEmptyEnvironment }) => {
+    test('Opens an archive link', async ({ page, skipOnEmptyEnvironment }) => {
 
         test.slow();
 
@@ -278,9 +278,13 @@ test.describe('The Discover app', () => {
         await expect(waybackMachineLink).toBeVisible();
         await waybackMachineLink.click();
 
+        const response = await (await fetch('https://archive.org/wayback/available?url=https://www.cbsnews.com/news/is-starbucks-shortchanging-its-baristas/')).json();
+
+        const expectedTimestamp = response.archived_snapshots.closest.timestamp;
+
         await expect(async () => {
             await expect(popup).toBeTruthy();
-            await expect(popup).toHaveURL('https://web.archive.org/web/20240404174436/https://www.cbsnews.com/news/is-starbucks-shortchanging-its-baristas/');
+            await expect(popup).toHaveURL(`https://web.archive.org/web/${expectedTimestamp}/https://www.cbsnews.com/news/is-starbucks-shortchanging-its-baristas/`);
         }).toPass();
     });
 

--- a/site/gatsby-site/src/components/discover/Actions.js
+++ b/site/gatsby-site/src/components/discover/Actions.js
@@ -78,15 +78,7 @@ export default function Actions({ item, toggleFilterByIncidentId = null }) {
 
   return (
     <div className="flex flex-wrap">
-      <WebArchiveLink
-        url={item.url}
-        date={item.date_submitted}
-        className="btn btn-link px-1"
-        title={t('Authors')}
-        datePublished={item.epoch_date_published}
-        incidentDate={item.epoch_incident_date}
-        dateSubmitted={item.epoch_date_submitted}
-      >
+      <WebArchiveLink url={item.url} className="btn btn-link px-1">
         <FontAwesomeIcon
           titleId="report-source"
           icon={faNewspaper}

--- a/site/gatsby-site/src/components/ui/WebArchiveLink.js
+++ b/site/gatsby-site/src/components/ui/WebArchiveLink.js
@@ -2,22 +2,20 @@ import React from 'react';
 import { Trans } from 'react-i18next';
 import { Dropdown } from 'flowbite-react';
 
-async function getSnapshotURL(url, date) {
-  const timestamp = date ? date.replace('-', '') : '';
-
-  const waUrl = `https://archive.org/wayback/available?url=${url}&timestamp=${timestamp}`;
+async function getSnapshotURL(url) {
+  const waUrl = `https://archive.org/wayback/available?url=${url}`;
 
   const response = await (await fetch(waUrl)).json();
 
   return response.archived_snapshots.closest.url.replace('http:', 'https:');
 }
 
-export default function WebArchiveLink({ url, date, children, className = '' }) {
+export default function WebArchiveLink({ url, children, className = '' }) {
   const onClick = async () => {
     const win = window.open('', '_blank');
 
     try {
-      const snapshotUrl = await getSnapshotURL(url, date);
+      const snapshotUrl = await getSnapshotURL(url);
 
       win.location.href = snapshotUrl;
     } catch (e) {


### PR DESCRIPTION
This PR fixes https://github.com/responsible-ai-collaborative/aiid/issues/3328

### The reason for the test failure
The Wayback Archive site indexed a new version of the testing report URL (https://www.cbsnews.com/news/is-starbucks-shortchanging-its-baristas/) on `2025-01-17` that invalidates the hardcoded expected URL timestamp