### PR TITLE
Create deploy-only (no tests, no notifications) workflow for production

### DIFF
--- a/.github/workflows/production-deploy-only.yml
+++ b/.github/workflows/production-deploy-only.yml
@@ -1,4 +1,4 @@
-name: Deploy Production Branch (NO TESTS, NOTIFICATIONS)
+name: Deploy Production Branch (NO TESTS, NO NOTIFICATIONS)
 
 on:
   push:


### PR DESCRIPTION
In the future, can also add an input variable to make this also work for staging.

On merging this, I would cancel the staging deploy, then merge production and cancel that too.