### PR TITLE
Optimize page data

### DIFF
--- a/site/gatsby-site/page-creators/createCitationPages.js
+++ b/site/gatsby-site/page-creators/createCitationPages.js
@@ -13,14 +13,11 @@ const createCitationPages = async (graphql, createPage, { languages }) => {
           reports {
             title
             report_number
-            language
             image_url
             cloudinary_id
           }
           editor_similar_incidents
           editor_dissimilar_incidents
-          flagged_dissimilar_incidents
-          description
           nlp_similar_incidents {
             incident_id
             similarity
@@ -66,7 +63,6 @@ const createCitationPages = async (graphql, createPage, { languages }) => {
     );
 
     pageContexts.push({
-      incident,
       incident_id,
       report_numbers: incident.reports.map((r) => r.report_number),
       nextIncident:

--- a/site/gatsby-site/page-creators/createLandingPage.js
+++ b/site/gatsby-site/page-creators/createLandingPage.js
@@ -66,14 +66,31 @@ const createLandingPage = async (graphql, createPage) => {
     }
   `);
 
+  // The landing page renders only a short preview (~240 chars) of a single report per
+  // incident, so ship just that one report with a trimmed body. This keeps the homepage
+  // page-data.json small — it is downloaded on every visit to "/", including every crawl.
+  const PREVIEW_CHARS = 600;
+
   const latestIncidents = result.data.latestIncidents.nodes.map((node) => {
     const filteredReports = node.reports
       .filter((r) => r.is_incident_report && !r.quiet)
       .sort((a, b) => a.epoch_date_submitted - b.epoch_date_submitted);
 
+    const [previewReport] = filteredReports;
+
     return {
       ...node,
-      reports: filteredReports,
+      reports: previewReport
+        ? [
+            {
+              ...previewReport,
+              text:
+                typeof previewReport.text === 'string'
+                  ? previewReport.text.slice(0, PREVIEW_CHARS)
+                  : previewReport.text,
+            },
+          ]
+        : [],
     };
   });
 

--- a/site/gatsby-site/src/components/blog/PostsListing.js
+++ b/site/gatsby-site/src/components/blog/PostsListing.js
@@ -29,7 +29,7 @@ export default function PostsListing({ posts, mdxBlogPosts }) {
           return p.mdx ? (
             <PostPreview key={p.fields.slug} post={p} />
           ) : (
-            <PrismicPostPreview key={p.node.id} post={p.node} />
+            <PrismicPostPreview key={p.node.data.slug} post={p.node} />
           );
         })}
       </div>

--- a/site/gatsby-site/src/components/entities/CommonEntities.js
+++ b/site/gatsby-site/src/components/entities/CommonEntities.js
@@ -23,8 +23,6 @@ export default function CommonEntities() {
           reports {
             report_number
           }
-          title
-          description
           Alleged_deployer_of_AI_system
           Alleged_developer_of_AI_system
           Alleged_harmed_or_nearly_harmed_parties

--- a/site/gatsby-site/src/components/forms/SubmissionWizard/StepThree.js
+++ b/site/gatsby-site/src/components/forms/SubmissionWizard/StepThree.js
@@ -140,13 +140,6 @@ const StepThree = (props) => {
 
   const staticQueryData = useStaticQuery(graphql`
     query SubmissionFormQuery {
-      allMongodbAiidprodReports {
-        edges {
-          node {
-            tags
-          }
-        }
-      }
       allMongodbAiidprodEntities {
         nodes {
           name
@@ -158,18 +151,6 @@ const StepThree = (props) => {
   const entityNames = staticQueryData.allMongodbAiidprodEntities.nodes
     .map((node) => node.name)
     .sort();
-
-  const tags = [];
-
-  for (const node of staticQueryData.allMongodbAiidprodReports.edges) {
-    if (node.node.tags) {
-      for (const tag of node.node.tags) {
-        if (!tags.includes(tag)) {
-          tags.push(tag);
-        }
-      }
-    }
-  }
 
   return (
     <StepContainer name={props.name} childClassName="p-6">

--- a/site/gatsby-site/src/components/layout/Footer.js
+++ b/site/gatsby-site/src/components/layout/Footer.js
@@ -25,17 +25,9 @@ export default function Footer() {
     query FooterQuery {
       site {
         siteMetadata {
-          headerTitle
           githubUrl
           facebookUrl
           linkedInUrl
-          helpUrl
-          tweetText
-          logo {
-            link
-            image
-            mobile
-          }
         }
       }
       allPrismicFooter(sort: { data: { order: ASC } }) {
@@ -50,7 +42,6 @@ export default function Footer() {
                 }
                 path
               }
-              order
               social {
                 name
                 url {

--- a/site/gatsby-site/src/components/leaderboards/UniqueSubmittersLeaderboard.js
+++ b/site/gatsby-site/src/components/leaderboards/UniqueSubmittersLeaderboard.js
@@ -15,7 +15,6 @@ const UniqueSubmittersLeaderboard = ({ limit = 0, className = '' }) => {
           reports {
             report_number
             submitters
-            date_submitted
             is_incident_report
           }
         }

--- a/site/gatsby-site/src/pages/apps/incidents.js
+++ b/site/gatsby-site/src/pages/apps/incidents.js
@@ -270,11 +270,6 @@ export const query = graphql`
         incident_id
         title
         description
-        editors {
-          userId
-          first_name
-          last_name
-        }
         date
         Alleged_deployer_of_AI_system
         Alleged_developer_of_AI_system
@@ -298,17 +293,12 @@ export const query = graphql`
         reports {
           report_number
           title
-          url
           authors
-          date_downloaded
           date_modified
           date_published
           date_submitted
-          description
           flag
-          image_url
           language
-          source_domain
           submitters
           is_incident_report
         }
@@ -322,17 +312,12 @@ export const query = graphql`
       nodes {
         report_number
         title
-        url
         authors
-        date_downloaded
         date_modified
         date_published
         date_submitted
-        description
         flag
-        image_url
         language
-        source_domain
         submitters
         is_incident_report
       }

--- a/site/gatsby-site/src/pages/blog/index.js
+++ b/site/gatsby-site/src/pages/blog/index.js
@@ -41,24 +41,15 @@ export const IndexQuery = graphql`
     ) {
       edges {
         node {
-          uid
-          lang
           data {
-            metatitle
-            metadescription
             slug
-            aitranslated
-            language
             title {
               text
             }
             content {
-              richText
               text
-              html
             }
             image {
-              url
               gatsbyImageData
             }
             date
@@ -80,7 +71,6 @@ export const IndexQuery = graphql`
         body
         excerpt
         frontmatter {
-          metaDescription
           date
           author
           slug

--- a/site/gatsby-site/src/pages/cite/[id].js
+++ b/site/gatsby-site/src/pages/cite/[id].js
@@ -76,17 +76,11 @@ export const query = graphql`
         field_list {
           field_number
           short_name
-          long_name
           short_description
           long_description
           display_type
-          mongo_type
-          default
-          placeholder
           permitted_values
           weight
-          instant_facet
-          required
           public
           complete_from {
             all
@@ -96,17 +90,11 @@ export const query = graphql`
           subfields {
             field_number
             short_name
-            long_name
             short_description
             long_description
             display_type
-            mongo_type
-            default
-            placeholder
             permitted_values
             weight
-            instant_facet
-            required
             public
             complete_from {
               all

--- a/site/gatsby-site/src/pages/summaries/cset-charts.js
+++ b/site/gatsby-site/src/pages/summaries/cset-charts.js
@@ -131,16 +131,6 @@ export const pageQuery = graphql`
           short_name
           value_json
         }
-        publish
-      }
-    }
-    allMongodbAiidprodTaxa(limit: 9999999) {
-      nodes {
-        namespace
-        field_list {
-          short_name
-          hide_search
-        }
       }
     }
   }

--- a/site/gatsby-site/src/pages/summaries/gallery.js
+++ b/site/gatsby-site/src/pages/summaries/gallery.js
@@ -172,7 +172,6 @@ export const pageQuery = graphql`
         incident_id
         title
         reports {
-          report_number
           image_url
           cloudinary_id
         }

--- a/site/gatsby-site/src/pages/summaries/incidents.js
+++ b/site/gatsby-site/src/pages/summaries/incidents.js
@@ -153,7 +153,6 @@ export const pageQuery = graphql`
       nodes {
         incident_id
         title
-        date
         reports {
           report_number
           title

--- a/site/gatsby-site/src/pages/summaries/incidentsOverTime.js
+++ b/site/gatsby-site/src/pages/summaries/incidentsOverTime.js
@@ -138,24 +138,8 @@ export const pageQuery = graphql`
   query IncidentsOverTime {
     allMongodbAiidprodIncidents(sort: { reports: { date_submitted: ASC } }) {
       nodes {
-        incident_id
-        title
-        date
         reports {
-          report_number
-          title
-          url
-          authors
-          date_downloaded
-          date_modified
-          date_published
           date_submitted
-          description
-          flag
-          image_url
-          language
-          source_domain
-          submitters
         }
       }
     }

--- a/site/gatsby-site/src/pages/taxonomies.js
+++ b/site/gatsby-site/src/pages/taxonomies.js
@@ -116,15 +116,6 @@ export const Head = (props) => {
 
 export const pageQuery = graphql`
   query TaxonomoyGraphCarouselTaxa {
-    allMongodbAiidprodTaxa {
-      nodes {
-        namespace
-        field_list {
-          permitted_values
-          short_name
-        }
-      }
-    }
     allMongodbAiidprodClassifications {
       nodes {
         namespace

--- a/site/gatsby-site/src/templates/cite.js
+++ b/site/gatsby-site/src/templates/cite.js
@@ -201,17 +201,11 @@ export const query = graphql`
         field_list {
           field_number
           short_name
-          long_name
           short_description
           long_description
           display_type
-          mongo_type
-          default
-          placeholder
           permitted_values
           weight
-          instant_facet
-          required
           public
           complete_from {
             all
@@ -221,17 +215,11 @@ export const query = graphql`
           subfields {
             field_number
             short_name
-            long_name
             short_description
             long_description
             display_type
-            mongo_type
-            default
-            placeholder
             permitted_values
             weight
-            instant_facet
-            required
             public
             complete_from {
               all

--- a/site/gatsby-site/src/templates/doc.js
+++ b/site/gatsby-site/src/templates/doc.js
@@ -66,23 +66,9 @@ export const Head = (props) => {
 
 export const pageQuery = graphql`
   query DocsTemplateQuery($slug: String!, $locale: String!) {
-    site {
-      siteMetadata {
-        title
-        docsLocation
-      }
-    }
     mdx(fields: { locale: { eq: $locale } }, frontmatter: { slug: { eq: $slug } }) {
       fields {
-        id
         title
-        slug
-      }
-      tableOfContents
-      parent {
-        ... on File {
-          relativePath
-        }
       }
       frontmatter {
         metaTitle
@@ -93,15 +79,7 @@ export const pageQuery = graphql`
     }
     enMdx: mdx(fields: { locale: { eq: "en" } }, frontmatter: { slug: { eq: $slug } }) {
       fields {
-        id
         title
-        slug
-      }
-      tableOfContents
-      parent {
-        ... on File {
-          relativePath
-        }
       }
       frontmatter {
         metaTitle

--- a/site/gatsby-site/src/templates/entities.js
+++ b/site/gatsby-site/src/templates/entities.js
@@ -88,11 +88,6 @@ export const query = graphql`
           report_number
         }
         title
-        description
-        Alleged_deployer_of_AI_system
-        Alleged_developer_of_AI_system
-        Alleged_harmed_or_nearly_harmed_parties
-        implicated_systems
       }
     }
   }

--- a/site/gatsby-site/src/templates/landingPage.js
+++ b/site/gatsby-site/src/templates/landingPage.js
@@ -176,50 +176,10 @@ export function Head({ location }) {
 
 export const query = graphql`
   query LandingPageQuery(
-    $latestReportNumber: Int
     $latestIncidentsReportNumbers: [Int]
     $locale: String!
     $latestIncidentIds: [Int]
   ) {
-    latestReportIncident: allMongodbAiidprodIncidents(
-      filter: { reports: { elemMatch: { report_number: { eq: $latestReportNumber } } } }
-    ) {
-      edges {
-        node {
-          incident_id
-        }
-      }
-    }
-    latestReportIncidents: allMongodbAiidprodIncidents(
-      filter: { reports: { elemMatch: { report_number: { in: $latestIncidentsReportNumbers } } } }
-    ) {
-      edges {
-        node {
-          incident_id
-          reports {
-            report_number
-            title
-            text
-            epoch_date_submitted
-            image_url
-            report_number
-            cloudinary_id
-            language
-            source_domain
-            url
-          }
-        }
-      }
-    }
-    latestReport: mongodbAiidprodReports(report_number: { in: $latestIncidentsReportNumbers }) {
-      title
-      text
-      epoch_date_submitted
-      image_url
-      report_number
-      cloudinary_id
-      language
-    }
     latestIncidentsReportsTranslations: allMongodbTranslationsReports(
       filter: { report_number: { in: $latestIncidentsReportNumbers } }
     ) {
@@ -247,24 +207,15 @@ export const query = graphql`
       limit: 1
     ) {
       nodes {
-        uid
-        lang
         data {
-          metatitle
-          metadescription
           slug
-          aitranslated
-          language
           title {
             text
           }
           content {
-            richText
             text
-            html
           }
           image {
-            url
             gatsbyImageData
           }
           date
@@ -281,13 +232,11 @@ export const query = graphql`
         fields {
           slug
           title
-          locale
           previewText
         }
         body
         excerpt
         frontmatter {
-          metaDescription
           slug
           date
           author

--- a/site/gatsby-site/src/templates/post.js
+++ b/site/gatsby-site/src/templates/post.js
@@ -140,21 +140,9 @@ export const Head = (props) => {
 
 export const pageQuery = graphql`
   query PostTemplateQuery($slug: String!, $locale: String!) {
-    site {
-      siteMetadata {
-        title
-        docsLocation
-      }
-    }
     mdx(fields: { locale: { eq: $locale } }, frontmatter: { slug: { eq: $slug } }) {
       fields {
         title
-      }
-      tableOfContents
-      parent {
-        ... on File {
-          relativePath
-        }
       }
       frontmatter {
         metaTitle
@@ -173,12 +161,6 @@ export const pageQuery = graphql`
     enMdx: mdx(fields: { locale: { eq: "en" } }, frontmatter: { slug: { eq: $slug } }) {
       fields {
         title
-      }
-      tableOfContents
-      parent {
-        ... on File {
-          relativePath
-        }
       }
       frontmatter {
         metaTitle

--- a/site/gatsby-site/src/templates/prismicBlogPost.js
+++ b/site/gatsby-site/src/templates/prismicBlogPost.js
@@ -44,27 +44,17 @@ export const Head = (props) => {
 
 export const pageQuery = graphql`
   query Post($slug: String!, $locale: String!) {
-    site {
-      siteMetadata {
-        title
-        docsLocation
-      }
-    }
     post: prismicBlog(data: { language: { eq: $locale }, slug: { eq: $slug } }) {
-      uid
       data {
         metatitle
         metadescription
         slug
         aitranslated
-        language
         title {
           text
         }
         content {
           richText
-          text
-          html
         }
         image {
           url
@@ -75,20 +65,16 @@ export const pageQuery = graphql`
       }
     }
     originalPost: prismicBlog(data: { language: { eq: "en" }, slug: { eq: $slug } }) {
-      uid
       data {
         metatitle
         metadescription
         slug
         aitranslated
-        language
         title {
           text
         }
         content {
           richText
-          text
-          html
         }
         image {
           url

--- a/site/gatsby-site/src/templates/prismicDoc.js
+++ b/site/gatsby-site/src/templates/prismicDoc.js
@@ -34,19 +34,12 @@ export const Head = (props) => {
 
 export const pageQuery = graphql`
   query Doc($slug: String!, $locale: String!) {
-    site {
-      siteMetadata {
-        title
-        docsLocation
-      }
-    }
     doc: prismicDoc(data: { language: { eq: $locale }, slug: { eq: $slug } }) {
       data {
         title
         metatitle
         metadescription
         aitranslated
-        language
         slug
         content {
           text {
@@ -65,7 +58,6 @@ export const pageQuery = graphql`
         metatitle
         metadescription
         aitranslated
-        language
         slug
         content {
           text {

--- a/site/gatsby-site/src/templates/report.js
+++ b/site/gatsby-site/src/templates/report.js
@@ -162,10 +162,8 @@ export const query = graphql`
       image_url
       cloudinary_id
       source_domain
-      mongodb_id
       text
       authors
-      epoch_date_submitted
       language
       description
       snippet_max_characters
@@ -193,17 +191,11 @@ export const query = graphql`
         field_list {
           field_number
           short_name
-          long_name
           short_description
           long_description
           display_type
-          mongo_type
-          default
-          placeholder
           permitted_values
           weight
-          instant_facet
-          required
           public
           complete_from {
             all
@@ -213,17 +205,11 @@ export const query = graphql`
           subfields {
             field_number
             short_name
-            long_name
             short_description
             long_description
             display_type
-            mongo_type
-            default
-            placeholder
             permitted_values
             weight
-            instant_facet
-            required
             public
             complete_from {
               all


### PR DESCRIPTION
Bandwidth bills with Netlify have crossed a threshold and it is starting to hurt. This pull request is a collection of easy fixes that reduce the Netlify bandwidth, primarily in reducing the page data sizes. There are a bunch of things being queries that don't get displayed -- those are in the packaged data anyway. Not anymore. :)

I am going to test run this in staging for a few days and land additional things with this.

<img width="1018" height="626" alt="Screenshot 2026-06-01 at 10 11 11 PM" src="https://github.com/user-attachments/assets/2a100d9a-9663-4742-973e-dcc9050067ee" />
<img width="1029" height="643" alt="Screenshot 2026-06-01 at 10 08 47 PM" src="https://github.com/user-attachments/assets/165fbf98-e822-45e9-95b9-3950a0e74fdc" />
