### PR TITLE
Fix `No latestReports_en for report ...` warning on landing page

### DIFF
--- a/site/gatsby-site/page-creators/createLandingPage.js
+++ b/site/gatsby-site/page-creators/createLandingPage.js
@@ -22,6 +22,7 @@ const createLandingPage = async (graphql, createPage) => {
             text
             title
             url
+            language
           }
         }
       }


### PR DESCRIPTION
This fixes https://github.com/responsible-ai-collaborative/aiid/issues/2873