### PR TITLE
Fix taxonomies with unpublished classifications showing in incident stats card

### DIFF
--- a/site/gatsby-site/src/templates/citeTemplate.js
+++ b/site/gatsby-site/src/templates/citeTemplate.js
@@ -304,7 +304,9 @@ function CiteTemplate({
                       incidentDate: incident.date,
                       taxonomiesWithClassifications: Array.from(
                         visibleClassifications.nodes.reduce((namespaces, classification) => {
-                          namespaces.add(classification.namespace);
+                          if (classification.publish) {
+                            namespaces.add(classification.namespace);
+                          }
                           return namespaces;
                         }, new Set())
                       ),


### PR DESCRIPTION
Resolves https://github.com/responsible-ai-collaborative/aiid/issues/3439