### PR TITLE
default to internet archive even when it doesn't exist in the archive

### DIFF
--- a/site/gatsby-site/src/components/ui/WebArchiveLink.js
+++ b/site/gatsby-site/src/components/ui/WebArchiveLink.js
@@ -7,19 +7,20 @@ async function getSnapshotURL(url) {
 
   const response = await (await fetch(waUrl)).json();
 
-  return response.archived_snapshots.closest.url.replace('http:', 'https:');
+  return response.archived_snapshots?.closest?.url.replace('http:', 'https:');
 }
 
 export default function WebArchiveLink({ url, children, className = '' }) {
   const onClick = async () => {
     const win = window.open('', '_blank');
+    const fallbackUrl = `https://web.archive.org/web/*/${url}`;
 
     try {
       const snapshotUrl = await getSnapshotURL(url);
 
-      win.location.href = snapshotUrl;
+      win.location.href = snapshotUrl || fallbackUrl;
     } catch (e) {
-      win.location.href = url;
+      win.location.href = fallbackUrl;
     }
   };
 


### PR DESCRIPTION
The fail through for a non-existent archive was to silently fail and send the user to the actual resource link.

When the wayback-available API returns no closest snapshot (or the call throws), the link now falls back to  https://web.archive.org/web/*/<url> — the Wayback Machine calendar view — instead of the original source. The happy-path (snapshot exists) still uses the returned snapshot URL, so the existing discover.spec.ts:308 assertion still passes.