### PR TITLE
Add continue-on-error option to PR comment step in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -159,6 +159,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ vars.NETLIFY_SITE_ID }}
 
       - name: Comment on PR
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
deals with current broken builds. 

https://github.com/responsible-ai-collaborative/aiid/actions/workflows/production.yml

https://github.com/responsible-ai-collaborative/aiid/actions/workflows/staging.yml