### PR TITLE
Fix/report empty submitter

### DIFF
--- a/site/gatsby-site/migrations/2025.02.18T14.25.42.report-undefined-submitters.js
+++ b/site/gatsby-site/migrations/2025.02.18T14.25.42.report-undefined-submitters.js
@@ -1,0 +1,25 @@
+const config = require('../config');
+
+/** @type {import('umzug').MigrationFn<any>} */
+exports.up = async ({ context: { client } }) => {
+  await client.connect();
+
+  const reportsCollection = client.db(config.realm.production_db.db_name).collection('reports');
+
+  const reportsCursor = reportsCollection.find({ submitters: [] });
+
+  while (await reportsCursor.hasNext()) {
+    const report = await reportsCursor.next();
+
+    if (report.submitters.length === 0) {
+      await reportsCollection.updateOne(
+        { _id: report._id },
+        {
+          $set: {
+            submitters: ['Anonymous'],
+          },
+        }
+      );
+    }
+  }
+};

--- a/site/gatsby-site/playwright/e2e-full/submit.spec.ts
+++ b/site/gatsby-site/playwright/e2e-full/submit.spec.ts
@@ -1707,4 +1707,54 @@ test.describe('The Submit form', () => {
         await expect(page.locator('.tw-toast:has-text("Report successfully added to review queue. You can see your submission")')).toBeVisible();
         await expect(page.locator(':text("Please review. Some data is missing.")')).not.toBeVisible();
     });
+
+    test('Should set submitters to Anonymous if they are not provided', async ({ page }) => {
+      await conditionalIntercept(
+        page,
+        '**/parseNews**',
+        () => true,
+        parseNews,
+        'parseNews',
+      );
+
+      await trackRequest(
+          page,
+          '**/graphql',
+          (req) => req.postDataJSON().operationName == 'FindSubmissions',
+          'findSubmissions'
+      );
+
+      await page.goto(url);
+
+      await waitForRequest('findSubmissions');
+
+      await page.locator('input[name="url"]').fill(
+          `https://www.arstechnica.com/gadgets/2017/11/youtube-to-crack-down-on-inappropriate-content-masked-as-kids-cartoons/`
+      );
+
+      await page.locator('[data-cy="fetch-info"]').click();
+
+      await waitForRequest('parseNews');
+
+      await page.locator('input[name="authors"]').fill('Something');
+
+      await page.locator('[name="incident_date"]').fill('2020-01-01');
+
+      await page.locator('[data-cy="submit-step-1"]').click();
+
+      await expect(page.locator('.tw-toast:has-text("Report successfully added to review queue. You can see your submission")')).toBeVisible();
+
+      const { data } = await query({
+        query: gql`
+          query {
+            submission(sort: { _id: DESC }){
+                _id
+                submitters
+            }
+          }
+        `,
+      });
+
+      expect(data.submission.submitters).toEqual(['Anonymous']);
+    });
 });


### PR DESCRIPTION
- closes #2628 

This pull request includes changes to handle cases where submitters are not provided in reports, and to ensure that such reports are marked with "Anonymous" as the submitter. The changes include a new migration script and an additional test case.

### Handling undefined submitters:

* [`site/gatsby-site/migrations/2025.02.18T14.25.42.report-undefined-submitters.js`](diffhunk://#diff-fe718bd227260dcf179d4de6571b0c6371249903ce7c1a63769796d472852b1fR1-R25): Added a migration script to update reports with no submitters by setting the submitters field to ['Anonymous'].

### Testing:

* [`site/gatsby-site/playwright/e2e-full/submit.spec.ts`](diffhunk://#diff-7f25c493ae692a3b614ebf776cbf544d5d983f08b36601ccb9bcdc19dfe2137aR1710-R1759): Added a test case to ensure that if submitters are not provided, they are set to "Anonymous" when the report is submitted.