### PR TITLE
Don't call `FindUserSubscriptions` on the entity page if the user is not authenticated

### DIFF
--- a/site/gatsby-site/src/templates/entity.js
+++ b/site/gatsby-site/src/templates/entity.js
@@ -35,7 +35,7 @@ const incidentFields = [
 const EntityPage = ({ pageContext, data, ...props }) => {
   const { id, name, relatedEntities, entityRelationships } = pageContext;
 
-  const { isRole, user } = useUserContext();
+  const { isRole, user, loading } = useUserContext();
 
   const addToast = useToastContext();
 
@@ -136,6 +136,7 @@ const EntityPage = ({ pageContext, data, ...props }) => {
         entityId: { EQ: id },
       },
     },
+    skip: !user || loading,
     notifyOnNetworkStatusChange: true,
   });
 


### PR DESCRIPTION
This fixes:
- https://github.com/responsible-ai-collaborative/aiid/issues/3686