### PR TITLE
fix/authors-fill

### DIFF
--- a/site/gatsby-site/src/components/forms/FlowbiteSearchInput.js
+++ b/site/gatsby-site/src/components/forms/FlowbiteSearchInput.js
@@ -38,7 +38,7 @@ const FlowbiteSearchInput = ({
       </div>
       <input
         name={name}
-        className={`block p-4 pl-10 w-full text-sm bg-gray-50 border text-gray-900 rounded-lg dark:bg-gray-700 dark:placeholder-gray-400 dark:text-white  ${
+        className={`block p-4 pl-10 pr-28 w-full text-sm bg-gray-50 border text-gray-900 rounded-lg dark:bg-gray-700 dark:placeholder-gray-400 dark:text-white  ${
           props.touched[name] && props.errors[name]
             ? 'border-red-600 focus:border-red-600 focus:ring-red-500'
             : 'border-gray-300 dark:border-gray-600 dark:focus:border-blue-500 focus:border-blue-500 focus:ring-blue-500 dark:focus:ring-blue-500'

--- a/site/gatsby-site/src/components/forms/SubmissionWizard/StepOne.js
+++ b/site/gatsby-site/src/components/forms/SubmissionWizard/StepOne.js
@@ -249,7 +249,7 @@ const FormDetails = ({
             incident={values}
             setFieldValue={setFieldValue}
             columns={['byURL']}
-            triggerSearch={values['url'].length}
+            triggerSearch={values['url']?.length}
           />
         </FieldContainer>
 
@@ -284,7 +284,7 @@ const FormDetails = ({
             incident={values}
             setFieldValue={setFieldValue}
             columns={['byAuthors']}
-            triggerSearch={values['authors'].length}
+            triggerSearch={values['authors']?.length}
           />
         </FieldContainer>
 
@@ -307,7 +307,7 @@ const FormDetails = ({
             incident={values}
             setFieldValue={setFieldValue}
             columns={['byDatePublished']}
-            triggerSearch={values['date_published'].length}
+            triggerSearch={values['date_published']?.length}
           />
         </FieldContainer>
 


### PR DESCRIPTION
- closes #3338 

This pull request includes several updates to improve the handling of form input and search triggers in the `site/gatsby-site` components. The most important changes include adding a right padding to the `FlowbiteSearchInput` component and adding optional chaining to prevent errors when accessing the length of certain form fields.

Improvements to form input handling:

* [`site/gatsby-site/src/components/forms/FlowbiteSearchInput.js`](diffhunk://#diff-948d62290f7554b7ce60082b1889baa086024ddedac45a52be9fd21903d8166dL41-R41): Added right padding to the input field by modifying the `className` attribute.

Enhancements to search triggers:

* [`site/gatsby-site/src/components/forms/SubmissionWizard/StepOne.js`](diffhunk://#diff-e0c56d14df6cb3f66e97acb70ea195145e44d67064f4b17ab910fd666471b25bL252-R252): Added optional chaining to the `triggerSearch` attribute for the `url` field to prevent errors when the field is undefined.
* [`site/gatsby-site/src/components/forms/SubmissionWizard/StepOne.js`](diffhunk://#diff-e0c56d14df6cb3f66e97acb70ea195145e44d67064f4b17ab910fd666471b25bL287-R287): Added optional chaining to the `triggerSearch` attribute for the `authors` field to prevent errors when the field is undefined.
* [`site/gatsby-site/src/components/forms/SubmissionWizard/StepOne.js`](diffhunk://#diff-e0c56d14df6cb3f66e97acb70ea195145e44d67064f4b17ab910fd666471b25bL310-R310): Added optional chaining to the `triggerSearch` attribute for the `date_published` field to prevent errors when the field is undefined.