### PR TITLE
Add environment variable for tsne nIter

### DIFF
--- a/site/gatsby-site/README.md
+++ b/site/gatsby-site/README.md
@@ -245,7 +245,7 @@ Example:
 SKIP_PAGE_CREATOR=createTsneVisualizationPage,createCitationPages npm run start
 ```
 
-In general, skipping the TSNE visualization has the most significant reduction in build time.
+In general, skipping the TSNE visualization has the most significant reduction in build time. You can also reduce the time to build the TSNE visualization by setting the `TSNE_NITER` environment variable to a value lower than the default `1000`. A value of `100` produces visually acceptable results in about 1/10th the build time.
 
 
 ### Restoring Production database to Staging

--- a/site/gatsby-site/src/utils/updateTsne.js
+++ b/site/gatsby-site/src/utils/updateTsne.js
@@ -26,7 +26,7 @@ const updateTsneInDatabase = async () => {
     perplexity: 30.0,
     earlyExaggeration: 3.0,
     learningRate: 100.0,
-    nIter: 1000,
+    nIter: process.env.TSNE_NITER || 1000,
     metric: 'euclidean',
   });
 
@@ -34,13 +34,7 @@ const updateTsneInDatabase = async () => {
   // alternatively, it can be an array of coordinates (second argument should be specified as 'sparse')
   model.init({ data: embeddings, type: 'dense' });
 
-  // `error`,  `iter`: final error and iteration number
-  // note: computation-heavy action happens here
-  const [err, iter] = model.run();
-
-  if (err) {
-    console.error(err, iter);
-  }
+  model.run();
 
   // `outputScaled` is `output` scaled to a range of [-1, 1]
   const outputScaled = model.getOutputScaled();


### PR DESCRIPTION
Adds an `nIter` environment variable which can speed up TSNE build times when set below the default `1000`. On my machine the build times were:

- 29.617s at nIter=10
- 37.75s at nIter=100
- 180.087s at nIter=500
- 351.423s at nIter=1000

The visualization seems to become visually acceptable at about nIter=100. nIter 10:

![nIter-10](https://github.com/user-attachments/assets/e8a68188-2082-4bcb-a84d-3b12ed835de8)

nIter 100:

![nIter-100](https://github.com/user-attachments/assets/11a999a7-097a-4278-9ae9-f4a7459a9852)

---

This also removes the "error" that always printed up to now on building the TSNE visualization. Running the tsne model returns an error variable, but this represents the error metric of the model, *not* an error as in a malfunction.
