### PR TITLE
Point dependabot to gatsby-site directory to find package.json

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/"
+    directory: "/site/gatsby-site/"
     target-branch: "staging"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Runs are failing with errors as the `package.json` file isn't found in the root directory.
e.g. https://github.com/responsible-ai-collaborative/aiid/actions/runs/13311362687

Some dependabot runs seem to trivially succeed, so I hadn't noticed these failures among the successful runs.
e.g. https://github.com/responsible-ai-collaborative/aiid/actions/runs/13311362657/job/37174462670