### PR TITLE
Fix displayOptions on discover reload

### DIFF
--- a/site/gatsby-site/src/components/discover/Discover.js
+++ b/site/gatsby-site/src/components/discover/Discover.js
@@ -76,8 +76,8 @@ export default function Discover() {
     // Set the current page from the URL, defaulting to 0 (Algolia's pagination is zero-based)
     setCurrentPage(!isNaN(page) ? page - 1 : 0);
 
-    // If there are no query params, set the defaults
-    if ([...params.keys()].length === 0) {
+    // If both 'hideDuplicates' and 'is_incident_report' are missing, set the defaults
+    if (!params.has('hideDuplicates') && !params.has('is_incident_report')) {
       params.set('hideDuplicates', '1');
       params.set('is_incident_report', 'true');
       navigate(`?${params.toString()}`, { replace: true });

--- a/site/gatsby-site/src/components/discover/Discover.js
+++ b/site/gatsby-site/src/components/discover/Discover.js
@@ -75,6 +75,13 @@ export default function Discover() {
 
     // Set the current page from the URL, defaulting to 0 (Algolia's pagination is zero-based)
     setCurrentPage(!isNaN(page) ? page - 1 : 0);
+
+    // If there are no query params, set the defaults
+    if ([...params.keys()].length === 0) {
+      params.set('hideDuplicates', '1');
+      params.set('is_incident_report', 'true');
+      navigate(`?${params.toString()}`, { replace: true });
+    }
   }, []);
 
   if (width == 0) {

--- a/site/gatsby-site/src/components/discover/queryParams.js
+++ b/site/gatsby-site/src/components/discover/queryParams.js
@@ -28,7 +28,7 @@ const queryConfig = {
   display: DisplayModeEnumParam,
   page: withDefault(NumberParam, 1),
   hideDuplicates: withDefault(BooleanParam, false),
-  is_incident_report: withDefault(StringParam, 'true'),
+  is_incident_report: StringParam,
   sortBy: withDefault(StringParam, 'relevance'),
   tags: StringParam,
   language: StringParam,

--- a/site/gatsby-site/src/components/discover/queryParams.js
+++ b/site/gatsby-site/src/components/discover/queryParams.js
@@ -27,7 +27,7 @@ const queryConfig = {
   epoch_date_published_max: StringParam,
   display: DisplayModeEnumParam,
   page: withDefault(NumberParam, 1),
-  hideDuplicates: withDefault(BooleanParam, true),
+  hideDuplicates: withDefault(BooleanParam, false),
   is_incident_report: withDefault(StringParam, 'true'),
   sortBy: withDefault(StringParam, 'relevance'),
   tags: StringParam,


### PR DESCRIPTION
- closes #3651 

On the `displayOptions` settings we have the following:
```
const displayOptions = [
  {
    text: 'Incidents',
    state: {
      configure: { distinct: true },
      refinementList: { is_incident_report: ['true'] },
    },
  },
  {
    text: 'Incident and Issue Reports',
    state: {
      configure: { distinct: false },
      refinementList: { is_incident_report: ['false', 'true'] },
    },
  },
  {
    text: 'Incident Reports',
    state: {
      configure: { distinct: false },
      refinementList: { is_incident_report: ['true'] },
    },
  },
  {
    text: 'Issue Reports',
    state: {
      configure: { distinct: false },
      refinementList: { is_incident_report: ['false'] },
    },
  },
];
```

If we default `hideDuplicates: withDefault(BooleanParam, true),` it will expect distinct to be true every time.


This PR fixes the logic to load the display options based on the URL parameters. It also takes into consideration the other selected filters and sort options.
