### PR TITLE
Configure connection pooling for MongoDB client in graphQL serverless function

### DIFF
--- a/site/gatsby-site/netlify/functions/graphql.ts
+++ b/site/gatsby-site/netlify/functions/graphql.ts
@@ -46,8 +46,8 @@ const server = new ApolloServer({
 });
 
 const client = new MongoClient(config.API_MONGODB_CONNECTION_STRING, {
-    maxPoolSize: 10,
-    minPoolSize: 1,
+    maxPoolSize: 10,  // default 100
+    minPoolSize: 1,  // default 0
     maxIdleTimeMS: 60000,
 });
 


### PR DESCRIPTION
The max default connections (100) and no idle connection limit might be resulting in large amounts of connections.