### PR TITLE
Change rate limit window size from 600 to 180

### DIFF
--- a/site/gatsby-site/deploy-netlify.toml
+++ b/site/gatsby-site/deploy-netlify.toml
@@ -25,7 +25,7 @@
   [redirects.rate_limit]
     # 100 requests per 60 seconds, per unique IP + domain
     window_limit = 100
-    window_size = 600
+    window_size = 180
     aggregate_by = ["ip", "domain"]
 
 [[redirects]]


### PR DESCRIPTION
Reduce the rate limit window size for redirects.

The former value was larger than the permitted value found in a comment here: https://docs.netlify.com/manage/security/secure-access-to-sites/rate-limiting/#add-rules-in-code