### PR TITLE
Make production builds run less frequently

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "0 6,18 * * *"
+    - cron: "9 18 */2 * *"
   workflow_dispatch:
     inputs:
       skip-cache:


### PR DESCRIPTION
At 18:09 on every 2nd day-of-month.

Cost reduction. We can trigger them manually after doing major ingestions of reports.