### PR TITLE
fix flaky tests

### DIFF
--- a/site/gatsby-site/playwright/e2e/apps/incidents.spec.ts
+++ b/site/gatsby-site/playwright/e2e/apps/incidents.spec.ts
@@ -263,7 +263,7 @@ test.describe('Incidents App', () => {
     await page.waitForSelector('[data-cy="table-view"] button:has-text("Issue Reports")');
     await page.locator('[data-cy="table-view"] button:has-text("Issue Reports")').click();
 
-    await page.waitForSelector('[data-cy="row"]');
+    await page.waitForURL(/view=issueReports/);
     await expect(page.locator('[data-cy="row"]')).toHaveCount(2);
 
     const firstRowLink = await page.locator('[data-cy="row"] td a').first().getAttribute('href');
@@ -271,7 +271,7 @@ test.describe('Incidents App', () => {
 
     await page.getByText('Reports', { exact: true }).click();
 
-    await page.waitForSelector('[data-cy="row"]');
+    await page.waitForURL(/view=reports/);
     await expect(page.locator('[data-cy="row"]')).toHaveCount(4);
 
     const firstCiteLink = await page.locator('[data-cy="row"] td a').first().getAttribute('href');


### PR DESCRIPTION
The most plausible explanation for the [flakes](https://github.com/responsible-ai-collaborative/aiid/actions/runs/24545736391/job/71774376751) is a race between the initial-mount useEffect in src/pages/apps/incidents.js:46-52 (which sets selectedView to  'incidents') and the click handler — the test clicks before the view state stabilizes, so the incidents table (4 rows) remains rendered.

Fix: Make the test wait for the view to actually switch before asserting row count. In playwright/e2e/apps/incidents.spec.ts:260-279, add a wait for the URL query param to update (the click handler sets ?view=issueReports via replaceState) before the row count assertion.