### PR TITLE
Fix precedent cards not appearing in checklist risks

### DIFF
--- a/site/gatsby-site/server/fields/checklists.ts
+++ b/site/gatsby-site/server/fields/checklists.ts
@@ -116,11 +116,11 @@ export const queryFields: GraphQLFieldConfigMap<any, any> = {
                 ).toArray()
             );
 
-            const tagsByIncidentId: any = {};
+            const searchTagsByIncidentId: any = {};
             for (const classification of classificationsMatchingSearchTags) {
                 for (const id of classification.incidents) {
-                    tagsByIncidentId[id] = (
-                        (tagsByIncidentId[id] || []).concat(
+                    searchTagsByIncidentId[id] = (
+                        (searchTagsByIncidentId[id] || []).concat(
                             tagsFromClassification(classification)
                         )
                     );
@@ -160,6 +160,17 @@ export const queryFields: GraphQLFieldConfigMap<any, any> = {
                 ).toArray()
             )
 
+            const failureTagsByIncidentId: any = {};
+            for (const classification of failureClassificationsMatchingIncidentIds) {
+                for (const id of classification.incidents) {
+                    failureTagsByIncidentId[id] = (
+                        (failureTagsByIncidentId[id] || []).concat(
+                            tagsFromClassification(classification)
+                        )
+                    );
+                }
+            }
+
             const matchingClassificationsByFailure = groupByMultiple(
                 failureClassificationsMatchingIncidentIds,
                 (classification: any) => tagsFromClassification(classification).filter(
@@ -179,7 +190,13 @@ export const queryFields: GraphQLFieldConfigMap<any, any> = {
                         (failureClassification: any) => (
                             incidentsMatchingSearchTags
                                 .filter((incident: any) => failureClassification.incidents.includes(incident.incident_id))
-                                .map((incident: any) => ({ ...incident, tags: tagsByIncidentId[incident.incident_id] }))
+                                .map((incident: any) => ({ 
+                                  ...incident, 
+                                  tags: Array.from(new Set(
+                                    searchTagsByIncidentId[incident.incident_id]
+                                      .concat(failureTagsByIncidentId[incident.incident_id])
+                                  ))
+                                }))
                         )
                     ).flat()
                 })


### PR DESCRIPTION
Resolves https://github.com/responsible-ai-collaborative/aiid/issues/3585.

This is the last show-stopping bug on risk checklists.

This was a tricky one – although the API used failure tags on the precedents to determine that they were precedents, it wasn't including them in the response. Because we need to show precedents for both generated and manual risks, the precedents to display are picked by filtering all precedents to those with matching tags. But the necessary tags weren't always there, leading to situations where a risk was raised but no precedents appeared.