### PR TITLE
Regenerate Report's translations if report's title or text are changed

### DIFF
--- a/site/gatsby-site/playwright/e2e/citeEdit.spec.ts
+++ b/site/gatsby-site/playwright/e2e/citeEdit.spec.ts
@@ -321,4 +321,107 @@ test.describe('Edit report', () => {
 
     expect(imgSrc).toBe('https://res.cloudinary.com/pai/image/upload/f_auto/q_auto/v1/reports/static01.nyt.com/images/2014/08/13/us/worker-hours-1407960684740/worker-hours-1407960684740-articleLarge.jpg');
   });
+
+  test("Should mark the report translations as dirty if the report's title is changed", async ({ page, login }) => {
+
+    await login();
+
+    await page.goto(url);
+    
+    const titleLocator = page.locator('[name=title]');
+    await titleLocator.fill('');
+    await titleLocator.fill('Test Title');
+
+    await page.getByRole('button', { name: 'Submit' }).click();
+
+    await expect(page.getByText('Incident report 3 updated successfully.')).toBeVisible();
+
+    const { data } = await query({
+      query: gql`{
+        report(filter: { report_number: { EQ: 3 } }) {
+          report_number
+          title
+          translations(languages: ["es"]) {
+            dirty
+          }
+        }
+      }`,
+    });
+
+    expect(data.report).toMatchObject({
+      report_number: 3,
+      title: 'Test Title',
+      translations: [{
+        dirty: true,
+      }],
+    })
+  });
+
+  test("Should mark the report translations as dirty if the report's text is changed", async ({ page, login }) => {
+
+    await login();
+
+    await page.goto(url);
+    
+    await setEditorText(page, '## This is text in English\n\nthat is longer that eighty characters, yes eighty characters!');
+
+    await page.getByRole('button', { name: 'Submit' }).click();
+
+    await expect(page.getByText('Incident report 3 updated successfully.')).toBeVisible();
+
+    const { data } = await query({
+      query: gql`{
+        report(filter: { report_number: { EQ: 3 } }) {
+          report_number
+          text
+          translations(languages: ["es"]) {
+            dirty
+          }
+        }
+      }`,
+    });
+
+    expect(data.report).toMatchObject({
+      report_number: 3,
+      text: '## This is text in English\n\nthat is longer that eighty characters, yes eighty characters!',
+      translations: [{
+        dirty: true,
+      }],
+    })
+  });
+
+  test("Should not mark the report translations as dirty if the report's text or title are not changed", async ({ page, login }) => {
+
+    await login();
+
+    await page.goto(url);
+
+    const authorsLocator = page.locator('[name=authors]');
+    await authorsLocator.fill('');
+    await authorsLocator.fill('Test Author');
+
+    await page.getByRole('button', { name: 'Submit' }).click();
+
+    await expect(page.getByText('Incident report 3 updated successfully.')).toBeVisible();
+
+    const { data } = await query({
+      query: gql`{
+        report(filter: { report_number: { EQ: 3 } }) {
+          report_number
+          authors
+          translations(languages: ["es"]) {
+            dirty
+          }
+        }
+      }`,
+    });
+
+    expect(data.report).toMatchObject({
+      report_number: 3,
+      authors: ['Test Author'],
+      translations: [{
+        dirty: null,
+      }],
+    })
+  });
 });

--- a/site/gatsby-site/server/fields/reports.ts
+++ b/site/gatsby-site/server/fields/reports.ts
@@ -153,6 +153,7 @@ export const mutationFields: GraphQLFieldConfigMap<any, any> = {
                         report_number: { type: new GraphQLNonNull(GraphQLInt) },
                         text: { type: new GraphQLNonNull(GraphQLString) },
                         title: { type: new GraphQLNonNull(GraphQLString) },
+                        dirty: { type: GraphQLBoolean },
                     },
                 }))
             }
@@ -167,6 +168,7 @@ export const mutationFields: GraphQLFieldConfigMap<any, any> = {
                 text: args.input.text,
                 plain_text: args.input.plain_text,
                 language: args.input.language,
+                dirty: args.input.dirty,
             };
             
             await translationsCollection.updateOne(

--- a/site/gatsby-site/server/generated/graphql.ts
+++ b/site/gatsby-site/server/generated/graphql.ts
@@ -2314,6 +2314,7 @@ export type ReportSortType = {
 
 export type ReportTranslations = {
   __typename?: 'ReportTranslations';
+  dirty?: Maybe<Scalars['Boolean']['output']>;
   language: Scalars['String']['output'];
   plain_text?: Maybe<Scalars['String']['output']>;
   text?: Maybe<Scalars['String']['output']>;
@@ -2816,6 +2817,7 @@ export type UpdateOneEntityPayload = {
 };
 
 export type UpdateOneReportTranslationInput = {
+  dirty?: InputMaybe<Scalars['Boolean']['input']>;
   language: Scalars['String']['input'];
   plain_text: Scalars['String']['input'];
   report_number: Scalars['Int']['input'];

--- a/site/gatsby-site/server/types/report.ts
+++ b/site/gatsby-site/server/types/report.ts
@@ -13,6 +13,7 @@ const ReportTranslationsType = new GraphQLObjectType({
         title: { type: GraphQLString },
         plain_text: { type: GraphQLString },
         language: { type: new GraphQLNonNull(GraphQLString) },
+        dirty: { type: GraphQLBoolean },
     }
 });
 
@@ -69,6 +70,7 @@ export const ReportType = new GraphQLObjectType({
                         text: translation.text,
                         title: translation.title,
                         plain_text: translation.plain_text,
+                        dirty: translation.dirty,
                         language: language,
                     } : {
                         text: null,

--- a/site/gatsby-site/src/pages/cite/edit.js
+++ b/site/gatsby-site/src/pages/cite/edit.js
@@ -228,8 +228,17 @@ function EditCitePage(props) {
         },
       });
 
+      const hasTitleChanged = values.title !== reportData.report.title;
+
+      const hasTextChanged = values.text !== reportData.report.text;
+
       for (const { code } of availableLanguages.filter((c) => c.code !== values.language)) {
         const updatedTranslation = pick(values[`translations_${code}`], translationsFields);
+
+        // If the title or text has changed, mark the translation as dirty
+        if (hasTitleChanged || hasTextChanged) {
+          updatedTranslation.dirty = true;
+        }
 
         await updateReportTranslations({
           variables: {


### PR DESCRIPTION
This is part of https://github.com/responsible-ai-collaborative/aiid/issues/1821