### PR TITLE
workflow to cleanup translations

### DIFF
--- a/.github/workflows/cleanup-translations.yml
+++ b/.github/workflows/cleanup-translations.yml
@@ -1,0 +1,53 @@
+name: Cleanup Invalid Translations
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Environment to clean up (production or staging)"
+        required: true
+        default: "production"
+        type: choice
+        options:
+          - production
+          - staging
+      dry-run:
+        description: "Dry run (preview deletions without deleting)"
+        required: true
+        default: true
+        type: boolean
+
+jobs:
+  cleanup:
+    name: Remove Invalid Translations
+    environment: ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Cache NPM dependencies
+        id: cache-npm-dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            site/gatsby-site/node_modules
+          key: ${{ runner.os }}-npm-dependencies-${{ hashFiles('**/gatsby-site/package-lock.json') }}
+
+      - name: Install NPM dependencies
+        if: steps.cache-npm-dependencies.outputs.cache-hit != 'true'
+        run: npm ci
+        working-directory: site/gatsby-site
+
+      - name: Run cleanup script
+        run: npx tsx src/scripts/cleanupTranslations.ts
+        working-directory: site/gatsby-site
+        env:
+          MONGODB_TRANSLATIONS_CONNECTION_STRING: ${{ secrets.MONGODB_TRANSLATIONS_CONNECTION_STRING }}
+          DRY_RUN: ${{ inputs.dry-run }}

--- a/.github/workflows/cleanup-translations.yml
+++ b/.github/workflows/cleanup-translations.yml
@@ -6,7 +6,7 @@ on:
       environment:
         description: "Environment to clean up (production or staging)"
         required: true
-        default: "production"
+        default: "staging"
         type: choice
         options:
           - production

--- a/site/gatsby-site/package.json
+++ b/site/gatsby-site/package.json
@@ -156,6 +156,7 @@
     "process-briefing-notifications:ci": "npx tsx src/scripts/process-briefing-notifications.ts",
     "translate-reports": "npx tsx src/scripts/translateReports.ts",
     "translate-incidents": "npx tsx src/scripts/translateIncidents.ts",
+    "cleanup-translations": "npx tsx src/scripts/cleanupTranslations.ts",
     "magic-link": "npx tsx --env-file=.env src/scripts/magic-link.ts $1 $2",
     "restore-mongodb": "npx tsx --env-file=.env src/scripts/restore-mongodb.ts",
     "import-classifications-csv": "npx tsx --env-file=.env src/scripts/import-classifications-csv.ts",

--- a/site/gatsby-site/src/scripts/cleanupTranslations.ts
+++ b/site/gatsby-site/src/scripts/cleanupTranslations.ts
@@ -1,0 +1,66 @@
+import { MongoClient } from 'mongodb';
+
+const DRY_RUN = process.env.DRY_RUN !== 'false';
+
+const invalidFieldQuery = (fields: string[]) => ({
+  $or: fields.flatMap((field) => [
+    { [field]: { $exists: false } },
+    { [field]: null },
+    { [field]: '' },
+  ]),
+});
+
+(async () => {
+  const connectionString = process.env.MONGODB_TRANSLATIONS_CONNECTION_STRING;
+
+  if (!connectionString) {
+    throw new Error('MONGODB_TRANSLATIONS_CONNECTION_STRING is required');
+  }
+
+  console.log(`Running in ${DRY_RUN ? 'DRY RUN' : 'LIVE'} mode\n`);
+
+  const client = new MongoClient(connectionString);
+
+  try {
+    await client.connect();
+    const db = client.db('translations');
+
+    // Clean up report translations with empty/null/missing title or text
+    const reportQuery = invalidFieldQuery(['title', 'text']);
+    const invalidReports = await db.collection('reports').find(reportQuery).toArray();
+
+    console.log(`Found ${invalidReports.length} invalid report translations:`);
+    for (const t of invalidReports) {
+      console.log(`  report_number: ${t.report_number}, language: ${t.language}, title: ${JSON.stringify(t.title)}, text: ${t.text === undefined ? 'undefined' : t.text === null ? 'null' : `"${t.text.slice(0, 50)}..."`}`);
+    }
+
+    if (!DRY_RUN && invalidReports.length > 0) {
+      const reportResult = await db.collection('reports').deleteMany(reportQuery);
+      console.log(`\nDeleted ${reportResult.deletedCount} invalid report translations`);
+    }
+
+    // Clean up incident translations with empty/null/missing title or description
+    const incidentQuery = invalidFieldQuery(['title', 'description']);
+    const invalidIncidents = await db.collection('incidents').find(incidentQuery).toArray();
+
+    console.log(`\nFound ${invalidIncidents.length} invalid incident translations:`);
+    for (const t of invalidIncidents) {
+      console.log(`  incident_id: ${t.incident_id}, language: ${t.language}, title: ${JSON.stringify(t.title)}, description: ${t.description === undefined ? 'undefined' : t.description === null ? 'null' : `"${t.description.slice(0, 50)}..."`}`);
+    }
+
+    if (!DRY_RUN && invalidIncidents.length > 0) {
+      const incidentResult = await db.collection('incidents').deleteMany(incidentQuery);
+      console.log(`\nDeleted ${incidentResult.deletedCount} invalid incident translations`);
+    }
+
+    if (DRY_RUN && (invalidReports.length > 0 || invalidIncidents.length > 0)) {
+      console.log('\nDRY RUN: No documents were deleted. Set DRY_RUN=false to delete.');
+    }
+
+    if (invalidReports.length === 0 && invalidIncidents.length === 0) {
+      console.log('\nNo invalid translations found.');
+    }
+  } finally {
+    await client.close();
+  }
+})();


### PR DESCRIPTION
After months of no translation issues, we had a translation API outage and empty strings landed in prod. This causes [integrity tests to fail](https://github.com/responsible-ai-collaborative/aiid/actions/runs/24434077890/job/71384371092). This workflow deletes the offending translations.