### PR TITLE
Avoid inserting empty report translation if the Google's translate API returns empty translations

### DIFF
--- a/site/gatsby-site/src/scripts/Translator.js
+++ b/site/gatsby-site/src/scripts/Translator.js
@@ -137,6 +137,16 @@ class Translator {
     for (let i = 0; i < results.length; i++) {
       const result = results[i];
 
+      // Check if the translation is empty. The translation API sometimes returns empty strings with a 200 status code.
+      if (result === '') {
+        this.reporter.error(
+          `Error translating report ${entry.report_number}, ${keys[i]} field is empty`
+        );
+        throw new Error(
+          `Translation process failed for report ${entry.report_number}. ${keys[i]} field is empty`
+        );
+      }
+
       const key = keys[i];
 
       translatedEntry[key] = result;

--- a/site/gatsby-site/src/scripts/Translator.js
+++ b/site/gatsby-site/src/scripts/Translator.js
@@ -142,9 +142,6 @@ class Translator {
         this.reporter.error(
           `Error translating report ${entry.report_number}, ${keys[i]} field is empty`
         );
-        throw new Error(
-          `Translation process failed for report ${entry.report_number}. ${keys[i]} field is empty`
-        );
       }
 
       const key = keys[i];
@@ -200,7 +197,10 @@ class Translator {
 
       const items = reports.filter((r) => r.language !== to);
 
-      const translated = await this.translateReportsCollection({ items, to });
+      let translated = await this.translateReportsCollection({ items, to });
+
+      // filter translated reports that are not empty
+      translated = translated.filter((t) => t.text !== '' && t.title !== '');
 
       if (translated.length > 0) {
         this.reporter.log(`Translated [${translated.length}] new reports to [${to}]`);

--- a/site/gatsby-site/src/scripts/Translator.js
+++ b/site/gatsby-site/src/scripts/Translator.js
@@ -199,7 +199,7 @@ class Translator {
 
       let translated = await this.translateReportsCollection({ items, to });
 
-      // filter translated reports that are not empty
+      // filter translated reports that are empty
       translated = translated.filter((t) => t.text !== '' && t.title !== '');
 
       if (translated.length > 0) {


### PR DESCRIPTION
This is the permanent fix for https://github.com/responsible-ai-collaborative/aiid/issues/3368