### PR TITLE
Fix alignment of taxonomy text

### DIFF
--- a/site/gatsby-site/src/components/taxa/Taxonomy.js
+++ b/site/gatsby-site/src/components/taxa/Taxonomy.js
@@ -185,6 +185,10 @@ const Taxonomy = ({ taxonomy, incidentId, reportNumber, canEdit, initialEditing 
                           ${isFirst ? 'border-t-0' : ''}
                           ${isLast ? 'border-b-0' : ''}
                         `}
+                          components={{
+                            ol: ({ children }) => <ol className="mt-4 mb-4">{children}</ol>,
+                            p: ({ children }) => <p className="mt-4 mb-4">{children}</p>,
+                          }}
                         >
                           {showNotes ? taxonomy.notes : field.value}
                         </Markdown>


### PR DESCRIPTION
Should fix this:

<img width="590" alt="image" src="https://github.com/user-attachments/assets/1723f60c-8be7-4f0e-96d2-98e9525300f4" />

There are some lines missing and some are double but I didn't want to rewrite the entire thing.


https://pr-3440--staging-aiid.netlify.app
