### PR TITLE
Update rate limit window size in Netlify config

### DIFF
--- a/site/gatsby-site/deploy-netlify.toml
+++ b/site/gatsby-site/deploy-netlify.toml
@@ -25,7 +25,7 @@
   [redirects.rate_limit]
     # 100 requests per 60 seconds, per unique IP + domain
     window_limit = 100
-    window_size = 60
+    window_size = 600
     aggregate_by = ["ip", "domain"]
 
 [[redirects]]


### PR DESCRIPTION
Increase rate limit window size from 60 to 600 seconds.