### PR TITLE
Add cross-taxonomy visualization page

### DIFF
--- a/site/gatsby-site/config.js
+++ b/site/gatsby-site/config.js
@@ -87,6 +87,12 @@ const config = {
       { title: 'List View', label: 'list', url: '/summaries/incidents/', items: [] },
       { title: 'Entities', label: 'entities', url: '/entities/', items: [] },
       { title: 'Taxonomies', label: 'taxonomies', url: '/taxonomies/', items: [] },
+      {
+        title: 'Cross-Taxonomy Visualizations',
+        label: 'cross-taxonomy',
+        url: '/apps/cross-taxonomy/',
+        items: [],
+      },
       { title: 'Random Incident', label: 'random', url: '/random/', items: [] },
       { title: 'Submit Incident Reports', label: 'submit', url: '/apps/submit/', items: [] },
       { title: 'Risk Checklists', label: 'checklists', url: '/apps/checklists/', items: [] },

--- a/site/gatsby-site/jest.utils.config.js
+++ b/site/gatsby-site/jest.utils.config.js
@@ -1,0 +1,11 @@
+/**
+ * Minimal Jest config for running pure utility function tests.
+ * Separate from the main jest.config.ts which requires MongoDB setup.
+ */
+module.exports = {
+  testEnvironment: 'node',
+  transform: {
+    '\\.[jt]sx?$': ['babel-jest', { presets: ['@babel/preset-env'] }],
+  },
+  testMatch: ['**/src/utils/__tests__/**/*.test.js'],
+};

--- a/site/gatsby-site/src/components/visualizations/ChartCard.js
+++ b/site/gatsby-site/src/components/visualizations/ChartCard.js
@@ -1,0 +1,151 @@
+import React, { useMemo } from 'react';
+import { Card } from 'flowbite-react';
+import BillboardJS from '@billboard.js/react';
+import bb, { bar, donut } from 'billboard.js';
+import { Trans, useTranslation } from 'react-i18next';
+
+// Color palette matching the AIID taxonomy page style
+const COLORS = [
+  '#3b82f6', // blue
+  '#f59e0b', // amber
+  '#10b981', // emerald
+  '#ef4444', // red
+  '#8b5cf6', // violet
+  '#6b7280', // gray
+  '#ec4899', // pink
+  '#14b8a6', // teal
+  '#f97316', // orange
+  '#06b6d4', // cyan
+  '#84cc16', // lime
+  '#a855f7', // purple
+  '#78716c', // stone
+  '#e11d48', // rose
+  '#0ea5e9', // sky
+  '#d946ef', // fuchsia
+  '#eab308', // yellow
+  '#22c55e', // green
+  '#64748b', // slate
+  '#dc2626', // red-dark
+];
+
+export default function ChartCard({ title, subtitle, counts, chartType = 'bar', maxItems = 15 }) {
+  const { t } = useTranslation();
+
+  const sortedEntries = useMemo(() => {
+    if (!counts) return [];
+
+    return Array.from(counts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, maxItems);
+  }, [counts, maxItems]);
+
+  if (!counts || counts.size === 0) {
+    return (
+      <Card>
+        <h3 className="text-base font-semibold">{t(title)}</h3>
+        {subtitle && <p className="text-xs text-gray-500">{t(subtitle)}</p>}
+        <div className="py-8 text-center text-sm text-gray-400">
+          <Trans>No data available for this analysis.</Trans>
+        </div>
+      </Card>
+    );
+  }
+
+  if (chartType === 'donut') {
+    return <DonutChartCard title={title} subtitle={subtitle} entries={sortedEntries} t={t} />;
+  }
+
+  return <BarChartCard title={title} subtitle={subtitle} entries={sortedEntries} t={t} />;
+}
+
+function BarChartCard({ title, subtitle, entries, t }) {
+  const options = useMemo(() => {
+    // Each category becomes its own data series with a unique color
+    const columns = entries.map(([label, count]) => [label, count]);
+
+    const colors = {};
+
+    entries.forEach(([label], i) => {
+      colors[label] = COLORS[i % COLORS.length];
+    });
+
+    return {
+      data: {
+        columns,
+        type: bar(),
+        colors,
+      },
+      axis: {
+        x: {
+          show: false,
+        },
+        y: {
+          label: { text: t('Count'), position: 'outer-middle' },
+          tick: { format: (x) => (x === Math.floor(x) ? x : '') },
+        },
+      },
+      bar: { width: { ratio: 0.7 } },
+      legend: {
+        show: true,
+        position: 'bottom',
+      },
+      tooltip: { grouped: false },
+      padding: { bottom: 10 },
+      size: { height: Math.max(350, 300 + Math.ceil(entries.length / 3) * 24) },
+      resize: { auto: true },
+    };
+  }, [entries, t]);
+
+  return (
+    <Card>
+      <h3 className="text-base font-semibold">{t(title)}</h3>
+      {subtitle && <p className="text-xs text-gray-500">{t(subtitle)}</p>}
+      <div className="overflow-hidden [&_.bb-ygrid-line>line]:stroke-gray-300 [&_.bb-ygrid-line>line]:stroke-1">
+        <BillboardJS bb={bb} options={options} />
+      </div>
+    </Card>
+  );
+}
+
+function DonutChartCard({ title, subtitle, entries, t }) {
+  const options = useMemo(() => {
+    const columns = entries.map(([label, count]) => [label, count]);
+
+    const colors = {};
+
+    entries.forEach(([label], i) => {
+      colors[label] = COLORS[i % COLORS.length];
+    });
+
+    const names = columns.reduce((obj, [key]) => {
+      obj[key] = t(key);
+      return obj;
+    }, {});
+
+    return {
+      data: {
+        columns,
+        type: donut(),
+        names,
+        colors,
+      },
+      donut: {
+        title: t(title),
+      },
+      legend: {
+        show: true,
+        position: 'bottom',
+      },
+      size: { height: 300 },
+      resize: { auto: true },
+    };
+  }, [entries, t, title]);
+
+  return (
+    <Card>
+      <h3 className="text-base font-semibold">{t(title)}</h3>
+      {subtitle && <p className="text-xs text-gray-500">{t(subtitle)}</p>}
+      <BillboardJS bb={bb} options={options} />
+    </Card>
+  );
+}

--- a/site/gatsby-site/src/components/visualizations/CrossTaxonomyChart.js
+++ b/site/gatsby-site/src/components/visualizations/CrossTaxonomyChart.js
@@ -1,0 +1,109 @@
+import React, { useMemo } from 'react';
+import BillboardJS from '@billboard.js/react';
+import bb, { bar, line, scatter } from 'billboard.js';
+import { toBillboardColumns, toScatterData } from 'utils/crossTaxonomy';
+import { useTranslation } from 'react-i18next';
+
+export default function CrossTaxonomyChart({ chartType, crossData, xLabel, yLabel }) {
+  const { t } = useTranslation();
+
+  const options = useMemo(() => {
+    if (!crossData || crossData.xValues.length === 0) return null;
+
+    if (chartType === 'scatter') {
+      return buildScatterOptions(crossData, xLabel, yLabel, t);
+    }
+    return buildBarLineOptions(crossData, chartType, xLabel, yLabel, t);
+  }, [crossData, chartType, xLabel, yLabel, t]);
+
+  if (!options) return null;
+
+  const height = Math.max(400, crossData.xValues.length * 25 + 100);
+
+  return (
+    <div className="[&_.bb-ygrid-line>line]:stroke-gray-300 [&_.bb-ygrid-line>line]:stroke-1">
+      <BillboardJS
+        bb={bb}
+        options={{
+          ...options,
+          size: { height },
+          resize: { auto: true },
+        }}
+      />
+    </div>
+  );
+}
+
+function buildBarLineOptions(crossData, chartType, xLabel, yLabel, t) {
+  const columns = toBillboardColumns(crossData);
+
+  const chartTypeFunc = chartType === 'line' ? line() : bar();
+
+  const isStacked = chartType === 'histogram';
+
+  return {
+    data: {
+      x: 'x',
+      columns,
+      type: chartTypeFunc,
+      groups: isStacked ? [crossData.yValues] : [],
+    },
+    axis: {
+      x: {
+        type: 'category',
+        label: { text: t(xLabel), position: 'outer-center' },
+        tick: { rotate: crossData.xValues.length > 8 ? -45 : 0, tooltip: true },
+        height: crossData.xValues.length > 8 ? 120 : 60,
+      },
+      y: {
+        label: { text: t(yLabel), position: 'outer-middle' },
+      },
+    },
+    bar: {
+      width: { ratio: 0.7 },
+    },
+    legend: {
+      show: crossData.yValues.length <= 20,
+    },
+    tooltip: {
+      grouped: true,
+    },
+  };
+}
+
+function buildScatterOptions(crossData, xLabel, yLabel, t) {
+  const { xs, columns, xValues } = toScatterData(crossData);
+
+  return {
+    data: {
+      xs,
+      columns,
+      type: scatter(),
+    },
+    axis: {
+      x: {
+        label: { text: t(xLabel), position: 'outer-center' },
+        tick: {
+          format: (i) => xValues[Math.round(i)] || '',
+          rotate: xValues.length > 8 ? -45 : 0,
+        },
+        height: xValues.length > 8 ? 120 : 60,
+      },
+      y: {
+        label: { text: t('Count'), position: 'outer-middle' },
+        min: 0,
+      },
+    },
+    legend: {
+      show: crossData.yValues.length <= 20,
+    },
+    point: {
+      r: 5,
+    },
+    tooltip: {
+      format: {
+        title: (i) => xValues[Math.round(i)] || '',
+      },
+    },
+  };
+}

--- a/site/gatsby-site/src/components/visualizations/GuidedAnalysisTab.js
+++ b/site/gatsby-site/src/components/visualizations/GuidedAnalysisTab.js
@@ -1,0 +1,184 @@
+import React, { useMemo } from 'react';
+import { Select } from 'flowbite-react';
+import { Trans, useTranslation } from 'react-i18next';
+import ChartCard from './ChartCard';
+import {
+  buildFilteredCounts,
+  getFieldValues,
+  countFilteredIncidents,
+  getEntityValues,
+  countEntityIncidents,
+  buildEntityFilteredCounts,
+} from 'utils/crossTaxonomy';
+
+/**
+ * A generic guided analysis tab. Given a config object describing:
+ * - which field the user selects from (selectorField or entity-based)
+ * - which charts to generate (charts array)
+ *
+ * It renders a dropdown populated from real data, and a grid of charts
+ * filtered by the user's selection.
+ *
+ * Config shape (classification-based):
+ * {
+ *   selectorField: { namespace: string, short_name: string },
+ *   selectorLabel: string,
+ *   charts: [{ title, subtitle?, namespace, field, type }]
+ * }
+ *
+ * Config shape (entity-based — for By Developer / By Deployer):
+ * {
+ *   selectorSource: 'entity',
+ *   selectorEntityField: 'developers' | 'deployers' | 'harmedParties',
+ *   selectorLabel: string,
+ *   charts: [{ title, subtitle?, namespace, field, type }]
+ * }
+ */
+export default function GuidedAnalysisTab({
+  config,
+  selectedValue,
+  onSelectValue,
+  groupedClassifications,
+  allClassifications,
+  incidentEntityMap,
+}) {
+  const { t } = useTranslation();
+
+  const isEntitySource = config.selectorSource === 'entity';
+
+  // Get available values for the selector dropdown, sorted by frequency
+  const selectorOptions = useMemo(() => {
+    if (isEntitySource) {
+      return getEntityValues(incidentEntityMap, config.selectorEntityField);
+    }
+
+    return getFieldValues(
+      allClassifications,
+      config.selectorField.namespace,
+      config.selectorField.short_name
+    );
+  }, [allClassifications, incidentEntityMap, config, isEntitySource]);
+
+  // Count total incidents for the selected value
+  const incidentCount = useMemo(() => {
+    if (!selectedValue) return 0;
+    if (isEntitySource) {
+      return countEntityIncidents(incidentEntityMap, config.selectorEntityField, selectedValue);
+    }
+
+    return countFilteredIncidents(
+      groupedClassifications,
+      config.selectorField.namespace,
+      config.selectorField.short_name,
+      selectedValue
+    );
+  }, [groupedClassifications, incidentEntityMap, config, selectedValue, isEntitySource]);
+
+  // Build chart data for each chart in the config
+  const chartData = useMemo(() => {
+    if (!selectedValue) return [];
+
+    return config.charts.map((chart) => {
+      let result;
+
+      if (isEntitySource) {
+        result = buildEntityFilteredCounts(
+          groupedClassifications,
+          incidentEntityMap,
+          config.selectorEntityField,
+          selectedValue,
+          chart.namespace,
+          chart.field
+        );
+      } else {
+        result = buildFilteredCounts(
+          groupedClassifications,
+          config.selectorField.namespace,
+          config.selectorField.short_name,
+          selectedValue,
+          chart.namespace,
+          chart.field
+        );
+      }
+
+      return { ...chart, counts: result.counts, incidentCount: result.incidentCount };
+    });
+  }, [groupedClassifications, incidentEntityMap, config, selectedValue, isEntitySource]);
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Selector */}
+      <div className="flex flex-wrap items-end gap-4">
+        <div className="flex flex-col gap-1">
+          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+          <label className="text-sm font-medium text-gray-700">{t(config.selectorLabel)}</label>
+          <Select
+            value={selectedValue}
+            onChange={(e) => onSelectValue(e.target.value)}
+            className="min-w-[280px]"
+          >
+            <option value="">— {t('Select')} —</option>
+            {selectorOptions.map(({ value, count }) => (
+              <option key={value} value={value}>
+                {value} ({count} {t('incidents')})
+              </option>
+            ))}
+          </Select>
+        </div>
+      </div>
+
+      {/* Results */}
+      {selectedValue && (
+        <>
+          {/* Sample size header */}
+          <div className="text-sm text-gray-600">
+            <span className="font-semibold text-lg text-gray-900">N = {incidentCount}</span>{' '}
+            <Trans>classified incidents involving</Trans>{' '}
+            <span className="font-medium">&quot;{selectedValue}&quot;</span>
+          </div>
+
+          {incidentCount < 3 && (
+            <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 text-yellow-800 text-sm">
+              <Trans>
+                Too few classified incidents ({{ count: incidentCount }}) to generate meaningful
+                visualizations. Try selecting a more commonly represented option.
+              </Trans>
+            </div>
+          )}
+
+          {incidentCount >= 3 && (
+            <>
+              {incidentCount < 10 && (
+                <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3 text-yellow-800 text-xs">
+                  <Trans>
+                    Small sample size ({{ count: incidentCount }} incidents). Results may not be
+                    representative.
+                  </Trans>
+                </div>
+              )}
+
+              {/* Chart grid */}
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                {chartData.map((chart, i) => (
+                  <ChartCard
+                    key={`${selectedValue}-${i}`}
+                    title={chart.title}
+                    subtitle={chart.subtitle}
+                    counts={chart.counts}
+                    chartType={chart.type}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+        </>
+      )}
+
+      {!selectedValue && (
+        <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center text-gray-500">
+          <Trans>Select an option above to generate visualizations.</Trans>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/site/gatsby-site/src/pages/apps/cross-taxonomy.js
+++ b/site/gatsby-site/src/pages/apps/cross-taxonomy.js
@@ -1,0 +1,643 @@
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { useApolloClient } from '@apollo/client';
+import gql from 'graphql-tag';
+import { FIND_CLASSIFICATION } from '../../graphql/classifications';
+import { Button, Select, Spinner, Card, Badge } from 'flowbite-react';
+import { Trans, useTranslation } from 'react-i18next';
+import { useUserContext } from 'contexts/UserContext';
+import HeadContent from 'components/HeadContent';
+import CrossTaxonomyChart from 'components/visualizations/CrossTaxonomyChart';
+import GuidedAnalysisTab from 'components/visualizations/GuidedAnalysisTab';
+import {
+  groupClassificationsByIncident,
+  getAvailableFields,
+  buildCrossData,
+  buildIncidentEntityMap,
+} from 'utils/crossTaxonomy';
+import { StringParam, useQueryParams, withDefault } from 'use-query-params';
+
+const TABS = [
+  { id: 'developer', label: 'By Developer' },
+  { id: 'deployer', label: 'By Deployer' },
+  { id: 'affected', label: 'By Affected Group' },
+  { id: 'technology', label: 'By Technology' },
+  { id: 'custom', label: 'Custom Explorer' },
+];
+
+const GUIDED_TAB_CONFIGS = {
+  developer: {
+    selectorSource: 'entity',
+    selectorEntityField: 'developers',
+    selectorLabel: 'Select a Developer',
+    charts: [
+      {
+        title: 'Sector of Deployment',
+        subtitle: "Sectors where this developer's AI is deployed",
+        namespace: 'CSETv1',
+        field: 'Sector of Deployment',
+        type: 'bar',
+      },
+      {
+        title: 'Failure Modes',
+        subtitle: 'Known technical failures in incidents',
+        namespace: 'GMF',
+        field: 'Known AI Technical Failure',
+        type: 'bar',
+      },
+      {
+        title: 'Affected Demographics',
+        subtitle: 'Demographic groups disproportionately affected',
+        namespace: 'CSETv1',
+        field: 'Harm Distribution Basis',
+        type: 'bar',
+      },
+      {
+        title: 'Intent',
+        subtitle: 'Whether harms were intentional or unintentional',
+        namespace: 'MIT',
+        field: 'Intent',
+        type: 'donut',
+      },
+      {
+        title: 'Risk Domains',
+        subtitle: 'Risk categories from the MIT AI Risk Repository',
+        namespace: 'MIT',
+        field: 'Risk Domain',
+        type: 'bar',
+      },
+    ],
+  },
+  deployer: {
+    selectorSource: 'entity',
+    selectorEntityField: 'deployers',
+    selectorLabel: 'Select a Deployer',
+    charts: [
+      {
+        title: 'AI Technologies Used',
+        subtitle: 'Known AI technologies involved in incidents',
+        namespace: 'GMF',
+        field: 'Known AI Technology',
+        type: 'bar',
+      },
+      {
+        title: 'What Goes Wrong',
+        subtitle: 'Technical failures in incidents involving this deployer',
+        namespace: 'GMF',
+        field: 'Known AI Technical Failure',
+        type: 'bar',
+      },
+      {
+        title: 'Who Is Affected',
+        subtitle: 'Demographic groups impacted',
+        namespace: 'CSETv1',
+        field: 'Harm Distribution Basis',
+        type: 'bar',
+      },
+      {
+        title: 'Sector of Deployment',
+        subtitle: 'Deployment sectors where incidents occurred',
+        namespace: 'CSETv1',
+        field: 'Sector of Deployment',
+        type: 'bar',
+      },
+      {
+        title: 'Risk Domains',
+        subtitle: 'Risk categories from the MIT AI Risk Repository',
+        namespace: 'MIT',
+        field: 'Risk Domain',
+        type: 'bar',
+      },
+    ],
+  },
+  affected: {
+    selectorField: { namespace: 'CSETv1', short_name: 'Harm Distribution Basis' },
+    selectorLabel: 'Select an Affected Group',
+    charts: [
+      {
+        title: 'Which Sectors',
+        subtitle: 'Deployment sectors associated with harm to this group',
+        namespace: 'CSETv1',
+        field: 'Sector of Deployment',
+        type: 'bar',
+      },
+      {
+        title: 'Which Technologies',
+        subtitle: 'AI technologies involved in harm to this group',
+        namespace: 'GMF',
+        field: 'Known AI Technology',
+        type: 'bar',
+      },
+      {
+        title: 'Harm Domain',
+        subtitle: 'Categories of harm experienced',
+        namespace: 'CSETv1',
+        field: 'Harm Domain',
+        type: 'bar',
+      },
+      {
+        title: 'Failure Modes',
+        subtitle: 'Technical failures involved',
+        namespace: 'GMF',
+        field: 'Known AI Technical Failure',
+        type: 'bar',
+      },
+      {
+        title: 'Intentional vs Unintentional',
+        subtitle: 'Whether harms were intentional',
+        namespace: 'MIT',
+        field: 'Intent',
+        type: 'donut',
+      },
+    ],
+  },
+  technology: {
+    selectorField: { namespace: 'GMF', short_name: 'Known AI Technology' },
+    selectorLabel: 'Select a Technology',
+    charts: [
+      {
+        title: 'Deployment Sectors',
+        subtitle: 'Where this technology is deployed',
+        namespace: 'CSETv1',
+        field: 'Sector of Deployment',
+        type: 'bar',
+      },
+      {
+        title: 'Failure Modes',
+        subtitle: 'Technical failures associated with this technology',
+        namespace: 'GMF',
+        field: 'Known AI Technical Failure',
+        type: 'bar',
+      },
+      {
+        title: 'Who Is Harmed',
+        subtitle: 'Demographic groups affected',
+        namespace: 'CSETv1',
+        field: 'Harm Distribution Basis',
+        type: 'bar',
+      },
+      {
+        title: 'Risk Domains',
+        subtitle: 'Risk categories from the MIT AI Risk Repository',
+        namespace: 'MIT',
+        field: 'Risk Domain',
+        type: 'bar',
+      },
+      {
+        title: 'Harm Domain',
+        subtitle: 'Types of harm caused by this technology',
+        namespace: 'CSETv1',
+        field: 'Harm Domain',
+        type: 'bar',
+      },
+    ],
+  },
+};
+
+const CHART_TYPES = [
+  { value: 'bar', label: 'Bar Chart' },
+  { value: 'histogram', label: 'Stacked Bar Chart' },
+  { value: 'line', label: 'Line Chart' },
+  { value: 'scatter', label: 'Scatter Plot' },
+];
+
+const FIND_TAXA = gql`
+  query FindTaxa {
+    taxas {
+      namespace
+      weight
+      description
+      field_list {
+        field_number
+        short_name
+        long_name
+        display_type
+        mongo_type
+        permitted_values
+        instant_facet
+        public
+      }
+    }
+  }
+`;
+
+const FIND_INCIDENTS_ENTITIES = gql`
+  query FindIncidentsEntities {
+    incidents(pagination: { limit: 9999, skip: 0 }) {
+      incident_id
+      AllegedDeveloperOfAISystem {
+        entity_id
+        name
+      }
+      AllegedDeployerOfAISystem {
+        entity_id
+        name
+      }
+      AllegedHarmedOrNearlyHarmedParties {
+        entity_id
+        name
+      }
+    }
+  }
+`;
+
+export default function CrossTaxonomyPage(props) {
+  const { isAdmin } = useUserContext();
+
+  const { t } = useTranslation();
+
+  const client = useApolloClient();
+
+  const [loading, setLoading] = useState(true);
+
+  const [allTaxas, setAllTaxas] = useState([]);
+
+  const [allClassifications, setAllClassifications] = useState([]);
+
+  const [incidentEntityMap, setIncidentEntityMap] = useState(new Map());
+
+  // URL query params for all state
+  const [query, setQuery] = useQueryParams({
+    tab: withDefault(StringParam, ''),
+    sel: withDefault(StringParam, ''),
+    chartType: withDefault(StringParam, ''),
+    x: withDefault(StringParam, ''),
+    y: withDefault(StringParam, ''),
+    filterField: withDefault(StringParam, ''),
+    filterValue: withDefault(StringParam, ''),
+  });
+
+  const activeTab = query.tab || 'developer';
+
+  const guidedSelection = query.sel || '';
+
+  const chartType = query.chartType || 'bar';
+
+  const xAxisKey = query.x || '';
+
+  const yAxisKey = query.y || '';
+
+  const filterKey = query.filterField || '';
+
+  const filterValue = query.filterValue || '';
+
+  const setActiveTab = useCallback(
+    (tab) => setQuery({ tab: tab || undefined, sel: undefined }),
+    [setQuery]
+  );
+
+  const setGuidedSelection = useCallback((v) => setQuery({ sel: v || undefined }), [setQuery]);
+
+  const setChartType = useCallback((v) => setQuery({ chartType: v || undefined }), [setQuery]);
+
+  const setXAxisKey = useCallback((v) => setQuery({ x: v || undefined }), [setQuery]);
+
+  const setYAxisKey = useCallback((v) => setQuery({ y: v || undefined }), [setQuery]);
+
+  const setFilterKey = useCallback(
+    (v) => setQuery({ filterField: v || undefined, filterValue: undefined }),
+    [setQuery]
+  );
+
+  const setFilterValue = useCallback((v) => setQuery({ filterValue: v || undefined }), [setQuery]);
+
+  const copyShareLink = useCallback(() => {
+    if (typeof navigator !== 'undefined' && navigator.clipboard) {
+      navigator.clipboard.writeText(window.location.href);
+    }
+  }, [query]);
+
+  // Fetch all taxa and classifications on mount
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchData() {
+      setLoading(true);
+      try {
+        const [taxaResult, classResult, incidentsResult] = await Promise.all([
+          client.query({ query: FIND_TAXA }),
+          client.query({ query: FIND_CLASSIFICATION, variables: { filter: {} } }),
+          client.query({ query: FIND_INCIDENTS_ENTITIES }),
+        ]);
+
+        if (cancelled) return;
+
+        let taxas = taxaResult.data.taxas;
+
+        if (!isAdmin) {
+          taxas = taxas.map((taxa) => ({
+            ...taxa,
+            field_list: taxa.field_list.filter((f) => f.public !== false),
+          }));
+        }
+
+        const classifications = classResult.data.classifications.filter(
+          (c) => c.attributes && (c.publish || isAdmin)
+        );
+
+        setAllTaxas(taxas);
+        setAllClassifications(classifications);
+        setIncidentEntityMap(buildIncidentEntityMap(incidentsResult.data.incidents || []));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    fetchData();
+    return () => {
+      cancelled = true;
+    };
+  }, [isAdmin]);
+
+  // Shared computed data
+  const groupedClassifications = useMemo(
+    () => groupClassificationsByIncident(allClassifications),
+    [allClassifications]
+  );
+
+  const availableFields = useMemo(() => getAvailableFields(allTaxas), [allTaxas]);
+
+  const fieldsByNamespace = useMemo(() => {
+    const grouped = {};
+
+    for (const f of availableFields) {
+      if (!grouped[f.namespace]) grouped[f.namespace] = [];
+      grouped[f.namespace].push(f);
+    }
+    return grouped;
+  }, [availableFields]);
+
+  // Custom explorer logic
+  const parseKey = useCallback((key) => {
+    if (!key) return { namespace: '', field: '' };
+    const [namespace, ...rest] = key.split('::');
+
+    return { namespace, field: rest.join('::') };
+  }, []);
+
+  const xAxis = parseKey(xAxisKey);
+
+  const yAxis = parseKey(yAxisKey);
+
+  const filter = parseKey(filterKey);
+
+  const crossData = useMemo(() => {
+    if (!xAxis.namespace || !yAxis.namespace) return null;
+    return buildCrossData(
+      groupedClassifications,
+      xAxis.namespace,
+      xAxis.field,
+      yAxis.namespace,
+      yAxis.field,
+      filter.namespace || null,
+      filter.field || null,
+      filterValue || null
+    );
+  }, [groupedClassifications, xAxis, yAxis, filter, filterValue]);
+
+  const filterOptions = useMemo(() => {
+    if (!filter.namespace || !filter.field) return [];
+    const values = new Set();
+
+    for (const c of allClassifications) {
+      if (c.namespace !== filter.namespace) continue;
+      const attr = c.attributes?.find((a) => a.short_name === filter.field);
+
+      if (!attr) continue;
+      try {
+        const parsed = JSON.parse(attr.value_json);
+
+        if (Array.isArray(parsed)) {
+          parsed.forEach((v) => v && values.add(String(v)));
+        } else if (parsed !== null && parsed !== undefined && parsed !== '') {
+          values.add(typeof parsed === 'boolean' ? (parsed ? 'Yes' : 'No') : String(parsed));
+        }
+      } catch {
+        // skip unparseable
+      }
+    }
+    return Array.from(values).sort();
+  }, [allClassifications, filter]);
+
+  const renderFieldSelect = (value, onChange, label) => (
+    <div className="flex flex-col gap-1">
+      <label className="text-sm font-medium text-gray-700">{label}</label>
+      <Select value={value} onChange={(e) => onChange(e.target.value)} className="min-w-[220px]">
+        <option value="">— {t('Select a field')} —</option>
+        {Object.entries(fieldsByNamespace).map(([namespace, fields]) => (
+          <optgroup key={namespace} label={namespace}>
+            {fields.map((f) => (
+              <option key={`${namespace}::${f.short_name}`} value={`${namespace}::${f.short_name}`}>
+                {f.short_name}
+              </option>
+            ))}
+          </optgroup>
+        ))}
+      </Select>
+    </div>
+  );
+
+  const hasSelection = activeTab === 'custom' ? xAxisKey && yAxisKey : guidedSelection;
+
+  return (
+    <div {...props}>
+      <div className="flex flex-col gap-6">
+        {/* Header */}
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-bold">
+              <Trans>Cross-Taxonomy Visualizations</Trans>
+            </h1>
+            <p className="text-gray-600 mt-1">
+              <Trans>
+                Explore patterns in AI incidents across taxonomies. Pick a lens below or build a
+                custom chart.
+              </Trans>
+            </p>
+          </div>
+          {hasSelection && (
+            <Button color="light" size="sm" onClick={copyShareLink}>
+              <Trans>Copy Share Link</Trans>
+            </Button>
+          )}
+        </div>
+
+        {loading && (
+          <div className="flex items-center gap-2 py-8 justify-center">
+            <Spinner size="lg" />
+            <Trans>Loading taxonomy data...</Trans>
+          </div>
+        )}
+
+        {!loading && (
+          <>
+            {/* Tab bar */}
+            <div className="border-b border-gray-200">
+              <nav className="flex flex-wrap -mb-px gap-0">
+                {TABS.map((tab) => (
+                  <button
+                    key={tab.id}
+                    onClick={() => setActiveTab(tab.id)}
+                    className={`px-4 py-3 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
+                      activeTab === tab.id
+                        ? 'border-blue-500 text-blue-600'
+                        : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                    }`}
+                  >
+                    {t(tab.label)}
+                  </button>
+                ))}
+              </nav>
+            </div>
+
+            {/* Guided tabs */}
+            {activeTab !== 'custom' && GUIDED_TAB_CONFIGS[activeTab] && (
+              <GuidedAnalysisTab
+                config={GUIDED_TAB_CONFIGS[activeTab]}
+                selectedValue={guidedSelection}
+                onSelectValue={setGuidedSelection}
+                groupedClassifications={groupedClassifications}
+                allClassifications={allClassifications}
+                incidentEntityMap={incidentEntityMap}
+              />
+            )}
+
+            {/* Custom explorer tab */}
+            {activeTab === 'custom' && (
+              <>
+                <Card>
+                  <div className="flex flex-wrap gap-4 items-end">
+                    <div className="flex flex-col gap-1">
+                      {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+                      <label className="text-sm font-medium text-gray-700">
+                        <Trans>Chart Type</Trans>
+                      </label>
+                      <Select
+                        value={chartType}
+                        onChange={(e) => setChartType(e.target.value)}
+                        className="min-w-[180px]"
+                      >
+                        {CHART_TYPES.map((ct) => (
+                          <option key={ct.value} value={ct.value}>
+                            {t(ct.label)}
+                          </option>
+                        ))}
+                      </Select>
+                    </div>
+
+                    {renderFieldSelect(xAxisKey, setXAxisKey, t('X-Axis Field'))}
+                    {renderFieldSelect(yAxisKey, setYAxisKey, t('Y-Axis Field'))}
+                  </div>
+
+                  <div className="flex flex-wrap gap-4 items-end mt-4 pt-4 border-t border-gray-200">
+                    <div className="text-sm font-medium text-gray-700 self-center">
+                      <Trans>Optional Filter:</Trans>
+                    </div>
+                    {renderFieldSelect(filterKey, setFilterKey, t('Filter Field'))}
+
+                    {filterKey && (
+                      <div className="flex flex-col gap-1">
+                        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+                        <label className="text-sm font-medium text-gray-700">
+                          <Trans>Filter Value</Trans>
+                        </label>
+                        <Select
+                          value={filterValue}
+                          onChange={(e) => setFilterValue(e.target.value)}
+                          className="min-w-[200px]"
+                        >
+                          <option value="">— {t('All')} —</option>
+                          {filterOptions.map((v) => (
+                            <option key={v} value={v}>
+                              {v}
+                            </option>
+                          ))}
+                        </Select>
+                      </div>
+                    )}
+
+                    {(filterKey || filterValue) && (
+                      <Button
+                        color="gray"
+                        size="sm"
+                        onClick={() => {
+                          setFilterKey('');
+                          setFilterValue('');
+                        }}
+                      >
+                        <Trans>Clear Filter</Trans>
+                      </Button>
+                    )}
+                  </div>
+                </Card>
+
+                {crossData && (
+                  <div className="flex flex-col gap-4">
+                    <div className="flex items-center gap-2 text-sm text-gray-600">
+                      <span className="font-semibold text-lg text-gray-900">
+                        N = {crossData.incidentCount}
+                      </span>
+                      <Trans>incidents with data for both selected fields</Trans>
+                      {filterValue && (
+                        <Badge color="info">
+                          {filter.field} = &quot;{filterValue}&quot;
+                        </Badge>
+                      )}
+                    </div>
+
+                    {crossData.incidentCount < 5 && (
+                      <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 text-yellow-800 text-sm">
+                        <Trans>
+                          Warning: Only {{ count: crossData.incidentCount }} incidents have
+                          classifications for both selected fields. Results may not be
+                          representative.
+                        </Trans>
+                      </div>
+                    )}
+
+                    {crossData.incidentCount === 0 ? (
+                      <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center text-gray-500">
+                        <Trans>
+                          No incidents found with classifications in both selected fields. Try
+                          selecting fields from the same taxonomy or more commonly used fields.
+                        </Trans>
+                      </div>
+                    ) : (
+                      <Card>
+                        <CrossTaxonomyChart
+                          chartType={chartType}
+                          crossData={crossData}
+                          xLabel={xAxis.field}
+                          yLabel={yAxis.field}
+                        />
+                      </Card>
+                    )}
+                  </div>
+                )}
+
+                {!crossData && !xAxisKey && !yAxisKey && (
+                  <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center text-gray-500">
+                    <Trans>Select fields for both axes above to generate a visualization.</Trans>
+                  </div>
+                )}
+              </>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const Head = (props) => {
+  const {
+    location: { pathname },
+  } = props;
+
+  return (
+    <HeadContent
+      path={pathname}
+      metaTitle="Cross-Taxonomy Visualizations"
+      metaDescription="Visualize relationships between AI incident classification fields across different taxonomies."
+    />
+  );
+};

--- a/site/gatsby-site/src/utils/__tests__/crossTaxonomy.test.js
+++ b/site/gatsby-site/src/utils/__tests__/crossTaxonomy.test.js
@@ -1,0 +1,903 @@
+/* eslint-env jest */
+/**
+ * Unit tests for src/utils/crossTaxonomy.js
+ *
+ * Every function under test is a pure function: data in, data out.
+ * No React, GraphQL, Apollo, or DOM dependencies are needed.
+ */
+
+const {
+  groupClassificationsByIncident,
+  buildFilteredCounts,
+  buildCrossData,
+  toBillboardColumns,
+  buildIncidentEntityMap,
+  getEntityValues,
+  countEntityIncidents,
+  buildEntityFilteredCounts,
+} = require('../crossTaxonomy');
+
+// ─────────────────────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Factory: create a classification document matching the GraphQL schema.
+ *
+ * @param {string} namespace - Taxonomy namespace, e.g. "CSETv1", "GMF", "MIT"
+ * @param {number[]} incidentIds - Array of incident IDs this classification links to
+ * @param {Object} fields - Key-value pairs, e.g. { "Sector of Deployment": "Education" }
+ *                          Values are auto-serialised to value_json (JSON.stringify).
+ * @returns {Object} A classification document shaped like the GraphQL response.
+ */
+function makeClassification(namespace, incidentIds, fields = {}) {
+  return {
+    _id: `${namespace}-${incidentIds.join('-')}-${Math.random().toString(36).slice(2, 6)}`,
+    namespace,
+    incidents: incidentIds.map((id) => ({ incident_id: id })),
+    publish: true,
+    attributes: Object.entries(fields).map(([short_name, value]) => ({
+      short_name,
+      value_json: JSON.stringify(value),
+    })),
+  };
+}
+
+/**
+ * Factory: create an incident document matching the FindIncidentsEntities query shape.
+ *
+ * @param {number} id - incident_id
+ * @param {Object} opts - Optional entity arrays.
+ * @param {Array<{entity_id:string, name:string}>} [opts.developers=[]]
+ * @param {Array<{entity_id:string, name:string}>} [opts.deployers=[]]
+ * @param {Array<{entity_id:string, name:string}>} [opts.harmedParties=[]]
+ * @returns {Object} An incident document.
+ */
+function makeIncident(id, { developers = [], deployers = [], harmedParties = [] } = {}) {
+  return {
+    incident_id: id,
+    AllegedDeveloperOfAISystem: developers.map((name) =>
+      typeof name === 'string' ? { entity_id: name.toLowerCase().replace(/\s/g, '-'), name } : name
+    ),
+    AllegedDeployerOfAISystem: deployers.map((name) =>
+      typeof name === 'string' ? { entity_id: name.toLowerCase().replace(/\s/g, '-'), name } : name
+    ),
+    AllegedHarmedOrNearlyHarmedParties: harmedParties.map((name) =>
+      typeof name === 'string' ? { entity_id: name.toLowerCase().replace(/\s/g, '-'), name } : name
+    ),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────
+// groupClassificationsByIncident
+// ─────────────────────────────────────────────────────────────
+
+describe('groupClassificationsByIncident', () => {
+  test('groups 3 classifications across 2 incidents correctly', () => {
+    // Two classifications belong to incident 1, one to incident 2.
+    // Verifies the fundamental grouping: the Map should have 2 keys,
+    // with incident 1 holding 2 entries and incident 2 holding 1.
+    const c1 = makeClassification('CSETv1', [1], { Severity: 'Minor' });
+
+    const c2 = makeClassification('GMF', [1], { 'Known AI Technology': ['NLP'] });
+
+    const c3 = makeClassification('MIT', [2], { Intent: 'Accident' });
+
+    const grouped = groupClassificationsByIncident([c1, c2, c3]);
+
+    expect(grouped.size).toBe(2);
+    expect(grouped.get(1)).toHaveLength(2);
+    expect(grouped.get(1)).toContain(c1);
+    expect(grouped.get(1)).toContain(c2);
+    expect(grouped.get(2)).toHaveLength(1);
+    expect(grouped.get(2)).toContain(c3);
+  });
+
+  test('one classification linked to 2 incident IDs appears in both groups', () => {
+    // A single classification can reference multiple incidents.
+    // It should appear in the array for every incident it references.
+    const c = makeClassification('CSETv1', [10, 20], { Severity: 'Severe' });
+
+    const grouped = groupClassificationsByIncident([c]);
+
+    expect(grouped.size).toBe(2);
+    expect(grouped.get(10)).toContain(c);
+    expect(grouped.get(20)).toContain(c);
+  });
+
+  test('empty input returns an empty Map', () => {
+    // Edge case: no classifications at all should produce an empty Map,
+    // not null or undefined.
+    const grouped = groupClassificationsByIncident([]);
+
+    expect(grouped).toBeInstanceOf(Map);
+    expect(grouped.size).toBe(0);
+  });
+
+  test('two classifications for the same incident both appear in its array', () => {
+    // Verifies that duplicates within the same incident are accumulated,
+    // not overwritten.
+    const c1 = makeClassification('CSETv1', [5], { Severity: 'Minor' });
+
+    const c2 = makeClassification('GMF', [5], { 'Known AI Technology': ['CV'] });
+
+    const grouped = groupClassificationsByIncident([c1, c2]);
+
+    expect(grouped.size).toBe(1);
+    expect(grouped.get(5)).toHaveLength(2);
+    expect(grouped.get(5)).toEqual(expect.arrayContaining([c1, c2]));
+  });
+
+  test('classification with empty incidents array is skipped', () => {
+    // If a classification has an empty incidents array it should not appear
+    // in any group, and should not cause an error.
+    const c = { ...makeClassification('MIT', [], { Intent: 'Accident' }), incidents: [] };
+
+    const grouped = groupClassificationsByIncident([c]);
+
+    expect(grouped.size).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// buildFilteredCounts  (also tests extractValues indirectly)
+// ─────────────────────────────────────────────────────────────
+
+describe('buildFilteredCounts', () => {
+  // Helper: group a flat array into the Map that buildFilteredCounts expects.
+  const group = (arr) => groupClassificationsByIncident(arr);
+
+  test('plain string value is extracted correctly', () => {
+    // Verifies the simplest value_json shape: a JSON string like '"Education"'.
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor', 'Sector of Deployment': 'Education' }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'CSETv1',
+      'Sector of Deployment'
+    );
+
+    expect(result.counts.get('Education')).toBe(1);
+    expect(result.incidentCount).toBe(1);
+  });
+
+  test('JSON array value extracts each element separately', () => {
+    // value_json = '["NLP","Computer Vision"]' should produce two separate counts.
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor' }),
+      makeClassification('GMF', [1], { 'Known AI Technology': ['NLP', 'Computer Vision'] }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'GMF',
+      'Known AI Technology'
+    );
+
+    expect(result.counts.get('NLP')).toBe(1);
+    expect(result.counts.get('Computer Vision')).toBe(1);
+    expect(result.total).toBe(2);
+    expect(result.incidentCount).toBe(1);
+  });
+
+  test('boolean true is extracted as "Yes"', () => {
+    // Booleans stored as value_json: 'true' should be converted to "Yes".
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor', Critical: true }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'CSETv1',
+      'Critical'
+    );
+
+    expect(result.counts.get('Yes')).toBe(1);
+  });
+
+  test('boolean false is extracted as "No"', () => {
+    // Booleans stored as value_json: 'false' should be converted to "No".
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor', Critical: false }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'CSETv1',
+      'Critical'
+    );
+
+    expect(result.counts.get('No')).toBe(1);
+  });
+
+  test('semicolon-separated string is split into individual values', () => {
+    // CSETv1 sometimes stores multi-values as "A; B; C".
+    // extractValues should split on "; " and count each part.
+    const classifications = [
+      makeClassification('CSETv1', [1], {
+        Severity: 'Minor',
+        'System Developer': 'Google; DeepMind',
+      }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'CSETv1',
+      'System Developer'
+    );
+
+    expect(result.counts.get('Google')).toBe(1);
+    expect(result.counts.get('DeepMind')).toBe(1);
+    expect(result.total).toBe(2);
+  });
+
+  test('null value produces no counts for that field', () => {
+    // value_json = 'null' should be treated as empty; the incident is skipped
+    // for the target field.
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor', 'Sector of Deployment': null }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'CSETv1',
+      'Sector of Deployment'
+    );
+
+    expect(result.counts.size).toBe(0);
+    expect(result.incidentCount).toBe(0);
+  });
+
+  test('empty string value produces no counts for that field', () => {
+    // value_json = '""' should be treated as empty.
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor', 'Sector of Deployment': '' }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'CSETv1',
+      'Sector of Deployment'
+    );
+
+    expect(result.counts.size).toBe(0);
+    expect(result.incidentCount).toBe(0);
+  });
+
+  test('array containing nulls and empty strings filters them out', () => {
+    // value_json = '["NLP", null, ""]' should keep only "NLP".
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor' }),
+      makeClassification('GMF', [1], { 'Known AI Technology': ['NLP', null, ''] }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'GMF',
+      'Known AI Technology'
+    );
+
+    expect(result.counts.size).toBe(1);
+    expect(result.counts.get('NLP')).toBe(1);
+  });
+
+  test('numeric value is converted to string via toString fallback', () => {
+    // value_json = '42' should be stringified to "42".
+    const classifications = [makeClassification('CSETv1', [1], { Severity: 'Minor', Score: 42 })];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'CSETv1',
+      'Score'
+    );
+
+    expect(result.counts.get('42')).toBe(1);
+  });
+
+  test('field not present on classification returns no counts', () => {
+    // If the target field does not exist in the classification's attributes,
+    // getClassificationValue returns undefined, and extractValues returns [].
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor' }),
+      // No GMF classification for incident 1 at all
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'CSETv1',
+      'NonExistentField'
+    );
+
+    expect(result.counts.size).toBe(0);
+    expect(result.incidentCount).toBe(0);
+  });
+
+  test('filter matches no incidents returns empty results', () => {
+    // When no incident has the filter value, everything should be zero.
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor', 'Sector of Deployment': 'Education' }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Severe', // No incident has Severe
+      'CSETv1',
+      'Sector of Deployment'
+    );
+
+    expect(result.counts.size).toBe(0);
+    expect(result.total).toBe(0);
+    expect(result.incidentCount).toBe(0);
+  });
+
+  test('target namespace absent on matching incident skips it', () => {
+    // Incident matches the filter (CSETv1 Severity=Minor) but has no GMF
+    // classification, so it cannot produce target values.
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor' }),
+      // No GMF classification for incident 1
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'GMF',
+      'Known AI Technology'
+    );
+
+    expect(result.counts.size).toBe(0);
+    expect(result.incidentCount).toBe(0);
+  });
+
+  test('multi-value target field counts each value separately', () => {
+    // An incident whose target field has 3 values should increment
+    // all 3 in the counts Map, and incidentCount should still be 1.
+    const classifications = [
+      makeClassification('CSETv1', [1], {
+        Severity: 'Minor',
+        'Sector of Deployment': 'Education; Healthcare; Government',
+      }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'CSETv1',
+      'Sector of Deployment'
+    );
+
+    expect(result.counts.get('Education')).toBe(1);
+    expect(result.counts.get('Healthcare')).toBe(1);
+    expect(result.counts.get('Government')).toBe(1);
+    expect(result.total).toBe(3);
+    expect(result.incidentCount).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// buildCrossData
+// ─────────────────────────────────────────────────────────────
+
+describe('buildCrossData', () => {
+  const group = (arr) => groupClassificationsByIncident(arr);
+
+  test('happy path: 2 incidents with X and Y values', () => {
+    // Two incidents, each with values for both axes.
+    // Should produce a 2x2 matrix with correct counts.
+    const classifications = [
+      makeClassification('MIT', [1], { Intent: 'Accident' }),
+      makeClassification('CSETv1', [1], { Severity: 'Minor' }),
+      makeClassification('MIT', [2], { Intent: 'Deliberate' }),
+      makeClassification('CSETv1', [2], { Severity: 'Severe' }),
+    ];
+
+    const result = buildCrossData(
+      group(classifications),
+      'MIT',
+      'Intent',
+      'CSETv1',
+      'Severity',
+      null,
+      null,
+      null
+    );
+
+    expect(result.incidentCount).toBe(2);
+    expect(result.xValues).toContain('Accident');
+    expect(result.xValues).toContain('Deliberate');
+    expect(result.yValues).toContain('Minor');
+    expect(result.yValues).toContain('Severe');
+    expect(result.matrix.get('Accident').get('Minor')).toBe(1);
+    expect(result.matrix.get('Deliberate').get('Severe')).toBe(1);
+  });
+
+  test('multi-value X field generates multiple pairs', () => {
+    // If the X field has semicolon-separated values "A; B", two pairs
+    // should be generated: (A, Y) and (B, Y).
+    const classifications = [
+      makeClassification('CSETv1', [1], { 'Sector of Deployment': 'Education; Healthcare' }),
+      makeClassification('MIT', [1], { Intent: 'Accident' }),
+    ];
+
+    const result = buildCrossData(
+      group(classifications),
+      'CSETv1',
+      'Sector of Deployment',
+      'MIT',
+      'Intent',
+      null,
+      null,
+      null
+    );
+
+    expect(result.incidentCount).toBe(1);
+    expect(result.xValues).toEqual(expect.arrayContaining(['Education', 'Healthcare']));
+    expect(result.totalPairs).toBe(2);
+    expect(result.matrix.get('Education').get('Accident')).toBe(1);
+    expect(result.matrix.get('Healthcare').get('Accident')).toBe(1);
+  });
+
+  test('filter excludes non-matching incidents', () => {
+    // 2 incidents, but the filter only matches incident 2.
+    // Incident 1 should be excluded from the results.
+    const classifications = [
+      makeClassification('MIT', [1], { Intent: 'Accident' }),
+      makeClassification('CSETv1', [1], { Severity: 'Minor', 'Harm Domain': 'Physical' }),
+      makeClassification('MIT', [2], { Intent: 'Deliberate' }),
+      makeClassification('CSETv1', [2], { Severity: 'Severe', 'Harm Domain': 'Psychological' }),
+    ];
+
+    const result = buildCrossData(
+      group(classifications),
+      'MIT',
+      'Intent',
+      'CSETv1',
+      'Severity',
+      'CSETv1',
+      'Harm Domain',
+      'Psychological' // Only incident 2 matches
+    );
+
+    expect(result.incidentCount).toBe(1);
+    expect(result.xValues).toEqual(['Deliberate']);
+    expect(result.yValues).toEqual(['Severe']);
+  });
+
+  test('filter that matches nothing returns zero counts', () => {
+    // Filter value exists in no classification. Everything should be empty.
+    const classifications = [
+      makeClassification('MIT', [1], { Intent: 'Accident' }),
+      makeClassification('CSETv1', [1], { Severity: 'Minor', 'Harm Domain': 'Physical' }),
+    ];
+
+    const result = buildCrossData(
+      group(classifications),
+      'MIT',
+      'Intent',
+      'CSETv1',
+      'Severity',
+      'CSETv1',
+      'Harm Domain',
+      'NonExistent'
+    );
+
+    expect(result.incidentCount).toBe(0);
+    expect(result.xValues).toHaveLength(0);
+    expect(result.yValues).toHaveLength(0);
+    expect(result.pairs).toHaveLength(0);
+  });
+
+  test('incident missing X classification is skipped', () => {
+    // Incident 1 has CSETv1 (Y axis) but no MIT (X axis).
+    // It should be silently skipped, not cause an error.
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor' }),
+      // No MIT classification for incident 1
+    ];
+
+    const result = buildCrossData(
+      group(classifications),
+      'MIT',
+      'Intent',
+      'CSETv1',
+      'Severity',
+      null,
+      null,
+      null
+    );
+
+    expect(result.incidentCount).toBe(0);
+    expect(result.xValues).toHaveLength(0);
+  });
+
+  test('incident missing Y classification is skipped', () => {
+    // Incident 1 has MIT (X axis) but no CSETv1 (Y axis).
+    const classifications = [
+      makeClassification('MIT', [1], { Intent: 'Accident' }),
+      // No CSETv1 for incident 1
+    ];
+
+    const result = buildCrossData(
+      group(classifications),
+      'MIT',
+      'Intent',
+      'CSETv1',
+      'Severity',
+      null,
+      null,
+      null
+    );
+
+    expect(result.incidentCount).toBe(0);
+    expect(result.yValues).toHaveLength(0);
+  });
+
+  test('X and Y from the same taxonomy namespace work correctly', () => {
+    // Both axes reference CSETv1 fields. The function should find the
+    // single CSETv1 classification and extract both fields from it.
+    const classifications = [
+      makeClassification('CSETv1', [1], {
+        Severity: 'Minor',
+        'Sector of Deployment': 'Education',
+      }),
+    ];
+
+    const result = buildCrossData(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'CSETv1',
+      'Sector of Deployment',
+      null,
+      null,
+      null
+    );
+
+    expect(result.incidentCount).toBe(1);
+    expect(result.matrix.get('Minor').get('Education')).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// toBillboardColumns
+// ─────────────────────────────────────────────────────────────
+
+describe('toBillboardColumns', () => {
+  test('2x2 matrix produces correct Billboard.js column format', () => {
+    // A 2x2 matrix should yield: an x-axis column with 2 categories,
+    // plus 2 data-series columns, each with a value per x category.
+    const crossData = {
+      xValues: ['Accident', 'Deliberate'],
+      yValues: ['Minor', 'Severe'],
+      matrix: new Map([
+        [
+          'Accident',
+          new Map([
+            ['Minor', 3],
+            ['Severe', 1],
+          ]),
+        ],
+        [
+          'Deliberate',
+          new Map([
+            ['Minor', 0],
+            ['Severe', 2],
+          ]),
+        ],
+      ]),
+    };
+
+    const columns = toBillboardColumns(crossData);
+
+    expect(columns).toEqual([
+      ['x', 'Accident', 'Deliberate'],
+      ['Minor', 3, 0],
+      ['Severe', 1, 2],
+    ]);
+  });
+
+  test('single cell matrix', () => {
+    // Minimal case: one X value, one Y value.
+    const crossData = {
+      xValues: ['Accident'],
+      yValues: ['Minor'],
+      matrix: new Map([['Accident', new Map([['Minor', 5]])]]),
+    };
+
+    const columns = toBillboardColumns(crossData);
+
+    expect(columns).toEqual([
+      ['x', 'Accident'],
+      ['Minor', 5],
+    ]);
+  });
+
+  test('zero count values are preserved, not omitted', () => {
+    // If xValue "Deliberate" has no entry for yValue "Minor" in the matrix,
+    // the output should contain 0, not skip the entry.
+    const crossData = {
+      xValues: ['Accident', 'Deliberate'],
+      yValues: ['Minor'],
+      matrix: new Map([
+        ['Accident', new Map([['Minor', 2]])],
+        ['Deliberate', new Map()], // no Minor entry
+      ]),
+    };
+
+    const columns = toBillboardColumns(crossData);
+
+    expect(columns).toEqual([
+      ['x', 'Accident', 'Deliberate'],
+      ['Minor', 2, 0],
+    ]);
+  });
+
+  test('empty cross data produces only an empty x column', () => {
+    // When there are no values at all, the output should be just ['x']
+    // with no data series.
+    const crossData = {
+      xValues: [],
+      yValues: [],
+      matrix: new Map(),
+    };
+
+    const columns = toBillboardColumns(crossData);
+
+    expect(columns).toEqual([['x']]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// buildIncidentEntityMap
+// ─────────────────────────────────────────────────────────────
+
+describe('buildIncidentEntityMap', () => {
+  test('3 incidents with full entity arrays produce correct Map', () => {
+    // Verifies that all three entity types are correctly extracted
+    // and mapped by incident_id.
+    const incidents = [
+      makeIncident(1, {
+        developers: ['OpenAI'],
+        deployers: ['Uber'],
+        harmedParties: ['Pedestrians'],
+      }),
+      makeIncident(2, { developers: ['Google', 'DeepMind'], deployers: ['Google'] }),
+      makeIncident(3, { developers: ['Meta'] }),
+    ];
+
+    const map = buildIncidentEntityMap(incidents);
+
+    expect(map.size).toBe(3);
+    expect(map.get(1).developers).toEqual(['OpenAI']);
+    expect(map.get(1).deployers).toEqual(['Uber']);
+    expect(map.get(1).harmedParties).toEqual(['Pedestrians']);
+    expect(map.get(2).developers).toEqual(['Google', 'DeepMind']);
+    expect(map.get(2).deployers).toEqual(['Google']);
+    expect(map.get(2).harmedParties).toEqual([]);
+    expect(map.get(3).developers).toEqual(['Meta']);
+    expect(map.get(3).deployers).toEqual([]);
+  });
+
+  test('incident with empty developer array produces empty developers list', () => {
+    // Explicit empty array should result in an empty array, not undefined.
+    const incidents = [makeIncident(1, { developers: [] })];
+
+    const map = buildIncidentEntityMap(incidents);
+
+    expect(map.get(1).developers).toEqual([]);
+  });
+
+  test('incident where AllegedDeveloperOfAISystem is null or undefined', () => {
+    // If the GraphQL response has null for an entity field, the code uses
+    // the || [] fallback. This should not throw.
+    const incident = {
+      incident_id: 1,
+      AllegedDeveloperOfAISystem: null,
+      AllegedDeployerOfAISystem: undefined,
+      AllegedHarmedOrNearlyHarmedParties: [{ entity_id: 'people', name: 'People' }],
+    };
+
+    const map = buildIncidentEntityMap([incident]);
+
+    expect(map.get(1).developers).toEqual([]);
+    expect(map.get(1).deployers).toEqual([]);
+    expect(map.get(1).harmedParties).toEqual(['People']);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// getEntityValues
+// ─────────────────────────────────────────────────────────────
+
+describe('getEntityValues', () => {
+  test('returns values sorted by count descending', () => {
+    // OpenAI appears in 3 incidents, Google in 1. OpenAI should come first.
+    const incidents = [
+      makeIncident(1, { developers: ['OpenAI'] }),
+      makeIncident(2, { developers: ['OpenAI', 'Google'] }),
+      makeIncident(3, { developers: ['OpenAI'] }),
+    ];
+
+    const map = buildIncidentEntityMap(incidents);
+
+    const values = getEntityValues(map, 'developers');
+
+    expect(values[0]).toEqual({ value: 'OpenAI', count: 3 });
+    expect(values[1]).toEqual({ value: 'Google', count: 1 });
+  });
+
+  test('empty map returns empty array', () => {
+    // No incidents at all should produce [], not an error.
+    const values = getEntityValues(new Map(), 'developers');
+
+    expect(values).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// countEntityIncidents
+// ─────────────────────────────────────────────────────────────
+
+describe('countEntityIncidents', () => {
+  test('entity present in 5 incidents returns 5', () => {
+    // Count how many incidents involve a specific entity.
+    const incidents = [
+      makeIncident(1, { developers: ['OpenAI'] }),
+      makeIncident(2, { developers: ['OpenAI'] }),
+      makeIncident(3, { developers: ['Google'] }),
+      makeIncident(4, { developers: ['OpenAI'] }),
+      makeIncident(5, { developers: ['OpenAI', 'Meta'] }),
+      makeIncident(6, { developers: ['OpenAI'] }),
+    ];
+
+    const map = buildIncidentEntityMap(incidents);
+
+    expect(countEntityIncidents(map, 'developers', 'OpenAI')).toBe(5);
+  });
+
+  test('entity not found returns 0', () => {
+    // An entity name that doesn't exist in any incident should return 0.
+    const incidents = [makeIncident(1, { developers: ['OpenAI'] })];
+
+    const map = buildIncidentEntityMap(incidents);
+
+    expect(countEntityIncidents(map, 'developers', 'UnknownCorp')).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// buildEntityFilteredCounts
+// ─────────────────────────────────────────────────────────────
+
+describe('buildEntityFilteredCounts', () => {
+  test('OpenAI incidents with CSETv1 Sector returns correct counts', () => {
+    // Two incidents have OpenAI as developer. Both have CSETv1 classifications.
+    // Sector values should be counted correctly.
+    const classifications = [
+      makeClassification('CSETv1', [1], { 'Sector of Deployment': 'Education' }),
+      makeClassification('CSETv1', [2], { 'Sector of Deployment': 'Healthcare' }),
+      makeClassification('CSETv1', [3], { 'Sector of Deployment': 'Government' }),
+    ];
+
+    const incidents = [
+      makeIncident(1, { developers: ['OpenAI'] }),
+      makeIncident(2, { developers: ['OpenAI'] }),
+      makeIncident(3, { developers: ['Google'] }), // Not OpenAI
+    ];
+
+    const grouped = groupClassificationsByIncident(classifications);
+
+    const entityMap = buildIncidentEntityMap(incidents);
+
+    const result = buildEntityFilteredCounts(
+      grouped,
+      entityMap,
+      'developers',
+      'OpenAI',
+      'CSETv1',
+      'Sector of Deployment'
+    );
+
+    expect(result.counts.get('Education')).toBe(1);
+    expect(result.counts.get('Healthcare')).toBe(1);
+    expect(result.counts.has('Government')).toBe(false); // Google's incident
+    expect(result.incidentCount).toBe(2);
+    expect(result.total).toBe(2);
+  });
+
+  test('entity matches incidents but those incidents have no target taxonomy', () => {
+    // OpenAI has 2 incidents, but neither has a CSETv1 classification.
+    // The function should return incidentCount=0 and empty counts.
+    const classifications = [
+      // Only GMF classifications, no CSETv1
+      makeClassification('GMF', [1], { 'Known AI Technology': ['NLP'] }),
+      makeClassification('GMF', [2], { 'Known AI Technology': ['CV'] }),
+    ];
+
+    const incidents = [
+      makeIncident(1, { developers: ['OpenAI'] }),
+      makeIncident(2, { developers: ['OpenAI'] }),
+    ];
+
+    const grouped = groupClassificationsByIncident(classifications);
+
+    const entityMap = buildIncidentEntityMap(incidents);
+
+    const result = buildEntityFilteredCounts(
+      grouped,
+      entityMap,
+      'developers',
+      'OpenAI',
+      'CSETv1',
+      'Sector of Deployment'
+    );
+
+    expect(result.counts.size).toBe(0);
+    expect(result.incidentCount).toBe(0);
+    expect(result.total).toBe(0);
+  });
+
+  test('entity not in any incident returns empty counts', () => {
+    // The entity name doesn't match any incident's developers.
+    const classifications = [
+      makeClassification('CSETv1', [1], { 'Sector of Deployment': 'Education' }),
+    ];
+
+    const incidents = [makeIncident(1, { developers: ['Google'] })];
+
+    const grouped = groupClassificationsByIncident(classifications);
+
+    const entityMap = buildIncidentEntityMap(incidents);
+
+    const result = buildEntityFilteredCounts(
+      grouped,
+      entityMap,
+      'developers',
+      'UnknownCorp',
+      'CSETv1',
+      'Sector of Deployment'
+    );
+
+    expect(result.counts.size).toBe(0);
+    expect(result.incidentCount).toBe(0);
+    expect(result.total).toBe(0);
+  });
+});

--- a/site/gatsby-site/src/utils/crossTaxonomy.js
+++ b/site/gatsby-site/src/utils/crossTaxonomy.js
@@ -1,0 +1,400 @@
+import { getClassificationValue } from './classifications';
+
+/**
+ * Groups a flat array of classification documents by incident_id.
+ * Returns a Map<number, Classification[]>.
+ */
+export function groupClassificationsByIncident(classifications) {
+  const grouped = new Map();
+
+  for (const c of classifications) {
+    if (!c.incidents || c.incidents.length === 0) continue;
+    for (const incident of c.incidents) {
+      const id = incident.incident_id;
+
+      if (!grouped.has(id)) {
+        grouped.set(id, []);
+      }
+      grouped.get(id).push(c);
+    }
+  }
+  return grouped;
+}
+
+/**
+ * Returns a flat list of fields suitable for axis selection dropdowns,
+ * filtered to categorical/enumerable types.
+ */
+export function getAvailableFields(taxas) {
+  const categoricalTypes = ['enum', 'multi', 'list', 'bool'];
+
+  const fields = [];
+
+  for (const taxa of taxas) {
+    for (const field of taxa.field_list) {
+      if (
+        categoricalTypes.includes(field.display_type) ||
+        (field.permitted_values && field.permitted_values.length > 0)
+      ) {
+        fields.push({
+          namespace: taxa.namespace,
+          short_name: field.short_name,
+          long_name: field.long_name,
+          display_type: field.display_type,
+          permitted_values: field.permitted_values,
+        });
+      }
+    }
+  }
+  return fields;
+}
+
+/**
+ * Extracts a flat array of string values from a classification for a given field.
+ * Handles strings, arrays, booleans, and nulls.
+ */
+function extractValues(classification, fieldName) {
+  const raw = getClassificationValue(classification, fieldName);
+
+  if (raw === null || raw === undefined || raw === '') return [];
+  if (typeof raw === 'boolean') return [raw ? 'Yes' : 'No'];
+  if (Array.isArray(raw)) return raw.filter((v) => v !== null && v !== undefined && v !== '');
+  if (typeof raw === 'string') {
+    // Handle semicolon-separated values (e.g., CSETv1 "System Developer": "Google; DeepMind")
+    if (raw.includes('; ')) {
+      return raw
+        .split('; ')
+        .map((v) => v.trim())
+        .filter((v) => v !== '');
+    }
+
+    return [raw];
+  }
+  return [String(raw)];
+}
+
+/**
+ * Builds cross-taxonomy co-occurrence data from grouped classifications.
+ *
+ * Returns {
+ *   pairs: Array<{ x: string, y: string }>,  // every x/y value pair
+ *   matrix: Map<string, Map<string, number>>, // xValue -> yValue -> count
+ *   xValues: string[],
+ *   yValues: string[],
+ *   incidentCount: number,  // incidents contributing data
+ *   totalPairs: number,
+ * }
+ */
+export function buildCrossData(
+  groupedClassifications,
+  xNamespace,
+  xField,
+  yNamespace,
+  yField,
+  filterNamespace,
+  filterField,
+  filterValue
+) {
+  const matrix = new Map();
+
+  const xValuesSet = new Set();
+
+  const yValuesSet = new Set();
+
+  let incidentCount = 0;
+
+  let totalPairs = 0;
+
+  for (const [, classifications] of groupedClassifications) {
+    // Apply optional filter
+    if (filterNamespace && filterField && filterValue) {
+      const filterClassification = classifications.find((c) => c.namespace === filterNamespace);
+
+      if (!filterClassification) continue;
+
+      const filterValues = extractValues(filterClassification, filterField);
+
+      if (!filterValues.includes(filterValue)) continue;
+    }
+
+    const xClassification = classifications.find((c) => c.namespace === xNamespace);
+
+    const yClassification = classifications.find((c) => c.namespace === yNamespace);
+
+    if (!xClassification || !yClassification) continue;
+
+    const xVals = extractValues(xClassification, xField);
+
+    const yVals = extractValues(yClassification, yField);
+
+    if (xVals.length === 0 || yVals.length === 0) continue;
+
+    incidentCount++;
+
+    for (const xv of xVals) {
+      xValuesSet.add(xv);
+      if (!matrix.has(xv)) matrix.set(xv, new Map());
+      const row = matrix.get(xv);
+
+      for (const yv of yVals) {
+        yValuesSet.add(yv);
+        row.set(yv, (row.get(yv) || 0) + 1);
+        totalPairs++;
+      }
+    }
+  }
+
+  const xValues = Array.from(xValuesSet).sort();
+
+  const yValues = Array.from(yValuesSet).sort();
+
+  const pairs = [];
+
+  for (const xv of xValues) {
+    for (const yv of yValues) {
+      const count = matrix.get(xv)?.get(yv) || 0;
+
+      if (count > 0) {
+        pairs.push({ x: xv, y: yv, count });
+      }
+    }
+  }
+
+  return { pairs, matrix, xValues, yValues, incidentCount, totalPairs };
+}
+
+/**
+ * Converts cross-data matrix into Billboard.js column format for bar/line charts.
+ * Each y-value becomes a data series; x-values are the categories.
+ */
+export function toBillboardColumns(crossData) {
+  const { xValues, yValues, matrix } = crossData;
+
+  const xColumn = ['x', ...xValues];
+
+  const dataColumns = yValues.map((yv) => [
+    yv,
+    ...xValues.map((xv) => matrix.get(xv)?.get(yv) || 0),
+  ]);
+
+  return [xColumn, ...dataColumns];
+}
+
+/**
+ * Converts cross-data into scatter-plot xs/columns format for Billboard.js.
+ * Each y-value series gets its own x-axis series keyed as `${yv}_x`.
+ */
+export function toScatterData(crossData) {
+  const { pairs, yValues } = crossData;
+
+  const { xValues } = crossData;
+
+  // For scatter, we map categorical values to numeric indices
+  const xIndex = new Map(xValues.map((v, i) => [v, i]));
+
+  const xs = {};
+
+  const columns = [];
+
+  for (const yv of yValues) {
+    const xKey = `${yv}_x`;
+
+    xs[yv] = xKey;
+    const xCol = [xKey];
+
+    const yCol = [yv];
+
+    for (const p of pairs) {
+      if (p.y === yv) {
+        xCol.push(xIndex.get(p.x));
+        yCol.push(p.count);
+      }
+    }
+    columns.push(xCol, yCol);
+  }
+
+  return { xs, columns, xValues };
+}
+
+/**
+ * Counts occurrences of a target field's values across incidents that match a filter.
+ * Used by guided analysis tabs to build single-field distributions.
+ *
+ * Returns { counts: Map<string, number>, total: number, incidentCount: number }
+ */
+export function buildFilteredCounts(
+  groupedClassifications,
+  filterNamespace,
+  filterField,
+  filterValue,
+  targetNamespace,
+  targetField
+) {
+  const counts = new Map();
+
+  let incidentCount = 0;
+
+  for (const [, classifications] of groupedClassifications) {
+    // Apply filter
+    const filterClassification = classifications.find((c) => c.namespace === filterNamespace);
+
+    if (!filterClassification) continue;
+
+    const filterValues = extractValues(filterClassification, filterField);
+
+    if (!filterValues.includes(filterValue)) continue;
+
+    // Extract target values
+    const targetClassification = classifications.find((c) => c.namespace === targetNamespace);
+
+    if (!targetClassification) continue;
+
+    const targetVals = extractValues(targetClassification, targetField);
+
+    if (targetVals.length === 0) continue;
+
+    incidentCount++;
+
+    for (const v of targetVals) {
+      counts.set(v, (counts.get(v) || 0) + 1);
+    }
+  }
+
+  const total = Array.from(counts.values()).reduce((s, n) => s + n, 0);
+
+  return { counts, total, incidentCount };
+}
+
+/**
+ * Collects all unique values for a given field across all classifications,
+ * sorted by frequency descending.
+ */
+export function getFieldValues(allClassifications, namespace, fieldName) {
+  const counts = new Map();
+
+  for (const c of allClassifications) {
+    if (c.namespace !== namespace) continue;
+    const vals = extractValues(c, fieldName);
+
+    for (const v of vals) {
+      counts.set(v, (counts.get(v) || 0) + 1);
+    }
+  }
+
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([value, count]) => ({ value, count }));
+}
+
+/**
+ * Counts total incidents matching a filter field/value.
+ */
+export function countFilteredIncidents(groupedClassifications, namespace, field, value) {
+  let count = 0;
+
+  for (const [, classifications] of groupedClassifications) {
+    const classification = classifications.find((c) => c.namespace === namespace);
+
+    if (!classification) continue;
+    const vals = extractValues(classification, field);
+
+    if (vals.includes(value)) count++;
+  }
+  return count;
+}
+
+// ── Entity-based helpers (developer / deployer / harmed parties) ──
+
+/**
+ * Builds a map from incident_id to entity names.
+ * Input: array of incident objects from GraphQL with entity sub-objects.
+ * Returns Map<number, { developers: string[], deployers: string[], harmedParties: string[] }>
+ */
+export function buildIncidentEntityMap(incidents) {
+  const map = new Map();
+
+  for (const inc of incidents) {
+    map.set(inc.incident_id, {
+      developers: (inc.AllegedDeveloperOfAISystem || []).map((e) => e.name),
+      deployers: (inc.AllegedDeployerOfAISystem || []).map((e) => e.name),
+      harmedParties: (inc.AllegedHarmedOrNearlyHarmedParties || []).map((e) => e.name),
+    });
+  }
+  return map;
+}
+
+/**
+ * Returns unique entity values sorted by frequency descending.
+ * entityField is 'developers', 'deployers', or 'harmedParties'.
+ */
+export function getEntityValues(incidentEntityMap, entityField) {
+  const counts = new Map();
+
+  for (const [, entities] of incidentEntityMap) {
+    const values = entities[entityField] || [];
+
+    for (const v of values) {
+      counts.set(v, (counts.get(v) || 0) + 1);
+    }
+  }
+
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([value, count]) => ({ value, count }));
+}
+
+/**
+ * Counts incidents that include a specific entity value.
+ */
+export function countEntityIncidents(incidentEntityMap, entityField, entityValue) {
+  let count = 0;
+
+  for (const [, entities] of incidentEntityMap) {
+    if ((entities[entityField] || []).includes(entityValue)) count++;
+  }
+  return count;
+}
+
+/**
+ * Builds classification field counts for incidents that match an entity filter.
+ * Finds incidents with the given entity, looks up their classifications, and
+ * extracts values for the target field.
+ *
+ * Returns { counts: Map<string, number>, total: number, incidentCount: number }
+ */
+export function buildEntityFilteredCounts(
+  groupedClassifications,
+  incidentEntityMap,
+  entityField,
+  entityValue,
+  targetNamespace,
+  targetField
+) {
+  const counts = new Map();
+
+  let incidentCount = 0;
+
+  for (const [incidentId, classifications] of groupedClassifications) {
+    const entities = incidentEntityMap.get(incidentId);
+
+    if (!entities || !(entities[entityField] || []).includes(entityValue)) continue;
+
+    const targetClassification = classifications.find((c) => c.namespace === targetNamespace);
+
+    if (!targetClassification) continue;
+
+    const targetVals = extractValues(targetClassification, targetField);
+
+    if (targetVals.length === 0) continue;
+
+    incidentCount++;
+
+    for (const v of targetVals) {
+      counts.set(v, (counts.get(v) || 0) + 1);
+    }
+  }
+
+  const total = Array.from(counts.values()).reduce((s, n) => s + n, 0);
+
+  return { counts, total, incidentCount };
+}


### PR DESCRIPTION
## Summary

This PR adds a new page at `/apps/cross-taxonomy/` that enables users to explore patterns across AI incidents by cross-referencing data from multiple taxonomies (CSETv1, GMF, MIT) and incident entity data (developers, deployers, harmed parties).

The AIID currently has three independent classification taxonomies and rich entity metadata on incidents, but no way to visualize relationships between them. This tool bridges that gap by letting users ask questions like:
- "When OpenAI's AI systems cause incidents, what sectors are affected and what failure modes occur?"
- "For incidents involving facial recognition technology, which demographic groups are disproportionately harmed?"
- "How do failure modes differ between intentional and unintentional AI harms?"

## Features

### 5 Analysis Tabs

**By Developer** - Select a company from a dropdown (populated from incident `AllegedDeveloperOfAISystem` entities, sorted by incident count). Generates charts showing deployment sectors (CSETv1), failure modes (GMF), affected demographics (CSETv1), intent (MIT), and risk domains (MIT).

**By Deployer** - Same flow using `AllegedDeployerOfAISystem` entities. Shows AI technologies used, failure patterns, who is affected, deployment sectors, and risk domains.

**By Affected Group** - Select a demographic category from CSETv1 `Harm Distribution Basis` (race, sex, age, disability, etc.). Shows which sectors, technologies, harm domains, and failure modes are associated with harm to that group.

**By Technology** - Select from GMF `Known AI Technology` values (face recognition, language models, content filtering, etc.). Shows deployment sectors, failure modes, affected groups, risk domains, and harm categories.

**Custom Explorer** - Full flexibility. Select any two categorical fields from any taxonomy for X/Y axes, choose a chart type (bar, stacked bar, line, scatter), and optionally filter by a third field. Builds a co-occurrence matrix and visualizes it.

### Additional Features
- **URL state sync** via `use-query-params` — all selections are reflected in URL params so analyses are shareable via link
- **Sample size warnings** — displays warnings when N < 3 (too few to visualize) or N < 10 (may not be representative)
- **Responsive layout** — charts in 2-column grid on desktop, single column on mobile
- **i18n ready** — all user-visible strings wrapped in `<Trans>` / `t()` for translation
- **Chart styling** — each category gets a unique color with a bottom legend, matching the existing AIID taxonomy page style

## Files Changed

### New Files
- `src/pages/apps/cross-taxonomy.js` — Main page component with tab navigation, URL params, data fetching
- `src/components/visualizations/ChartCard.js` — Reusable bar/donut chart card component
- `src/components/visualizations/GuidedAnalysisTab.js` — Generic guided analysis tab component
- `src/components/visualizations/CrossTaxonomyChart.js` — Multi-chart-type component for Custom Explorer
- `src/utils/crossTaxonomy.js` — Data processing utilities (grouping, filtering, co-occurrence matrix, entity lookups)

### Modified Files
- `config.js` — Added sidebar fallback navigation entry (sidebar is primarily managed via Prismic CMS, so a Prismic entry would need to be added separately)

## Data Sources

The tool uses two data sources, fetched via Apollo Client on page mount:

1. **Incident entities** (via GraphQL `incidents` query) — `AllegedDeveloperOfAISystem`, `AllegedDeployerOfAISystem`, `AllegedHarmedOrNearlyHarmedParties` — covers all incidents in the database

2. **Classification attributes** (via existing `FIND_CLASSIFICATION` query) — taxonomy-specific annotation fields from CSETv1, GMF, and MIT

Cross-referencing works by grouping classifications by `incident_id`, then for any selected entity or classification value, finding matching incidents and aggregating their classification fields across taxonomies.

## Data Coverage Note

The visualizations are most useful when there is sufficient cross-taxonomy coverage for the selected filters. Current coverage varies:

- **MIT** classifications cover ~1,242 incidents (best coverage) — Intent, Risk Domain, Risk Subdomain, Timing
- **GMF** classifications cover ~326 incidents — Known AI Technology, Known AI Technical Failure, Known AI Goal
- **CSETv1** classifications cover ~214 incidents — Sector of Deployment, Harm Distribution Basis, Harm Domain, Autonomy Level
- **Entity data** (developers/deployers) covers all ~1,425 incidents

Some cross-taxonomy combinations yield small sample sizes currently. The tool handles this with sample size indicators and warnings. **As the database grows and more incidents receive taxonomy classifications, these visualizations will become increasingly insightful.**

## Potential Use Cases

- **Researchers** studying patterns in AI harms across industries, demographics, and technologies
- **Policymakers** exploring which sectors or demographics are most affected by specific types of AI failures
- **Companies** examining their own incident profiles compared to industry patterns
- **Journalists** finding data-driven angles on AI safety stories
- **AI safety practitioners** identifying which technologies are associated with which failure modes

## Technical Notes

- Uses Billboard.js (already in project) for all chart rendering
- No new dependencies added
- No backend/API changes required — uses existing GraphQL queries plus one new lightweight incidents query
- All processing happens client-side
- Handles CSETv1 semicolon-separated multi-value strings (e.g., `"Google; DeepMind"` split into separate values)

## Test Plan

- [ ] Verify page loads at `/apps/cross-taxonomy/`
- [ ] By Developer tab: select "OpenAI" — should show ~147 incidents with charts for sectors, failures, demographics, intent, risk domains
- [ ] By Deployer tab: select a deployer — should show charts
- [ ] By Affected Group tab: select "race" — should show ~68 incidents with sector/technology/harm breakdowns
- [ ] By Technology tab: select "Face Recognition" from GMF — should show deployment sectors, failure modes, etc.
- [ ] Custom Explorer: select CSETv1::Sector of Deployment (X) and MIT::Intent (Y) — should render a cross-taxonomy chart
- [ ] URL sharing: copy share link, open in new tab — should restore same view
- [ ] Mobile responsive: charts should stack in single column on small screens
- [ ] Sidebar: managed via Prismic CMS — entry would need to be added there after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)