### PR TITLE
Fix `Successfully loads and displays incident links` test

### DIFF
--- a/site/gatsby-site/playwright/e2e/incidentLinks.spec.ts
+++ b/site/gatsby-site/playwright/e2e/incidentLinks.spec.ts
@@ -24,7 +24,7 @@ test.describe('Incident Links', () => {
             const linkSelector = `a[href="${link.sameAs}"]`;
             const dropdownItem = page.locator(linkSelector);
             await expect(dropdownItem).toBeVisible();
-            await expect(dropdownItem).toHaveText(link.sameAs.split('/').pop());
+            await expect(dropdownItem).toHaveText(`Report ${link.sameAs.split('/').pop()}`);
         }
     });
 });


### PR DESCRIPTION
This PR fixes this failing test:
https://github.com/responsible-ai-collaborative/aiid/actions/runs/15496697654/job/43636031071
