### PR TITLE
Add basic rate limiting to graphQL endpoint

### DIFF
--- a/site/gatsby-site/deploy-netlify.toml
+++ b/site/gatsby-site/deploy-netlify.toml
@@ -22,6 +22,11 @@
   from = "/api/graphql"
   to = "/.netlify/functions/graphql"
   status = 200
+  [redirects.rate_limit]
+    # 100 requests per 60 seconds, per unique IP + domain
+    window_limit = 100
+    window_size = 60
+    aggregate_by = ["ip", "domain"]
 
 [[redirects]]
   from = "/api/parseNews"


### PR DESCRIPTION
Per: https://docs.netlify.com/manage/security/secure-access-to-sites/rate-limiting/#set-limits-for-redirects

If this doesn't work, we can try setting the limit at the function logic:
https://docs.netlify.com/manage/security/secure-access-to-sites/rate-limiting/#set-limits-for-functions