### PR TITLE
[HOTFIX] Delete all incident translations. All of them are incorrect in production

### DIFF
--- a/site/gatsby-site/migrations/2025.04.15T23.06.27.delete-wrong-incident-translations.js
+++ b/site/gatsby-site/migrations/2025.04.15T23.06.27.delete-wrong-incident-translations.js
@@ -1,0 +1,16 @@
+/**
+ *
+ * @param {{context: {client: import('mongodb').MongoClient}}} context
+ */
+
+exports.up = async ({ context: { client } }) => {
+  const db = client.db('translations');
+
+  console.log('Deleting incidents translations');
+
+  const translations = db.collection('incidents');
+
+  const result = await translations.deleteMany({});
+
+  console.log(`Deleted ${result.deletedCount} incidents translations`);
+};


### PR DESCRIPTION
We should merge this into `main` to fix the data and unblock the scheduled deploy.