### PR TITLE
Check origin, referrer, and user agent headers in graphQL API POST requests

### DIFF
--- a/site/gatsby-site/netlify/functions/graphql.ts
+++ b/site/gatsby-site/netlify/functions/graphql.ts
@@ -65,7 +65,7 @@ const graphqlHandler = startServerAndCreateLambdaHandler(
 
 const ALLOWED_ORIGINS = [
     'https://incidentdatabase.ai',
-    'https://aiid-staging.netlify.app',
+    'https://staging-aiid.netlify.app',
 ];
 
 const BLOCKED_AGENTS = [


### PR DESCRIPTION
Introduces simple checks against origin, referrer, and user agent headers to only restrict POST requests to those coming from AIID domains and filter some automated user agents by default.

This does not filter GET requests so that the Apollo playground can still be opened at the endpoint (all queries in question are POSTs).

Introduces the `API_VALIDATE_ORIGIN` and `API_VALIDATE_USER_AGENT` env variables to enable this behavior. They will need to be set at the Netlify function UI interface, and only take effect when a new site deploy happens (initiated from GitHub Actions in this repo). I'm 95% sure the variables are not pushed from the GH action.

Of note, if these are enabled, the integrity tests/probes that hit the live site might fail. For moving these, see:
* https://github.com/responsible-ai-collaborative/aiid/pull/3801