### PR TITLE
Add missing userId field data

### DIFF
--- a/site/gatsby-site/server/fields/common.ts
+++ b/site/gatsby-site/server/fields/common.ts
@@ -100,6 +100,7 @@ export const getUserAdminData = async (userId: string, context: Context): Promis
             creationDate: new Date(), //TODO: find a way to get this data
             lastAuthenticationDate: new Date(), //TODO: find a way to get this data
             disabled: false,
+            userId,
         }
     }
 

--- a/site/gatsby-site/server/tests/notifications.spec.ts
+++ b/site/gatsby-site/server/tests/notifications.spec.ts
@@ -1,7 +1,6 @@
 import { expect, jest, it } from '@jest/globals';
 import { ApolloServer } from "@apollo/server";
 import { makeRequest, mockSession, seedFixture, startTestServer } from "./utils";
-import * as context from '../context';
 import * as common from '../fields/common';
 import * as emails from '../emails';
 import { DBEntity, DBIncident, DBNotification, DBReport, DBSubmission, DBSubscription, DBUser } from '../interfaces';
@@ -63,23 +62,31 @@ describe(`Notifications`, () => {
         const subscriptions: DBSubscription[] = [
             {
                 type: 'new-incidents',
-                userId: '123',
+                userId: '5f8f4b3b9b3e6f001f3b3b3b',
             },
             {
                 type: 'incident',
-                userId: '123',
+                userId: '5f8f4b3b9b3e6f001f3b3b3b',
                 incident_id: 1,
             },
             {
                 type: 'submission-promoted',
-                userId: '123',
+                userId: '5f8f4b3b9b3e6f001f3b3b3b',
                 incident_id: 1,
             }
         ]
 
         const users: DBUser[] = [
             {
-                userId: "123",
+                userId: '5f8f4b3b9b3e6f001f3b3b3b',
+                roles: ['admin'],
+            }
+        ]
+
+        const authUsers = [
+            {
+                _id: new ObjectId('5f8f4b3b9b3e6f001f3b3b3b'),
+                email: 'test@test.com',
                 roles: ['admin'],
             }
         ]
@@ -143,11 +150,14 @@ describe(`Notifications`, () => {
                 incidents,
                 entities,
                 reports,
+            },
+            auth: {
+                users: authUsers,
             }
         });
 
-        mockSession('123');
-        jest.spyOn(common, 'getUserAdminData').mockResolvedValue({ userId: '123', email: 'test@test.com' });
+        mockSession('5f8f4b3b9b3e6f001f3b3b3b');
+
 
         const sendEmailMock = jest.spyOn(emails, 'sendBulkEmails').mockResolvedValue();
 
@@ -160,7 +170,7 @@ describe(`Notifications`, () => {
             recipients: [
                 {
                     email: "test@test.com",
-                    userId: "123",
+                    userId: "5f8f4b3b9b3e6f001f3b3b3b",
                 },
             ],
             subject: "New Incident {{incidentId}} was created",
@@ -195,19 +205,19 @@ describe(`Notifications`, () => {
         const subscriptions: DBSubscription[] = [
             {
                 type: 'entity',
-                userId: '123',
+                userId: '5f8f4b3b9b3e6f001f3b3b3b',
                 entityId: 'entity-1',
             },
             {
                 type: 'incident',
-                userId: '123',
+                userId: '5f8f4b3b9b3e6f001f3b3b3b',
                 incident_id: 1,
             },
         ]
 
         const users: DBUser[] = [
             {
-                userId: "123",
+                userId: "5f8f4b3b9b3e6f001f3b3b3b",
                 roles: ['admin'],
             }
         ]
@@ -271,12 +281,21 @@ describe(`Notifications`, () => {
                 incidents,
                 entities,
                 reports,
+            },
+            auth: {
+                users: [
+                    {
+                        _id: new ObjectId('5f8f4b3b9b3e6f001f3b3b3b'),
+                        email: 'test@test.com',
+                        roles: ['admin'],
+                    }
+                ]
             }
         });
 
 
-        mockSession('123');
-        jest.spyOn(common, 'getUserAdminData').mockResolvedValue({ userId: '123', email: 'test@test.com' });
+        mockSession('5f8f4b3b9b3e6f001f3b3b3b');
+
         const sendEmailMock = jest.spyOn(emails, 'sendBulkEmails').mockResolvedValue();
 
         const result = await processNotifications();
@@ -286,7 +305,7 @@ describe(`Notifications`, () => {
             recipients: [
                 {
                     email: "test@test.com",
-                    userId: "123",
+                    userId: "5f8f4b3b9b3e6f001f3b3b3b",
                 },
             ],
             subject: "New Incident for {{entityName}}",
@@ -322,19 +341,19 @@ describe(`Notifications`, () => {
         const subscriptions: DBSubscription[] = [
             {
                 type: 'incident',
-                userId: '123',
+                userId: '5f8f4b3b9b3e6f001f3b3b3b',
                 incident_id: 1,
             },
             {
                 type: 'submission-promoted',
-                userId: '123',
+                userId: '5f8f4b3b9b3e6f001f3b3b3b',
                 incident_id: 1,
             }
         ]
 
         const users: DBUser[] = [
             {
-                userId: "123",
+                userId: "5f8f4b3b9b3e6f001f3b3b3b",
                 roles: ['admin'],
             }
         ]
@@ -398,11 +417,20 @@ describe(`Notifications`, () => {
                 incidents,
                 entities,
                 reports,
+            },
+            auth: {
+                users: [
+                    {
+                        _id: new ObjectId('5f8f4b3b9b3e6f001f3b3b3b'),
+                        email: 'test@test.com',
+                        roles: ['admin'],
+                    }
+                ]
             }
         });
 
-        mockSession('123');
-        jest.spyOn(common, 'getUserAdminData').mockResolvedValue({ userId: '123', email: 'test@test.com' });
+        mockSession('5f8f4b3b9b3e6f001f3b3b3b');
+
         const sendEmailMock = jest.spyOn(emails, 'sendBulkEmails').mockResolvedValue();
 
         const result = await processNotifications();
@@ -412,7 +440,7 @@ describe(`Notifications`, () => {
             recipients: [
                 {
                     email: "test@test.com",
-                    userId: "123",
+                    userId: "5f8f4b3b9b3e6f001f3b3b3b",
                 },
             ],
             subject: "Incident {{incidentId}} was updated",
@@ -442,18 +470,18 @@ describe(`Notifications`, () => {
         const subscriptions: DBSubscription[] = [
             {
                 type: 'new-incidents',
-                userId: '123',
+                userId: '5f8f4b3b9b3e6f001f3b3b3b',
             },
             {
                 type: 'incident',
-                userId: '123',
+                userId: '5f8f4b3b9b3e6f001f3b3b3b',
                 incident_id: 1,
             },
         ]
 
         const users: DBUser[] = [
             {
-                userId: "123",
+                userId: "5f8f4b3b9b3e6f001f3b3b3b",
                 roles: ['admin'],
             }
         ]
@@ -517,12 +545,21 @@ describe(`Notifications`, () => {
                 incidents,
                 entities,
                 reports,
+            },
+            auth: {
+                users: [
+                    {
+                        _id: new ObjectId('5f8f4b3b9b3e6f001f3b3b3b'),
+                        email: 'test@test.com',
+                        roles: ['admin'],
+                    }
+                ]
             }
         });
 
 
-        mockSession('123');
-        jest.spyOn(common, 'getUserAdminData').mockResolvedValue({ userId: '123', email: 'test@test.com' });
+        mockSession('5f8f4b3b9b3e6f001f3b3b3b');
+
         const sendEmailMock = jest.spyOn(emails, 'sendBulkEmails').mockResolvedValue();
 
         const result = await processNotifications();
@@ -532,7 +569,7 @@ describe(`Notifications`, () => {
             recipients: [
                 {
                     email: "test@test.com",
-                    userId: "123",
+                    userId: "5f8f4b3b9b3e6f001f3b3b3b",
                 },
             ],
             subject: "Incident {{incidentId}} was updated",
@@ -556,25 +593,25 @@ describe(`Notifications`, () => {
                 processed: false,
                 type: 'submission-promoted',
                 incident_id: 1,
-                userId: '123',
+                userId: '5f8f4b3b9b3e6f001f3b3b3b',
             },
         ]
 
         const subscriptions: DBSubscription[] = [
             {
                 type: 'new-incidents',
-                userId: '123',
+                userId: '5f8f4b3b9b3e6f001f3b3b3b',
             },
             {
                 type: 'incident',
-                userId: '123',
+                userId: '5f8f4b3b9b3e6f001f3b3b3b',
                 incident_id: 1,
             },
         ]
 
         const users: DBUser[] = [
             {
-                userId: "123",
+                userId: "5f8f4b3b9b3e6f001f3b3b3b",
                 roles: ['admin'],
             }
         ]
@@ -638,12 +675,21 @@ describe(`Notifications`, () => {
                 incidents,
                 entities,
                 reports,
+            },
+            auth: {
+                users: [
+                    {
+                        _id: new ObjectId('5f8f4b3b9b3e6f001f3b3b3b'),
+                        email: 'test@test.com',
+                        roles: ['admin'],
+                    }
+                ]
             }
         });
 
 
-        mockSession('123');
-        jest.spyOn(common, 'getUserAdminData').mockResolvedValue({ userId: '123', email: 'test@test.com' });
+        mockSession('5f8f4b3b9b3e6f001f3b3b3b');
+
         const sendEmailMock = jest.spyOn(emails, 'sendBulkEmails').mockResolvedValue();
 
         const result = await processNotifications();
@@ -653,7 +699,7 @@ describe(`Notifications`, () => {
             recipients: [
                 {
                     email: "test@test.com",
-                    userId: "123",
+                    userId: "5f8f4b3b9b3e6f001f3b3b3b",
                 },
             ],
             subject: "Your submission has been approved!",
@@ -1199,31 +1245,31 @@ describe(`Notifications`, () => {
         const subscriptions: DBSubscription[] = [
             {
                 type: 'new-incidents',
-                userId: 'user1',
+                userId: '5f8f4b3b9b3e6f001f3b3b3b',
             },
             {
                 type: 'new-incidents',
-                userId: 'user2',
+                userId: '5f8f4b3b9b3e6f001f3b3b3c',
             },
             {
                 type: 'incident',
-                userId: 'user1',
+                userId: '5f8f4b3b9b3e6f001f3b3b3b',
                 incident_id: 1,
             },
             {
                 type: 'submission-promoted',
-                userId: 'user1',
+                userId: '5f8f4b3b9b3e6f001f3b3b3b',
                 incident_id: 1,
             }
         ]
 
         const users: DBUser[] = [
             {
-                userId: "user1",
+                userId: "5f8f4b3b9b3e6f001f3b3b3b",
                 roles: ['admin'],
             },
             {
-                userId: "user2",
+                userId: "5f8f4b3b9b3e6f001f3b3b3c",
                 roles: ['subscriber'],
             }
         ]
@@ -1291,12 +1337,24 @@ describe(`Notifications`, () => {
                 incidents,
                 entities,
                 reports,
+            },
+            auth: {
+                users: [
+                    {
+                        _id: new ObjectId('5f8f4b3b9b3e6f001f3b3b3b'),
+                        email: 'test@test.com',
+                        roles: ['admin'],
+                    },
+                    {
+                        _id: new ObjectId('5f8f4b3b9b3e6f001f3b3b3c'),
+                        email: 'test2@test.com',
+                        roles: ['subscriber'],
+                    }
+                ]
             }
         });
 
         jest.spyOn(emails, 'sendBulkEmails').mockRestore();
-        jest.spyOn(common, 'getUserAdminData').mockResolvedValueOnce({ userId: 'user1', email: 'test@test.com' })
-        jest.spyOn(common, 'getUserAdminData').mockResolvedValueOnce({ userId: 'user2', email: 'test2@test.com' });
 
         const mockMailersendBulkSend = jest.spyOn(emails, 'mailersendBulkSend').mockResolvedValue();
 
@@ -1344,7 +1402,7 @@ describe(`Notifications`, () => {
                         developers: "<a href=\"http://localhost:8000/entities/entity-1\">Entity 1</a>",
                         entitiesHarmed: "<a href=\"http://localhost:8000/entities/entity-1\">Entity 1</a>",
                         email: "test@test.com",
-                        userId: "user1",
+                        userId: "5f8f4b3b9b3e6f001f3b3b3b",
                         siteUrl: "http://localhost:8000",
                         implicatedSystems: "<a href=\"http://localhost:8000/entities/entity-1\">Entity 1</a>",
                     },
@@ -1393,7 +1451,7 @@ describe(`Notifications`, () => {
                         developers: "<a href=\"http://localhost:8000/entities/entity-1\">Entity 1</a>",
                         entitiesHarmed: "<a href=\"http://localhost:8000/entities/entity-1\">Entity 1</a>",
                         email: "test2@test.com",
-                        userId: "user2",
+                        userId: "5f8f4b3b9b3e6f001f3b3b3c",
                         siteUrl: "http://localhost:8000",
                         implicatedSystems: "<a href=\"http://localhost:8000/entities/entity-1\">Entity 1</a>",
                     },
@@ -1416,23 +1474,23 @@ describe(`Notifications`, () => {
         const subscriptions: DBSubscription[] = [
             {
                 type: 'new-incidents',
-                userId: '123',
+                userId: '5f8f4b3b9b3e6f001f3b3b3b',
             },
             {
                 type: 'incident',
-                userId: '123',
+                userId: '5f8f4b3b9b3e6f001f3b3b3b',
                 incident_id: 1,
             },
             {
                 type: 'submission-promoted',
-                userId: '123',
+                userId: '5f8f4b3b9b3e6f001f3b3b3b',
                 incident_id: 1,
             }
         ]
 
         const users: DBUser[] = [
             {
-                userId: "123",
+                userId: "5f8f4b3b9b3e6f001f3b3b3b",
                 roles: ['admin'],
             }
         ]
@@ -1496,19 +1554,29 @@ describe(`Notifications`, () => {
                 incidents,
                 entities,
                 reports,
+            },
+            auth: {
+                users: [
+                    {
+                        _id: new ObjectId('5f8f4b3b9b3e6f001f3b3b3b'),
+                        email: 'test@test.com',
+                        roles: ['admin'],
+                    }
+                ]
             }
         });
 
 
-        mockSession('123');
-        jest.spyOn(common, 'getUserAdminData').mockResolvedValue({ userId: '123', email: 'test@test.com' });
+        mockSession('5f8f4b3b9b3e6f001f3b3b3b');
+
 
         const sendEmailMock = jest.spyOn(emails, 'sendBulkEmails').mockImplementation(() => {
             throw new Error('Failed to send email');
         });
 
+        const expectedErrorMessage = "[Process Pending Notifications: New Incidents]: Failed to send email";
+        await expect(processNotifications()).rejects.toThrow(expectedErrorMessage);
 
-        await expect(processNotifications()).rejects.toThrow('Failed to send email');
         expect(sendEmailMock).toHaveBeenCalledTimes(1);
 
         const result = await makeRequest(url, {


### PR DESCRIPTION
improves on https://github.com/responsible-ai-collaborative/aiid/pull/3379

Removes the mock so if the userId field is missing the tests fail.