### PR TITLE
Add `userId` to admin data retrieval in `getUserAdminData` function

### DIFF
--- a/site/gatsby-site/server/fields/common.ts
+++ b/site/gatsby-site/server/fields/common.ts
@@ -100,6 +100,7 @@ export const getUserAdminData = async (userId: string, context: Context): Promis
             creationDate: new Date(), //TODO: find a way to get this data
             lastAuthenticationDate: new Date(), //TODO: find a way to get this data
             disabled: false,
+            userId,
         }
     }
 

--- a/site/gatsby-site/server/tests/notifications.spec.ts
+++ b/site/gatsby-site/server/tests/notifications.spec.ts
@@ -147,7 +147,13 @@ describe(`Notifications`, () => {
         });
 
         mockSession('123');
-        jest.spyOn(common, 'getUserAdminData').mockResolvedValue({ userId: '123', email: 'test@test.com' });
+        jest.spyOn(common, 'getUserAdminData').mockResolvedValue({
+            email: 'test@test.com',
+            creationDate: new Date(),
+            lastAuthenticationDate: new Date(),
+            disabled: false,
+            userId: '123',
+        });
 
         const sendEmailMock = jest.spyOn(emails, 'sendBulkEmails').mockResolvedValue();
 
@@ -276,7 +282,13 @@ describe(`Notifications`, () => {
 
 
         mockSession('123');
-        jest.spyOn(common, 'getUserAdminData').mockResolvedValue({ userId: '123', email: 'test@test.com' });
+        jest.spyOn(common, 'getUserAdminData').mockResolvedValue({
+            email: 'test@test.com',
+            creationDate: new Date(),
+            lastAuthenticationDate: new Date(),
+            disabled: false,
+            userId: '123',
+        });
         const sendEmailMock = jest.spyOn(emails, 'sendBulkEmails').mockResolvedValue();
 
         const result = await processNotifications();
@@ -402,7 +414,13 @@ describe(`Notifications`, () => {
         });
 
         mockSession('123');
-        jest.spyOn(common, 'getUserAdminData').mockResolvedValue({ userId: '123', email: 'test@test.com' });
+        jest.spyOn(common, 'getUserAdminData').mockResolvedValue({
+            email: 'test@test.com',
+            creationDate: new Date(),
+            lastAuthenticationDate: new Date(),
+            disabled: false,
+            userId: '123',
+        });
         const sendEmailMock = jest.spyOn(emails, 'sendBulkEmails').mockResolvedValue();
 
         const result = await processNotifications();
@@ -522,7 +540,13 @@ describe(`Notifications`, () => {
 
 
         mockSession('123');
-        jest.spyOn(common, 'getUserAdminData').mockResolvedValue({ userId: '123', email: 'test@test.com' });
+        jest.spyOn(common, 'getUserAdminData').mockResolvedValue({
+            email: 'test@test.com',
+            creationDate: new Date(),
+            lastAuthenticationDate: new Date(),
+            disabled: false,
+            userId: '123',
+        });
         const sendEmailMock = jest.spyOn(emails, 'sendBulkEmails').mockResolvedValue();
 
         const result = await processNotifications();
@@ -643,7 +667,13 @@ describe(`Notifications`, () => {
 
 
         mockSession('123');
-        jest.spyOn(common, 'getUserAdminData').mockResolvedValue({ userId: '123', email: 'test@test.com' });
+        jest.spyOn(common, 'getUserAdminData').mockResolvedValue({
+            email: 'test@test.com',
+            creationDate: new Date(),
+            lastAuthenticationDate: new Date(),
+            disabled: false,
+            userId: '123',
+        });
         const sendEmailMock = jest.spyOn(emails, 'sendBulkEmails').mockResolvedValue();
 
         const result = await processNotifications();
@@ -1295,8 +1325,21 @@ describe(`Notifications`, () => {
         });
 
         jest.spyOn(emails, 'sendBulkEmails').mockRestore();
-        jest.spyOn(common, 'getUserAdminData').mockResolvedValueOnce({ userId: 'user1', email: 'test@test.com' })
-        jest.spyOn(common, 'getUserAdminData').mockResolvedValueOnce({ userId: 'user2', email: 'test2@test.com' });
+        
+        jest.spyOn(common, 'getUserAdminData').mockResolvedValueOnce({
+            email: 'test@test.com',
+            creationDate: new Date(),
+            lastAuthenticationDate: new Date(),
+            disabled: false,
+            userId: 'user1',
+        });
+        jest.spyOn(common, 'getUserAdminData').mockResolvedValueOnce({
+            email: 'test2@test.com',
+            creationDate: new Date(),
+            lastAuthenticationDate: new Date(),
+            disabled: false,
+            userId: 'user2',
+        });
 
         const mockMailersendBulkSend = jest.spyOn(emails, 'mailersendBulkSend').mockResolvedValue();
 
@@ -1501,7 +1544,13 @@ describe(`Notifications`, () => {
 
 
         mockSession('123');
-        jest.spyOn(common, 'getUserAdminData').mockResolvedValue({ userId: '123', email: 'test@test.com' });
+        jest.spyOn(common, 'getUserAdminData').mockResolvedValue({
+            email: 'test2@test.com',
+            creationDate: new Date(),
+            lastAuthenticationDate: new Date(),
+            disabled: false,
+            userId: '123',
+        });
 
         const sendEmailMock = jest.spyOn(emails, 'sendBulkEmails').mockImplementation(() => {
             throw new Error('Failed to send email');


### PR DESCRIPTION
Add missing `userId` field on `getUserAdminData` because is needed on the Process Notification script https://github.com/responsible-ai-collaborative/aiid/blob/140c6bbaa536c85326d7dc002d1f1916c70c31ca/site/gatsby-site/src/scripts/process-notifications.ts#L28

If this field is missing, it appears we don't send any notifications because that condition isn't fulfilled.

This could be related with https://github.com/responsible-ai-collaborative/aiid/issues/3354