### PR TITLE
Remove `config` dependency on `report-undefined-submitters` migration

### DIFF
--- a/site/gatsby-site/migrations/2025.02.18T14.25.42.report-undefined-submitters.js
+++ b/site/gatsby-site/migrations/2025.02.18T14.25.42.report-undefined-submitters.js
@@ -1,10 +1,8 @@
-const config = require('../config');
-
 /** @type {import('umzug').MigrationFn<any>} */
 exports.up = async ({ context: { client } }) => {
   await client.connect();
 
-  const reportsCollection = client.db(config.realm.production_db.db_name).collection('reports');
+  const reportsCollection = client.db('aiidprod').collection('reports');
 
   const reportsCursor = reportsCollection.find({ submitters: [] });
 


### PR DESCRIPTION
This PR fixes the migration execution failure due to required (but not needed) environment variables:
- https://github.com/responsible-ai-collaborative/aiid/actions/runs/14803228262/job/41566929885

These change is part of PR:
- https://github.com/responsible-ai-collaborative/aiid/pull/3381