### PR TITLE
Restore Sean as default editor

### DIFF
--- a/site/gatsby-site/src/components/cite/citationTypes/BibTex.js
+++ b/site/gatsby-site/src/components/cite/citationTypes/BibTex.js
@@ -22,7 +22,7 @@ const BibTex = ({ nodes, incidentDate, incident_id, incidentTitle, editors }) =>
   // Only return the earliest submitter
   let submitterCite = getFormattedName(docs[0]['submitters'][0]);
 
-  const [firstEditor] = editors;
+  const firstEditor = editors[0] || { first_name: 'Sean', last_name: 'McGregor' };
 
   const { first_name, last_name } = firstEditor;
 

--- a/site/gatsby-site/src/components/cite/citationTypes/Citation.js
+++ b/site/gatsby-site/src/components/cite/citationTypes/Citation.js
@@ -41,7 +41,7 @@ const Citation = ({ nodes, incidentDate, incident_id, incidentTitle, editors }) 
     setRetrievalString(text);
   }, []);
 
-  const [firstEditor] = editors;
+  const firstEditor = editors[0] || { first_name: 'Sean', last_name: 'McGregor' };
 
   const { first_name, last_name: editorLastName } = firstEditor;
 


### PR DESCRIPTION
Currently the page crashes if no editor is found, which happens in staging because it's missing users from the database https://github.com/responsible-ai-collaborative/aiid/issues/3590. Previously the default editor displayed in the citations was Sean. Although ideally we should have the actual editor associated with each incident, we don't want the page to crash in situations like the above. So this changes it back.