### PR TITLE
Add MIT chart on taxonomies page

### DIFF
--- a/site/gatsby-site/src/components/TaxonomyGraphCarousel.js
+++ b/site/gatsby-site/src/components/TaxonomyGraphCarousel.js
@@ -149,7 +149,7 @@ const TaxonomyGraphCarousel = ({ namespace, axes, data }) => {
                       )}`}
                       className="h-96"
                     >
-                      <BillboardJS bb={bb} options={{ ...options }} />
+                      <BillboardJS bb={bb} options={{ ...options }} style={{ height: '20rem' }} />
                     </LocalizedLink>
                   </div>
                 );

--- a/site/gatsby-site/src/pages/taxonomies.js
+++ b/site/gatsby-site/src/pages/taxonomies.js
@@ -70,7 +70,7 @@ export default function Taxonomies({ data }) {
             <TaxonomyGraphCarousel
               data={data}
               namespace="MIT"
-              axes={['Risk Domain', 'Entity', 'Timing', 'Intent', 'Risk Subdomain']}
+              axes={['Risk Domain', 'Entity', 'Timing', 'Intent']}
             />
           </li>
         </ul>


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/9180378e-d4aa-4dce-8bf1-49a73446ccff" width="500"/>

Also fixes extraneous padding at the bottom of all charts on /taxonomies/
