### PR TITLE
add MIT to Algolia index

### DIFF
--- a/site/gatsby-site/config.js
+++ b/site/gatsby-site/config.js
@@ -199,7 +199,7 @@ const config = {
     defaultLanguage: 'en',
   },
   discover: {
-    taxa: ['CSETv0', 'CSETv1', 'GMF'],
+    taxa: ['CSETv0', 'CSETv1', 'GMF', 'MIT'],
   },
   cloudflareR2: {
     accountId: process.env.CLOUDFLARE_R2_ACCOUNT_ID,

--- a/site/gatsby-site/src/components/discover/Filters.js
+++ b/site/gatsby-site/src/components/discover/Filters.js
@@ -8,7 +8,9 @@ function Filters({ expandFilters }) {
     taxa: { nodes: taxa },
   } = useStaticQuery(graphql`
     query FiltersTaxaQuery {
-      taxa: allMongodbAiidprodTaxa(filter: { namespace: { in: ["CSETv1", "CSETv0", "GMF"] } }) {
+      taxa: allMongodbAiidprodTaxa(
+        filter: { namespace: { in: ["CSETv1", "CSETv0", "GMF", "MIT"] } }
+      ) {
         nodes {
           namespace
           field_list {

--- a/site/gatsby-site/src/components/discover/OptionsModal.js
+++ b/site/gatsby-site/src/components/discover/OptionsModal.js
@@ -50,7 +50,9 @@ function OptionsModal() {
     taxa: { nodes: taxa },
   } = useStaticQuery(graphql`
     query FiltersTaxaQuery {
-      taxa: allMongodbAiidprodTaxa(filter: { namespace: { in: ["CSETv1", "CSETv0", "GMF"] } }) {
+      taxa: allMongodbAiidprodTaxa(
+        filter: { namespace: { in: ["CSETv1", "CSETv0", "GMF", "MIT"] } }
+      ) {
         nodes {
           namespace
           field_list {


### PR DESCRIPTION
 Issue #3664 — MIT classifications were being excluded from the discover interface filters.
  
  Fix — added 'MIT' to the three places where the supported discover taxonomies are enumerated:
  
  - site/gatsby-site/config.js:202 — drives Algolia attributesForFaceting, so MIT.* fields become facetable on next
  index rebuild.
  - site/gatsby-site/src/components/discover/Filters.js:11 — desktop filter row's GraphQL taxa query.
  - site/gatsby-site/src/components/discover/OptionsModal.js:53 — mobile/options modal's GraphQL taxa query.

The next Algolia rebuild is required for the change to take effect in search.