### PR TITLE
Fix flakiness on Discover app tests by mocking Wayback Machine API response

### DIFF
--- a/site/gatsby-site/playwright/e2e/discover.spec.ts
+++ b/site/gatsby-site/playwright/e2e/discover.spec.ts
@@ -251,6 +251,32 @@ test.describe('The Discover app', () => {
 
         test.slow();
 
+        const reportUrl = 'https://www.cbsnews.com/news/is-starbucks-shortchanging-its-baristas/';
+
+        // Define the mock response from the Wayback Machine API
+        const mockedTimestamp = '20250117132643X';
+
+        const mockResponse = {
+            url: reportUrl,
+            archived_snapshots: {
+              closest: {
+                status: '200',
+                available: true,
+                url: `http://web.archive.org/web/${mockedTimestamp}/${reportUrl}`,
+                timestamp: mockedTimestamp,
+              }
+            }
+          };
+
+        // Intercept the request to the Wayback Machine API
+        await page.route(`https://archive.org/wayback/available?url=${reportUrl}`, async (route) => {
+            await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(mockResponse)
+            });
+        });
+
         await page.goto(url);
 
         await page.locator('[data-cy="web-archive-link"] [data-cy="dropdown-toggle"]').first().click();
@@ -265,7 +291,7 @@ test.describe('The Discover app', () => {
 
         await expect(async () => {
             await expect(popup).toBeTruthy();
-            await expect(popup).toHaveURL('https://www.cbsnews.com/news/is-starbucks-shortchanging-its-baristas/');
+            await expect(popup).toHaveURL(reportUrl);
         }).toPass();
 
         popup = null;
@@ -278,14 +304,10 @@ test.describe('The Discover app', () => {
         await expect(waybackMachineLink).toBeVisible();
         await waybackMachineLink.click();
 
-        const response = await (await fetch('https://archive.org/wayback/available?url=https://www.cbsnews.com/news/is-starbucks-shortchanging-its-baristas/')).json();
-
-        const expectedTimestamp = response.archived_snapshots.closest.timestamp;
-
         await expect(async () => {
             await expect(popup).toBeTruthy();
-            await expect(popup).toHaveURL(`https://web.archive.org/web/${expectedTimestamp}/https://www.cbsnews.com/news/is-starbucks-shortchanging-its-baristas/`);
-        }).toPass();
+            await expect(popup).toHaveURL(mockResponse.archived_snapshots.closest.url.replace('http:', 'https:'));
+        }).toPass({ timeout: 10000 });
     });
 
     test('Lets you filter by type', async ({ page }) => {


### PR DESCRIPTION
Enhancement of this PR
- https://github.com/responsible-ai-collaborative/aiid/pull/3334