### PR TITLE
Add cross-taxonomy visualization feature

### DIFF
--- a/site/gatsby-site/config.js
+++ b/site/gatsby-site/config.js
@@ -87,6 +87,12 @@ const config = {
       { title: 'List View', label: 'list', url: '/summaries/incidents/', items: [] },
       { title: 'Entities', label: 'entities', url: '/entities/', items: [] },
       { title: 'Taxonomies', label: 'taxonomies', url: '/taxonomies/', items: [] },
+      {
+        title: 'Cross-Taxonomy Visualizations',
+        label: 'cross-taxonomy',
+        url: '/apps/cross-taxonomy/',
+        items: [],
+      },
       { title: 'Random Incident', label: 'random', url: '/random/', items: [] },
       { title: 'Submit Incident Reports', label: 'submit', url: '/apps/submit/', items: [] },
       { title: 'Risk Checklists', label: 'checklists', url: '/apps/checklists/', items: [] },

--- a/site/gatsby-site/jest.utils.config.js
+++ b/site/gatsby-site/jest.utils.config.js
@@ -1,0 +1,11 @@
+/**
+ * Minimal Jest config for running pure utility function tests.
+ * Separate from the main jest.config.ts which requires MongoDB setup.
+ */
+module.exports = {
+  testEnvironment: 'node',
+  transform: {
+    '\\.[jt]sx?$': ['babel-jest', { presets: ['@babel/preset-env'] }],
+  },
+  testMatch: ['**/src/utils/__tests__/**/*.test.js'],
+};

--- a/site/gatsby-site/package.json
+++ b/site/gatsby-site/package.json
@@ -144,6 +144,7 @@
     "serve": "netlify dev --target-port 9000 --port 8000 -d public --offline",
     "test:e2e": "npx playwright test playwright/e2e-full --ui",
     "test:e2e:ci": "DEBUG=pw:webserver npx playwright test $TEST_FOLDER --shard=$SHARD_INDEX/$SHARD_TOTAL",
+    "test:utils": "jest --config jest.utils.config.js",
     "test:api": "jest --setupFiles dotenv/config --runInBand --forceExit",
     "test:api:ci": "jest --runInBand --forceExit",
     "codegen": "graphql-codegen --config codegen.ts",

--- a/site/gatsby-site/src/components/visualizations/ChartCard.js
+++ b/site/gatsby-site/src/components/visualizations/ChartCard.js
@@ -1,0 +1,454 @@
+import React, { useMemo, useState, useLayoutEffect, useRef } from 'react';
+import { Card } from 'flowbite-react';
+import bb, { bar, line, donut } from 'billboard.js';
+import { Trans, useTranslation } from 'react-i18next';
+
+// Color palette matching the AIID taxonomy page style
+const COLORS = [
+  '#3b82f6', // blue
+  '#f59e0b', // amber
+  '#10b981', // emerald
+  '#ef4444', // red
+  '#8b5cf6', // violet
+  '#6b7280', // gray
+  '#ec4899', // pink
+  '#14b8a6', // teal
+  '#f97316', // orange
+  '#06b6d4', // cyan
+  '#84cc16', // lime
+  '#a855f7', // purple
+  '#78716c', // stone
+  '#e11d48', // rose
+  '#0ea5e9', // sky
+  '#d946ef', // fuchsia
+  '#eab308', // yellow
+  '#22c55e', // green
+  '#64748b', // slate
+  '#dc2626', // red-dark
+];
+
+// Thin wrapper instead of @billboard.js/react, whose destroy() can run against
+// a DOM node React already removed (Strict Mode) and throw. Regenerates only
+// when chartKey changes.
+export function BillboardChart({ options, chartKey }) {
+  const elRef = useRef(null);
+
+  useLayoutEffect(() => {
+    const el = elRef.current;
+
+    if (!el) return;
+    const instance = bb.generate({ bindto: el, ...options });
+
+    return () => {
+      try {
+        instance.destroy();
+      } catch (_) {
+        /* node already detached by React; nothing to clean up */
+      }
+    };
+  }, [chartKey]); // options are stable within a given key
+
+  return <div ref={elRef} />;
+}
+
+const TYPE_OPTIONS = [
+  { value: 'bar', label: 'Bar' },
+  { value: 'line', label: 'Line' },
+  { value: 'donut', label: 'Donut' },
+];
+
+export default function ChartCard({
+  title,
+  subtitle,
+  counts,
+  chartType = 'bar',
+  maxItems = 15,
+  incidentCount,
+  sortBy = 'count',
+  incidentIdsByValue,
+}) {
+  const { t } = useTranslation();
+
+  const [activeType, setActiveType] = useState(chartType);
+
+  const [showPct, setShowPct] = useState(false);
+
+  // When true, the chart is replaced by a list of the contributing incidents,
+  // grouped by the same values shown on the chart.
+  const [showIds, setShowIds] = useState(false);
+
+  const hasData = !!counts && counts.size > 0;
+
+  const canNormalize = activeType !== 'donut' && incidentCount > 0 && !showIds;
+
+  const hasIds = incidentIdsByValue && incidentIdsByValue.size > 0;
+
+  const sortedEntries = useMemo(() => {
+    if (!counts) return [];
+    const entries = Array.from(counts.entries());
+
+    if (sortBy === 'key') {
+      entries.sort((a, b) => a[0].localeCompare(b[0]));
+      // Keep the end of the ascending sort so the most recent years survive
+      // the cap.
+      return entries.slice(-maxItems);
+    }
+    entries.sort((a, b) => b[1] - a[1]);
+    return entries.slice(0, maxItems);
+  }, [counts, maxItems, sortBy]);
+
+  const typeToggle = (
+    <div className="flex gap-1 shrink-0 flex-wrap justify-end">
+      {TYPE_OPTIONS.map(({ value, label }) => (
+        <button
+          key={value}
+          type="button"
+          disabled={!hasData}
+          onClick={() => {
+            setActiveType(value);
+            setShowIds(false);
+            if (value === 'donut') setShowPct(false);
+          }}
+          className={`text-xs px-2 py-0.5 rounded border transition-colors ${
+            !hasData
+              ? 'border-gray-100 text-gray-300 cursor-not-allowed'
+              : activeType === value && !showIds
+              ? 'bg-blue-50 border-blue-300 text-blue-700 font-medium'
+              : 'border-gray-200 text-gray-400 hover:text-gray-600 hover:border-gray-300'
+          }`}
+        >
+          {t(label)}
+        </button>
+      ))}
+      <button
+        type="button"
+        onClick={() => canNormalize && setShowPct((p) => !p)}
+        className={`text-xs px-2 py-0.5 rounded border transition-colors ${
+          !canNormalize
+            ? 'border-gray-100 text-gray-300 cursor-not-allowed'
+            : showPct
+            ? 'bg-blue-50 border-blue-300 text-blue-700 font-medium'
+            : 'border-gray-200 text-gray-400 hover:text-gray-600 hover:border-gray-300'
+        }`}
+      >
+        %
+      </button>
+      {hasIds && (
+        <button
+          type="button"
+          onClick={() => setShowIds((s) => !s)}
+          className={`text-xs px-2 py-0.5 rounded border transition-colors ${
+            showIds
+              ? 'bg-blue-50 border-blue-300 text-blue-700 font-medium'
+              : 'border-gray-200 text-gray-400 hover:text-gray-600 hover:border-gray-300'
+          }`}
+        >
+          {t('Incident IDs')}
+        </button>
+      )}
+    </div>
+  );
+
+  if (!counts || counts.size === 0) {
+    return (
+      <Card>
+        <div className="flex items-start justify-between gap-2">
+          <div>
+            <h3 className="text-base font-semibold">{t(title)}</h3>
+            {subtitle && <p className="text-xs text-gray-500">{t(subtitle)}</p>}
+            {incidentCount !== undefined && (
+              <p className="text-xs text-gray-400 mt-0.5">N = {incidentCount}</p>
+            )}
+          </div>
+          {typeToggle}
+        </div>
+        <div className="py-8 text-center text-sm text-gray-400">
+          <Trans>No data available for this analysis.</Trans>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      {/* Card header: title + type toggle buttons */}
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <h3 className="text-base font-semibold">{t(title)}</h3>
+          {subtitle && <p className="text-xs text-gray-500">{t(subtitle)}</p>}
+          {incidentCount !== undefined && (
+            <p className="text-xs text-gray-400 mt-0.5">N = {incidentCount}</p>
+          )}
+          {incidentCount !== undefined && incidentCount > 0 && incidentCount < 10 && (
+            <p className="text-xs text-amber-600 mt-0.5">
+              <Trans>Low sample: based on only {{ incidents: incidentCount }} incidents.</Trans>
+            </p>
+          )}
+          {counts.size > maxItems && (
+            <p className="text-xs text-gray-400 mt-0.5">
+              {sortBy === 'key' ? (
+                <Trans>
+                  Showing the latest {{ shown: maxItems }} of {{ total: counts.size }} values.
+                </Trans>
+              ) : (
+                <Trans>
+                  Showing the top {{ shown: maxItems }} of {{ total: counts.size }} values.
+                </Trans>
+              )}
+            </p>
+          )}
+        </div>
+        {typeToggle}
+      </div>
+
+      {showIds ? (
+        <IncidentListBody entries={sortedEntries} incidentIdsByValue={incidentIdsByValue} t={t} />
+      ) : activeType === 'donut' ? (
+        <DonutChartBody entries={sortedEntries} t={t} />
+      ) : (
+        <BarLineChartBody
+          entries={sortedEntries}
+          t={t}
+          activeType={activeType}
+          showPct={showPct}
+          denominator={incidentCount}
+          sortBy={sortBy}
+        />
+      )}
+    </Card>
+  );
+}
+
+// ---- Incident list body ----------------------------------------------------
+
+// Renders a wrapped row of links to each incident's /cite page. Shared by the
+// guided/ad-hoc ChartCard list view and the Custom Explorer's cross list.
+export function IncidentLinks({ ids }) {
+  if (!ids || ids.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {ids.map((id) => (
+        <a
+          key={id}
+          href={`/cite/${id}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block text-xs px-1.5 py-0.5 rounded border border-gray-200 text-blue-600 hover:bg-blue-50 hover:border-blue-300 transition-colors"
+        >
+          #{id}
+        </a>
+      ))}
+    </div>
+  );
+}
+
+// Lists the incidents behind each charted value, in the same order/limit the
+// chart uses, with a color swatch matching the chart legend.
+function IncidentListBody({ entries, incidentIdsByValue, t }) {
+  return (
+    <div className="flex flex-col gap-3 mt-1 max-h-[420px] overflow-y-auto pr-1">
+      {entries.map(([label], i) => {
+        const ids = (incidentIdsByValue && incidentIdsByValue.get(label)) || [];
+
+        return (
+          <div key={label} className="flex flex-col gap-1">
+            <div className="flex items-center gap-1.5 text-sm font-medium text-gray-700">
+              <span
+                className="inline-block w-3 h-3 rounded-sm flex-shrink-0"
+                style={{ backgroundColor: COLORS[i % COLORS.length] }}
+              />
+              <span>{label}</span>
+              <span className="text-xs font-normal text-gray-400">
+                ({ids.length} {ids.length === 1 ? t('incident') : t('incidents')})
+              </span>
+            </div>
+            <IncidentLinks ids={ids} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---- Bar / Line chart body -------------------------------------------------
+
+function BarLineChartBody({ entries, t, activeType, showPct, denominator, sortBy = 'count' }) {
+  // Time series get x-axis labels instead of per-bar colors.
+  const isTimeSeries = sortBy === 'key';
+
+  // 1-2 bars get a fixed narrow width (bar only; line stays fluid).
+  const isFewBars = !isTimeSeries && activeType === 'bar' && entries.length <= 2;
+
+  const options = useMemo(() => {
+    const labels = entries.map(([label]) => label);
+
+    const rawValues = entries.map(([, count]) => count);
+
+    const values =
+      showPct && denominator > 0
+        ? rawValues.map((n) => +((n / denominator) * 100).toFixed(1))
+        : rawValues;
+
+    const chartTypeFunc = activeType === 'line' ? line() : bar();
+
+    const yLabel = showPct ? t('% of classified incidents') : t('Count');
+
+    const tickFormat = showPct ? (x) => `${x}%` : (x) => (x === Math.floor(x) ? x : '');
+
+    return {
+      data: {
+        x: 'x',
+        columns: [
+          ['x', ...labels],
+          ['Count', ...values],
+        ],
+        type: chartTypeFunc,
+        // Uniform color for time series; per-index colors elsewhere to match
+        // the legend below.
+        color: isTimeSeries
+          ? () => COLORS[0]
+          : (defaultColor, d) => {
+              if (d && typeof d.index === 'number') return COLORS[d.index % COLORS.length];
+              return defaultColor;
+            },
+        names: { Count: '' },
+      },
+      axis: {
+        x: {
+          type: 'category',
+          // Ticks only for time series; other charts use the legend instead.
+          show: isTimeSeries,
+          ...(isTimeSeries && {
+            // Fixed rotate threshold; billboard's autorotate lets labels touch.
+            tick: {
+              rotate: entries.length > 6 ? -30 : 0,
+              multiline: false,
+              culling: false,
+            },
+            height: entries.length > 6 ? 60 : 40,
+          }),
+        },
+        y: {
+          label: { text: yLabel, position: 'outer-middle' },
+          tick: { format: tickFormat },
+        },
+      },
+      // bar config is ignored by Billboard when chart type is line
+      bar: {
+        width: isFewBars
+          ? 120
+          : {
+              ratio: Math.max(0.45, Math.min(0.85, 0.37 + entries.length * 0.04)),
+              max: Math.max(80, Math.min(160, 280 / entries.length)),
+            },
+      },
+      grid: { y: { show: false } },
+      legend: { show: false },
+      tooltip: {
+        grouped: false,
+        format: {
+          title: (x) => labels[x] || '',
+          value: (value) => (showPct ? `${value}%` : value),
+        },
+      },
+      size: isFewBars
+        ? { height: 390, width: entries.length * 180 + 80 }
+        : { height: Math.max(390, 340 + Math.ceil(entries.length / 3) * 24) },
+      resize: { auto: !isFewBars },
+    };
+  }, [entries, t, activeType, isFewBars, isTimeSeries, showPct, denominator]);
+
+  return (
+    <>
+      <div
+        className={`[&_.bb-ygrid-line>line]:stroke-gray-300 [&_.bb-ygrid-line>line]:stroke-1 [&_.bb-line]:fill-none ${
+          isTimeSeries
+            ? '[&_svg]:overflow-visible'
+            : isFewBars
+            ? 'w-fit overflow-x-auto'
+            : 'overflow-hidden'
+        }`}
+      >
+        <BillboardChart options={options} chartKey={`${activeType}-${showPct}`} />
+      </div>
+      {/* Legend: only for non-time-series charts. Time-series charts use X-axis labels instead. */}
+      {!isTimeSeries && (
+        <div className="flex flex-wrap gap-x-4 gap-y-1 mt-1 justify-center">
+          {entries.map(([label], i) => (
+            <div key={label} className="flex items-center gap-1 text-xs text-gray-600">
+              <span
+                className="inline-block w-3 h-3 rounded-sm flex-shrink-0"
+                style={{ backgroundColor: COLORS[i % COLORS.length] }}
+              />
+              {label}
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}
+
+// ---- Donut chart body ------------------------------------------------------
+
+function DonutChartBody({ entries, t }) {
+  const options = useMemo(() => {
+    const columns = entries.map(([label, count]) => [label, count]);
+
+    const colors = {};
+
+    entries.forEach(([label], i) => {
+      colors[label] = COLORS[i % COLORS.length];
+    });
+
+    const names = columns.reduce((obj, [key]) => {
+      obj[key] = t(key);
+      return obj;
+    }, {});
+
+    return {
+      data: {
+        columns,
+        type: donut(),
+        names,
+        colors,
+      },
+      donut: {
+        title: '',
+        label: { show: false },
+      },
+      legend: {
+        show: true,
+        position: 'bottom',
+      },
+      tooltip: {
+        contents: (d) => {
+          if (!d || !d[0]) return '';
+
+          const { id, ratio } = d[0];
+
+          const name = names[id] || id;
+
+          const pct = (ratio * 100).toFixed(1);
+
+          const bg = colors[id] || '#3b82f6';
+
+          return (
+            '<div style="background:white;border:1px solid #d1d5db;border-radius:6px;' +
+            'padding:6px 12px;font-size:13px;box-shadow:0 1px 4px rgba(0,0,0,0.1);' +
+            'display:flex;align-items:center;gap:8px;">' +
+            `<span style="width:10px;height:10px;border-radius:2px;background:${bg};` +
+            'flex-shrink:0;display:inline-block;"></span>' +
+            `<span>${name} <strong>${pct}%</strong></span>` +
+            '</div>'
+          );
+        },
+      },
+      size: { height: 300 },
+      resize: { auto: true },
+    };
+  }, [entries, t]);
+
+  return <BillboardChart options={options} chartKey={`donut-${entries.length}`} />;
+}

--- a/site/gatsby-site/src/components/visualizations/ChartCard.js
+++ b/site/gatsby-site/src/components/visualizations/ChartCard.js
@@ -1,0 +1,429 @@
+import React, { useMemo, useState, useLayoutEffect, useRef } from 'react';
+import { Card } from 'flowbite-react';
+import bb, { bar, line, donut } from 'billboard.js';
+import { Trans, useTranslation } from 'react-i18next';
+
+// Color palette matching the AIID taxonomy page style
+const COLORS = [
+  '#3b82f6', // blue
+  '#f59e0b', // amber
+  '#10b981', // emerald
+  '#ef4444', // red
+  '#8b5cf6', // violet
+  '#6b7280', // gray
+  '#ec4899', // pink
+  '#14b8a6', // teal
+  '#f97316', // orange
+  '#06b6d4', // cyan
+  '#84cc16', // lime
+  '#a855f7', // purple
+  '#78716c', // stone
+  '#e11d48', // rose
+  '#0ea5e9', // sky
+  '#d946ef', // fuchsia
+  '#eab308', // yellow
+  '#22c55e', // green
+  '#64748b', // slate
+  '#dc2626', // red-dark
+];
+
+// Replaces @billboard.js/react to avoid the el.parentNode.removeChild crash in
+// React 18 Strict Mode. Billboard's class-component destroy() fires on a DOM
+// node that React has already detached; useLayoutEffect + try/catch prevents
+// that from bubbling up as an unhandled error.
+function BillboardChart({ options, chartKey }) {
+  const elRef = useRef(null);
+
+  useLayoutEffect(() => {
+    const el = elRef.current;
+
+    if (!el) return;
+    const instance = bb.generate({ bindto: el, ...options });
+
+    return () => {
+      try {
+        instance.destroy();
+      } catch (_) {
+        /* node already detached by React; nothing to clean up */
+      }
+    };
+  }, [chartKey]); // options are stable within a given key
+
+  return <div ref={elRef} />;
+}
+
+const TYPE_OPTIONS = [
+  { value: 'bar', label: 'Bar' },
+  { value: 'line', label: 'Line' },
+  { value: 'donut', label: 'Donut' },
+];
+
+export default function ChartCard({
+  title,
+  subtitle,
+  counts,
+  chartType = 'bar',
+  maxItems = 15,
+  incidentCount,
+  sortBy = 'count',
+  incidentIdsByValue,
+}) {
+  const { t } = useTranslation();
+
+  const [activeType, setActiveType] = useState(chartType);
+
+  const [showPct, setShowPct] = useState(false);
+
+  // When true, the chart is replaced by a list of the contributing incidents,
+  // grouped by the same values shown on the chart.
+  const [showIds, setShowIds] = useState(false);
+
+  const canNormalize = activeType !== 'donut' && incidentCount > 0 && !showIds;
+
+  const hasIds = incidentIdsByValue && incidentIdsByValue.size > 0;
+
+  const sortedEntries = useMemo(() => {
+    if (!counts) return [];
+    const entries = Array.from(counts.entries());
+
+    if (sortBy === 'key') {
+      entries.sort((a, b) => a[0].localeCompare(b[0]));
+    } else {
+      entries.sort((a, b) => b[1] - a[1]);
+    }
+    return entries.slice(0, maxItems);
+  }, [counts, maxItems, sortBy]);
+
+  const typeToggle = (
+    <div className="flex gap-1 shrink-0 flex-wrap justify-end">
+      {TYPE_OPTIONS.map(({ value, label }) => (
+        <button
+          key={value}
+          type="button"
+          onClick={() => {
+            setActiveType(value);
+            setShowIds(false);
+            if (value === 'donut') setShowPct(false);
+          }}
+          className={`text-xs px-2 py-0.5 rounded border transition-colors ${
+            activeType === value && !showIds
+              ? 'bg-blue-50 border-blue-300 text-blue-700 font-medium'
+              : 'border-gray-200 text-gray-400 hover:text-gray-600 hover:border-gray-300'
+          }`}
+        >
+          {t(label)}
+        </button>
+      ))}
+      <button
+        type="button"
+        onClick={() => canNormalize && setShowPct((p) => !p)}
+        className={`text-xs px-2 py-0.5 rounded border transition-colors ${
+          !canNormalize
+            ? 'border-gray-100 text-gray-300 cursor-not-allowed'
+            : showPct
+            ? 'bg-blue-50 border-blue-300 text-blue-700 font-medium'
+            : 'border-gray-200 text-gray-400 hover:text-gray-600 hover:border-gray-300'
+        }`}
+      >
+        %
+      </button>
+      {hasIds && (
+        <button
+          type="button"
+          onClick={() => setShowIds((s) => !s)}
+          className={`text-xs px-2 py-0.5 rounded border transition-colors ${
+            showIds
+              ? 'bg-blue-50 border-blue-300 text-blue-700 font-medium'
+              : 'border-gray-200 text-gray-400 hover:text-gray-600 hover:border-gray-300'
+          }`}
+        >
+          {t('Incident IDs')}
+        </button>
+      )}
+    </div>
+  );
+
+  if (!counts || counts.size === 0) {
+    return (
+      <Card>
+        <div className="flex items-start justify-between gap-2">
+          <div>
+            <h3 className="text-base font-semibold">{t(title)}</h3>
+            {subtitle && <p className="text-xs text-gray-500">{t(subtitle)}</p>}
+            {incidentCount !== undefined && (
+              <p className="text-xs text-gray-400 mt-0.5">N = {incidentCount}</p>
+            )}
+          </div>
+          {typeToggle}
+        </div>
+        <div className="py-8 text-center text-sm text-gray-400">
+          <Trans>No data available for this analysis.</Trans>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      {/* Card header: title + type toggle buttons */}
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <h3 className="text-base font-semibold">{t(title)}</h3>
+          {subtitle && <p className="text-xs text-gray-500">{t(subtitle)}</p>}
+          {incidentCount !== undefined && (
+            <p className="text-xs text-gray-400 mt-0.5">N = {incidentCount}</p>
+          )}
+        </div>
+        {typeToggle}
+      </div>
+
+      {showIds ? (
+        <IncidentListBody entries={sortedEntries} incidentIdsByValue={incidentIdsByValue} t={t} />
+      ) : activeType === 'donut' ? (
+        <DonutChartBody entries={sortedEntries} t={t} />
+      ) : (
+        <BarLineChartBody
+          entries={sortedEntries}
+          t={t}
+          activeType={activeType}
+          showPct={showPct}
+          denominator={incidentCount}
+          sortBy={sortBy}
+        />
+      )}
+    </Card>
+  );
+}
+
+// ---- Incident list body ----------------------------------------------------
+
+// Renders a wrapped row of links to each incident's /cite page. Shared by the
+// guided/ad-hoc ChartCard list view and the Custom Explorer's cross list.
+export function IncidentLinks({ ids }) {
+  if (!ids || ids.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {ids.map((id) => (
+        <a
+          key={id}
+          href={`/cite/${id}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block text-xs px-1.5 py-0.5 rounded border border-gray-200 text-blue-600 hover:bg-blue-50 hover:border-blue-300 transition-colors"
+        >
+          #{id}
+        </a>
+      ))}
+    </div>
+  );
+}
+
+// Lists the incidents behind each charted value, in the same order/limit the
+// chart uses, with a color swatch matching the chart legend.
+function IncidentListBody({ entries, incidentIdsByValue, t }) {
+  return (
+    <div className="flex flex-col gap-3 mt-1 max-h-[420px] overflow-y-auto pr-1">
+      {entries.map(([label], i) => {
+        const ids = (incidentIdsByValue && incidentIdsByValue.get(label)) || [];
+
+        return (
+          <div key={label} className="flex flex-col gap-1">
+            <div className="flex items-center gap-1.5 text-sm font-medium text-gray-700">
+              <span
+                className="inline-block w-3 h-3 rounded-sm flex-shrink-0"
+                style={{ backgroundColor: COLORS[i % COLORS.length] }}
+              />
+              <span>{label}</span>
+              <span className="text-xs font-normal text-gray-400">
+                ({ids.length} {t('incidents')})
+              </span>
+            </div>
+            <IncidentLinks ids={ids} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---- Bar / Line chart body -------------------------------------------------
+
+function BarLineChartBody({ entries, t, activeType, showPct, denominator, sortBy = 'count' }) {
+  // Time-ordered data (years, dates) gets X-axis labels instead of per-bar colors.
+  const isTimeSeries = sortBy === 'key';
+
+  // 1-2 bars get a fixed narrow chart width (bar only — line is always fluid).
+  const isFewBars = !isTimeSeries && activeType === 'bar' && entries.length <= 2;
+
+  const options = useMemo(() => {
+    const labels = entries.map(([label]) => label);
+
+    const rawValues = entries.map(([, count]) => count);
+
+    const values =
+      showPct && denominator > 0
+        ? rawValues.map((n) => +((n / denominator) * 100).toFixed(1))
+        : rawValues;
+
+    const chartTypeFunc = activeType === 'line' ? line() : bar();
+
+    const yLabel = showPct ? t('% of classified incidents') : t('Count');
+
+    const tickFormat = showPct ? (x) => `${x}%` : (x) => (x === Math.floor(x) ? x : '');
+
+    return {
+      data: {
+        x: 'x',
+        columns: [
+          ['x', ...labels],
+          ['Count', ...values],
+        ],
+        type: chartTypeFunc,
+        // Time series: single uniform color so the X-axis labels do the work.
+        // Other charts: per-index colors matched to the custom legend below.
+        color: isTimeSeries
+          ? () => COLORS[0]
+          : (defaultColor, d) => {
+              if (d && typeof d.index === 'number') return COLORS[d.index % COLORS.length];
+              return defaultColor;
+            },
+        names: { Count: '' },
+      },
+      axis: {
+        x: {
+          type: 'category',
+          // Time series shows tick labels on the X axis; other charts hide them
+          // and rely on the color legend rendered below the chart instead.
+          show: isTimeSeries,
+          ...(isTimeSeries && {
+            tick: {
+              rotate: entries.length > 10 ? -30 : 0,
+              multiline: false,
+            },
+            height: entries.length > 10 ? 60 : 40,
+          }),
+        },
+        y: {
+          label: { text: yLabel, position: 'outer-middle' },
+          tick: { format: tickFormat },
+        },
+      },
+      // bar config is ignored by Billboard when chart type is line
+      bar: {
+        width: isFewBars
+          ? 120
+          : {
+              ratio: Math.max(0.45, Math.min(0.85, 0.37 + entries.length * 0.04)),
+              max: Math.max(80, Math.min(160, 280 / entries.length)),
+            },
+      },
+      grid: { y: { show: false } },
+      legend: { show: false },
+      tooltip: {
+        grouped: false,
+        format: {
+          title: (x) => labels[x] || '',
+          value: (value) => (showPct ? `${value}%` : value),
+        },
+      },
+      size: isFewBars
+        ? { height: 390, width: entries.length * 180 + 80 }
+        : { height: Math.max(390, 340 + Math.ceil(entries.length / 3) * 24) },
+      resize: { auto: !isFewBars },
+    };
+  }, [entries, t, activeType, isFewBars, isTimeSeries, showPct, denominator]);
+
+  return (
+    <>
+      <div
+        className={`[&_.bb-ygrid-line>line]:stroke-gray-300 [&_.bb-ygrid-line>line]:stroke-1 [&_.bb-line]:fill-none ${
+          isTimeSeries
+            ? '[&_svg]:overflow-visible'
+            : isFewBars
+            ? 'w-fit overflow-x-auto'
+            : 'overflow-hidden'
+        }`}
+      >
+        <BillboardChart options={options} chartKey={`${activeType}-${showPct}`} />
+      </div>
+      {/* Legend: only for non-time-series charts. Time-series charts use X-axis labels instead. */}
+      {!isTimeSeries && (
+        <div className="flex flex-wrap gap-x-4 gap-y-1 mt-1 justify-center">
+          {entries.map(([label], i) => (
+            <div key={label} className="flex items-center gap-1 text-xs text-gray-600">
+              <span
+                className="inline-block w-3 h-3 rounded-sm flex-shrink-0"
+                style={{ backgroundColor: COLORS[i % COLORS.length] }}
+              />
+              {label}
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}
+
+// ---- Donut chart body ------------------------------------------------------
+
+function DonutChartBody({ entries, t }) {
+  const options = useMemo(() => {
+    const columns = entries.map(([label, count]) => [label, count]);
+
+    const colors = {};
+
+    entries.forEach(([label], i) => {
+      colors[label] = COLORS[i % COLORS.length];
+    });
+
+    const names = columns.reduce((obj, [key]) => {
+      obj[key] = t(key);
+      return obj;
+    }, {});
+
+    return {
+      data: {
+        columns,
+        type: donut(),
+        names,
+        colors,
+      },
+      donut: {
+        title: '',
+        label: { show: false },
+      },
+      legend: {
+        show: true,
+        position: 'bottom',
+      },
+      tooltip: {
+        contents: (d) => {
+          if (!d || !d[0]) return '';
+
+          const { id, ratio } = d[0];
+
+          const name = names[id] || id;
+
+          const pct = (ratio * 100).toFixed(1);
+
+          const bg = colors[id] || '#3b82f6';
+
+          return (
+            '<div style="background:white;border:1px solid #d1d5db;border-radius:6px;' +
+            'padding:6px 12px;font-size:13px;box-shadow:0 1px 4px rgba(0,0,0,0.1);' +
+            'display:flex;align-items:center;gap:8px;">' +
+            `<span style="width:10px;height:10px;border-radius:2px;background:${bg};` +
+            'flex-shrink:0;display:inline-block;"></span>' +
+            `<span>${name} <strong>${pct}%</strong></span>` +
+            '</div>'
+          );
+        },
+      },
+      size: { height: 300 },
+      resize: { auto: true },
+    };
+  }, [entries, t]);
+
+  return <BillboardChart options={options} chartKey={`donut-${entries.length}`} />;
+}

--- a/site/gatsby-site/src/components/visualizations/CrossTaxonomyChart.js
+++ b/site/gatsby-site/src/components/visualizations/CrossTaxonomyChart.js
@@ -1,0 +1,281 @@
+import React, { useMemo, useState } from 'react';
+import { bar, line, scatter } from 'billboard.js';
+import { toBillboardColumns, toScatterData } from 'utils/crossTaxonomy';
+import { Trans, useTranslation } from 'react-i18next';
+import { BillboardChart, IncidentLinks } from 'components/visualizations/ChartCard';
+
+// Shared color palette: same order Billboard will use via data.colors
+const CHART_COLORS = [
+  '#1f77b4',
+  '#ff7f0e',
+  '#2ca02c',
+  '#d62728',
+  '#9467bd',
+  '#8c564b',
+  '#e377c2',
+  '#7f7f7f',
+  '#bcbd22',
+  '#17becf',
+  '#aec7e8',
+  '#ffbb78',
+  '#98df8a',
+  '#ff9896',
+  '#c5b0d5',
+  '#c49c94',
+  '#f7b6d2',
+  '#c7c7c7',
+  '#dbdb8d',
+  '#9edae5',
+];
+
+export default function CrossTaxonomyChart({ chartType, crossData, xLabel, yLabel }) {
+  const { t } = useTranslation();
+
+  // When true, the chart is replaced by a list of the contributing incidents,
+  // grouped by x-value then y-value.
+  const [showIds, setShowIds] = useState(false);
+
+  const options = useMemo(() => {
+    if (!crossData || crossData.xValues.length === 0) return null;
+
+    const base =
+      chartType === 'scatter'
+        ? buildScatterOptions(crossData, xLabel, yLabel, t)
+        : buildBarLineOptions(crossData, chartType, xLabel, yLabel, t);
+
+    return { ...base, size: { height: 450 }, resize: { auto: true } };
+  }, [crossData, chartType, xLabel, yLabel, t]);
+
+  if (!options) return null;
+
+  // Custom legend below the chart (billboard's own is hidden); scrolls when
+  // a field has many values.
+  const showCustomLegend = chartType !== 'scatter' && crossData.yValues;
+
+  const legendEntries = showCustomLegend
+    ? crossData.yValues.map((v, i) => ({ label: v, color: CHART_COLORS[i % CHART_COLORS.length] }))
+    : [];
+
+  const toggle = (
+    <div className="flex justify-end gap-1 mb-2">
+      <button
+        type="button"
+        onClick={() => setShowIds(false)}
+        className={`text-xs px-2 py-0.5 rounded border transition-colors ${
+          !showIds
+            ? 'bg-blue-50 border-blue-300 text-blue-700 font-medium'
+            : 'border-gray-200 text-gray-400 hover:text-gray-600 hover:border-gray-300'
+        }`}
+      >
+        {t('Chart')}
+      </button>
+      <button
+        type="button"
+        onClick={() => setShowIds(true)}
+        className={`text-xs px-2 py-0.5 rounded border transition-colors ${
+          showIds
+            ? 'bg-blue-50 border-blue-300 text-blue-700 font-medium'
+            : 'border-gray-200 text-gray-400 hover:text-gray-600 hover:border-gray-300'
+        }`}
+      >
+        {t('Incident IDs')}
+      </button>
+    </div>
+  );
+
+  if (showIds) {
+    return (
+      <div>
+        {toggle}
+        <CrossIncidentList crossData={crossData} xLabel={xLabel} yLabel={yLabel} t={t} />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {toggle}
+      <div className="[&_.bb-ygrid-line>line]:stroke-gray-300 [&_.bb-ygrid-line>line]:stroke-1 [&_.bb-line]:fill-none">
+        {/* options is memoized, so a new object means the data changed */}
+        <BillboardChart options={options} chartKey={options} />
+        {/* Color-coded legend below the chart, mirroring the guided-tab cards.
+            Scrolls when a field has many values so it never dominates the page. */}
+        {legendEntries.length > 0 && (
+          <div className="flex flex-wrap gap-x-4 gap-y-1 mt-2 px-8 justify-center max-h-40 overflow-y-auto">
+            {legendEntries.map(({ label, color }) => (
+              <div key={label} className="flex items-center gap-1 text-xs text-gray-600">
+                <span
+                  className="inline-block w-3 h-3 rounded-sm flex-shrink-0"
+                  style={{ backgroundColor: color }}
+                />
+                {label}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// Lists the incidents behind each plotted (x, y) cell, grouped under each
+// x-value. Each y-value series within an x-value gets a colored sub-heading
+// matching the chart legend, followed by links to the contributing incidents.
+function CrossIncidentList({ crossData, xLabel, yLabel, t }) {
+  const { pairs, xValues, yValues } = crossData;
+
+  const colorByY = {};
+
+  yValues.forEach((v, i) => {
+    colorByY[v] = CHART_COLORS[i % CHART_COLORS.length];
+  });
+
+  const pairsByX = new Map();
+
+  for (const p of pairs) {
+    if (!pairsByX.has(p.x)) pairsByX.set(p.x, []);
+    pairsByX.get(p.x).push(p);
+  }
+
+  return (
+    <div className="flex flex-col gap-4 max-h-[450px] overflow-y-auto pr-1">
+      {xValues
+        .filter((xv) => pairsByX.has(xv))
+        .map((xv) => (
+          <div key={xv} className="flex flex-col gap-2">
+            <div className="text-sm font-semibold text-gray-800">
+              {t(xLabel)}: {xv}
+            </div>
+            {pairsByX.get(xv).map((p) => (
+              <div key={p.y} className="ml-3 flex flex-col gap-1">
+                <div className="flex items-center gap-1.5 text-xs text-gray-600">
+                  <span
+                    className="inline-block w-3 h-3 rounded-sm flex-shrink-0"
+                    style={{ backgroundColor: colorByY[p.y] }}
+                  />
+                  <span className="font-medium">
+                    {t(yLabel)}: {p.y}
+                  </span>
+                  <span className="text-gray-400">
+                    ({p.ids.length} {p.ids.length === 1 ? t('incident') : t('incidents')})
+                  </span>
+                </div>
+                <IncidentLinks ids={p.ids} />
+              </div>
+            ))}
+          </div>
+        ))}
+      {pairs.length === 0 && (
+        <div className="text-sm text-gray-400 py-4 text-center">
+          <Trans>No incidents to list.</Trans>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Long category labels are shortened on the axis; the tooltip shows the full value.
+const truncateTick = (name) => (name.length > 22 ? `${name.slice(0, 21)}…` : name);
+
+function buildBarLineOptions(crossData, chartType, xLabel, yLabel, t) {
+  const columns = toBillboardColumns(crossData);
+
+  const chartTypeFunc = chartType === 'line' ? line() : bar();
+
+  const isStacked = chartType === 'histogram';
+
+  // Assign explicit colors so bars match the custom React legend rendered below the chart
+  const colorMap = {};
+
+  crossData.yValues.forEach((v, i) => {
+    colorMap[v] = CHART_COLORS[i % CHART_COLORS.length];
+  });
+
+  // Rotate ticks before they crowd; billboard's autorotate lets them touch.
+  // Positive rotation extends right, so clippath must stay off.
+  const rotateTicks =
+    crossData.xValues.length > 4 || crossData.xValues.some((v) => String(v).length > 14);
+
+  return {
+    data: {
+      x: 'x',
+      columns,
+      type: chartTypeFunc,
+      groups: isStacked ? [crossData.yValues] : [],
+      colors: colorMap,
+    },
+    axis: {
+      x: {
+        type: 'category',
+        label: { text: t(xLabel), position: 'outer-center' },
+        // Fixed heights: billboard's auto height clips the axis title with
+        // this font. 130 clears rotated 21-char ticks plus the title.
+        height: rotateTicks ? 130 : 60,
+        tick: rotateTicks
+          ? {
+              rotate: 30,
+              multiline: false,
+              culling: false,
+              clippath: false,
+              format: (i, name) => truncateTick(String(name)),
+            }
+          : { multiline: true },
+      },
+      y: {
+        label: { text: t('Count'), position: 'outer-middle' },
+      },
+    },
+    ...(rotateTicks && { padding: { right: 110 } }),
+    bar: {
+      width: { ratio: 0.7 },
+    },
+    grid: { y: { show: false } },
+    // Billboard's built-in legend is hidden: custom legend is rendered below the chart
+    legend: {
+      show: false,
+    },
+    tooltip: {
+      grouped: true,
+      format: {
+        // Full, untruncated category value in the tooltip title
+        title: (x) => crossData.xValues[x] || '',
+      },
+    },
+  };
+}
+
+function buildScatterOptions(crossData, xLabel, yLabel, t) {
+  const { xs, columns, xValues } = toScatterData(crossData);
+
+  return {
+    data: {
+      xs,
+      columns,
+      type: scatter(),
+    },
+    axis: {
+      x: {
+        label: { text: t(xLabel), position: 'outer-center' },
+        tick: { multiline: true },
+        height: 160,
+      },
+      y: {
+        label: { text: t('Count'), position: 'outer-middle' },
+        min: 0,
+        // min alone still pads below zero on a count axis; pin it.
+        padding: { bottom: 0 },
+      },
+    },
+    legend: {
+      show: crossData.yValues.length <= 20,
+    },
+    point: {
+      r: 5,
+    },
+    tooltip: {
+      format: {
+        title: (i) => xValues[Math.round(i)] || '',
+      },
+    },
+  };
+}

--- a/site/gatsby-site/src/components/visualizations/CrossTaxonomyChart.js
+++ b/site/gatsby-site/src/components/visualizations/CrossTaxonomyChart.js
@@ -1,0 +1,262 @@
+import React, { useMemo, useState } from 'react';
+import BillboardJS from '@billboard.js/react';
+import bb, { bar, line, scatter } from 'billboard.js';
+import { toBillboardColumns, toScatterData } from 'utils/crossTaxonomy';
+import { Trans, useTranslation } from 'react-i18next';
+import { IncidentLinks } from 'components/visualizations/ChartCard';
+
+// Shared color palette — same order Billboard will use via data.colors
+const CHART_COLORS = [
+  '#1f77b4',
+  '#ff7f0e',
+  '#2ca02c',
+  '#d62728',
+  '#9467bd',
+  '#8c564b',
+  '#e377c2',
+  '#7f7f7f',
+  '#bcbd22',
+  '#17becf',
+  '#aec7e8',
+  '#ffbb78',
+  '#98df8a',
+  '#ff9896',
+  '#c5b0d5',
+  '#c49c94',
+  '#f7b6d2',
+  '#c7c7c7',
+  '#dbdb8d',
+  '#9edae5',
+];
+
+export default function CrossTaxonomyChart({ chartType, crossData, xLabel, yLabel }) {
+  const { t } = useTranslation();
+
+  // When true, the chart is replaced by a list of the contributing incidents,
+  // grouped by x-value then y-value.
+  const [showIds, setShowIds] = useState(false);
+
+  const options = useMemo(() => {
+    if (!crossData || crossData.xValues.length === 0) return null;
+
+    if (chartType === 'scatter') {
+      return buildScatterOptions(crossData, xLabel, yLabel, t);
+    }
+    return buildBarLineOptions(crossData, chartType, xLabel, yLabel, t);
+  }, [crossData, chartType, xLabel, yLabel, t]);
+
+  if (!options) return null;
+
+  // Custom legend entries for bar/line — Billboard's built-in legend is hidden to
+  // avoid overlapping the x-axis tick labels at the bottom.
+  const showCustomLegend =
+    chartType !== 'scatter' && crossData.yValues && crossData.yValues.length <= 20;
+
+  const legendEntries = showCustomLegend
+    ? crossData.yValues.map((v, i) => ({ label: v, color: CHART_COLORS[i % CHART_COLORS.length] }))
+    : [];
+
+  const toggle = (
+    <div className="flex justify-end gap-1 mb-2">
+      <button
+        type="button"
+        onClick={() => setShowIds(false)}
+        className={`text-xs px-2 py-0.5 rounded border transition-colors ${
+          !showIds
+            ? 'bg-blue-50 border-blue-300 text-blue-700 font-medium'
+            : 'border-gray-200 text-gray-400 hover:text-gray-600 hover:border-gray-300'
+        }`}
+      >
+        {t('Chart')}
+      </button>
+      <button
+        type="button"
+        onClick={() => setShowIds(true)}
+        className={`text-xs px-2 py-0.5 rounded border transition-colors ${
+          showIds
+            ? 'bg-blue-50 border-blue-300 text-blue-700 font-medium'
+            : 'border-gray-200 text-gray-400 hover:text-gray-600 hover:border-gray-300'
+        }`}
+      >
+        {t('Incident IDs')}
+      </button>
+    </div>
+  );
+
+  if (showIds) {
+    return (
+      <div>
+        {toggle}
+        <CrossIncidentList crossData={crossData} xLabel={xLabel} yLabel={yLabel} t={t} />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {toggle}
+      <div className="[&_.bb-ygrid-line>line]:stroke-gray-300 [&_.bb-ygrid-line>line]:stroke-1 [&_.bb-line]:fill-none">
+        {/* Legend sits above the chart so it never overlaps the x-axis label or tick labels */}
+        {legendEntries.length > 0 && (
+          <div className="flex flex-wrap gap-x-4 gap-y-1 mb-2 px-8 justify-center">
+            {legendEntries.map(({ label, color }) => (
+              <div key={label} className="flex items-center gap-1 text-xs text-gray-600">
+                <span
+                  className="inline-block w-3 h-3 rounded-sm flex-shrink-0"
+                  style={{ backgroundColor: color }}
+                />
+                {label}
+              </div>
+            ))}
+          </div>
+        )}
+        <BillboardJS
+          key={`${chartType}-${xLabel}-${yLabel}-${crossData.xValues.length}`}
+          bb={bb}
+          options={{
+            ...options,
+            size: { height: 450 },
+            resize: { auto: true },
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+// Lists the incidents behind each plotted (x, y) cell, grouped under each
+// x-value. Each y-value series within an x-value gets a colored sub-heading
+// matching the chart legend, followed by links to the contributing incidents.
+function CrossIncidentList({ crossData, xLabel, yLabel, t }) {
+  const { pairs, xValues, yValues } = crossData;
+
+  const colorByY = {};
+
+  yValues.forEach((v, i) => {
+    colorByY[v] = CHART_COLORS[i % CHART_COLORS.length];
+  });
+
+  const pairsByX = new Map();
+
+  for (const p of pairs) {
+    if (!pairsByX.has(p.x)) pairsByX.set(p.x, []);
+    pairsByX.get(p.x).push(p);
+  }
+
+  return (
+    <div className="flex flex-col gap-4 max-h-[450px] overflow-y-auto pr-1">
+      {xValues
+        .filter((xv) => pairsByX.has(xv))
+        .map((xv) => (
+          <div key={xv} className="flex flex-col gap-2">
+            <div className="text-sm font-semibold text-gray-800">
+              {t(xLabel)}: {xv}
+            </div>
+            {pairsByX.get(xv).map((p) => (
+              <div key={p.y} className="ml-3 flex flex-col gap-1">
+                <div className="flex items-center gap-1.5 text-xs text-gray-600">
+                  <span
+                    className="inline-block w-3 h-3 rounded-sm flex-shrink-0"
+                    style={{ backgroundColor: colorByY[p.y] }}
+                  />
+                  <span className="font-medium">
+                    {t(yLabel)}: {p.y}
+                  </span>
+                  <span className="text-gray-400">
+                    ({p.ids.length} {t('incidents')})
+                  </span>
+                </div>
+                <IncidentLinks ids={p.ids} />
+              </div>
+            ))}
+          </div>
+        ))}
+      {pairs.length === 0 && (
+        <div className="text-sm text-gray-400 py-4 text-center">
+          <Trans>No incidents to list.</Trans>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function buildBarLineOptions(crossData, chartType, xLabel, yLabel, t) {
+  const columns = toBillboardColumns(crossData);
+
+  const chartTypeFunc = chartType === 'line' ? line() : bar();
+
+  const isStacked = chartType === 'histogram';
+
+  // Assign explicit colors so bars match the custom React legend rendered above the chart
+  const colorMap = {};
+
+  crossData.yValues.forEach((v, i) => {
+    colorMap[v] = CHART_COLORS[i % CHART_COLORS.length];
+  });
+
+  return {
+    data: {
+      x: 'x',
+      columns,
+      type: chartTypeFunc,
+      groups: isStacked ? [crossData.yValues] : [],
+      colors: colorMap,
+    },
+    axis: {
+      x: {
+        type: 'category',
+        label: { text: t(xLabel), position: 'outer-center' },
+        tick: { multiline: true },
+        height: 160,
+      },
+      y: {
+        label: { text: t('Count'), position: 'outer-middle' },
+      },
+    },
+    bar: {
+      width: { ratio: 0.7 },
+    },
+    grid: { y: { show: false } },
+    // Billboard's built-in legend is hidden — custom legend is rendered above the chart
+    legend: {
+      show: false,
+    },
+    tooltip: {
+      grouped: true,
+    },
+  };
+}
+
+function buildScatterOptions(crossData, xLabel, yLabel, t) {
+  const { xs, columns, xValues } = toScatterData(crossData);
+
+  return {
+    data: {
+      xs,
+      columns,
+      type: scatter(),
+    },
+    axis: {
+      x: {
+        label: { text: t(xLabel), position: 'outer-center' },
+        tick: { multiline: true },
+        height: 160,
+      },
+      y: {
+        label: { text: t('Count'), position: 'outer-middle' },
+        min: 0,
+      },
+    },
+    legend: {
+      show: crossData.yValues.length <= 20,
+    },
+    point: {
+      r: 5,
+    },
+    tooltip: {
+      format: {
+        title: (i) => xValues[Math.round(i)] || '',
+      },
+    },
+  };
+}

--- a/site/gatsby-site/src/components/visualizations/GuidedAnalysisTab.js
+++ b/site/gatsby-site/src/components/visualizations/GuidedAnalysisTab.js
@@ -1,0 +1,487 @@
+import React, { useMemo, useState, useEffect, useCallback } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+import { Card, Button } from 'flowbite-react';
+import ChartCard from './ChartCard';
+import SearchableSelect from './SearchableSelect';
+import {
+  buildFilteredCounts,
+  getFieldValues,
+  countFilteredIncidents,
+  getEntityValues,
+  countEntityIncidents,
+  buildEntityFilteredCounts,
+  parseKey,
+} from 'utils/crossTaxonomy';
+
+// ---------------------------------------------------------------------------
+// AdHocChartPanel: a user-added visualization below the hardcoded charts.
+// Mirrors the Custom Explorer's ExplorerPanel layout: a controls card (field to
+// visualize + optional filter) followed by the chart. Keeping the selectors at
+// the top of a tall card gives the dropdown room to open instead of being
+// clipped against the bottom of the page.
+// ---------------------------------------------------------------------------
+function AdHocChartPanel({
+  panel,
+  graphNumber,
+  onUpdate,
+  onRemove,
+  isEntitySource,
+  config,
+  selectedValue,
+  groupedClassifications,
+  allClassifications,
+  incidentEntityMap,
+  fieldSelectOptions,
+}) {
+  const { t } = useTranslation();
+
+  const field = useMemo(() => parseKey(panel.fieldKey), [panel.fieldKey]);
+
+  const filter = useMemo(() => parseKey(panel.filterKey), [panel.filterKey]);
+
+  const result = useMemo(() => {
+    if (!field.namespace || !field.field || !selectedValue) return null;
+
+    if (isEntitySource) {
+      return buildEntityFilteredCounts(
+        groupedClassifications,
+        incidentEntityMap,
+        config.selectorEntityField,
+        selectedValue,
+        field.namespace,
+        field.field,
+        filter.namespace || null,
+        filter.field || null,
+        panel.filterValue || null
+      );
+    }
+
+    return buildFilteredCounts(
+      groupedClassifications,
+      config.selectorField.namespace,
+      config.selectorField.short_name,
+      selectedValue,
+      field.namespace,
+      field.field,
+      filter.namespace || null,
+      filter.field || null,
+      panel.filterValue || null
+    );
+  }, [
+    field,
+    filter,
+    panel.filterValue,
+    selectedValue,
+    isEntitySource,
+    groupedClassifications,
+    incidentEntityMap,
+    config,
+  ]);
+
+  const filterOptions = useMemo(() => {
+    if (!filter.namespace || !filter.field) return [];
+    return getFieldValues(allClassifications, filter.namespace, filter.field).map(
+      ({ value }) => value
+    );
+  }, [allClassifications, filter]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Card>
+        {/* Remove button */}
+        <div className="flex justify-end -mt-1 -mb-2">
+          <button
+            type="button"
+            onClick={() => onRemove(panel.id)}
+            className="text-xs text-gray-400 hover:text-red-500 transition-colors"
+          >
+            <Trans>Remove visualization</Trans>
+          </button>
+        </div>
+
+        <div className="flex flex-wrap gap-4 items-end">
+          <div className="flex flex-col gap-1">
+            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+            <label className="text-sm font-medium text-gray-700">
+              <Trans>Field to Visualize</Trans>
+            </label>
+            <SearchableSelect
+              options={fieldSelectOptions}
+              value={panel.fieldKey}
+              onChange={(v) => onUpdate(panel.id, 'fieldKey', v)}
+              placeholder={`— ${t('Search or select a field')} —`}
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-4 items-end mt-4 pt-4 border-t border-gray-200">
+          <div className="text-sm font-medium text-gray-700 self-center">
+            <Trans>Optional Filter:</Trans>
+          </div>
+          <div className="flex flex-col gap-1">
+            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+            <label className="text-sm font-medium text-gray-700">
+              <Trans>Filter Field</Trans>
+            </label>
+            <SearchableSelect
+              options={fieldSelectOptions}
+              value={panel.filterKey}
+              onChange={(v) => {
+                onUpdate(panel.id, 'filterKey', v);
+                onUpdate(panel.id, 'filterValue', '');
+              }}
+              placeholder={`— ${t('Search or select')} —`}
+            />
+          </div>
+
+          {panel.filterKey && (
+            <div className="flex flex-col gap-1">
+              {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+              <label className="text-sm font-medium text-gray-700">
+                <Trans>Filter Value</Trans>
+              </label>
+              <SearchableSelect
+                options={filterOptions.map((v) => ({ value: v, label: v }))}
+                value={panel.filterValue}
+                onChange={(v) => onUpdate(panel.id, 'filterValue', v)}
+                placeholder={`— ${t('All')} —`}
+              />
+            </div>
+          )}
+
+          {(panel.filterKey || panel.filterValue) && (
+            <Button
+              color="gray"
+              size="sm"
+              onClick={() => {
+                onUpdate(panel.id, 'filterKey', '');
+                onUpdate(panel.id, 'filterValue', '');
+              }}
+            >
+              <Trans>Clear Filter</Trans>
+            </Button>
+          )}
+        </div>
+      </Card>
+
+      {panel.fieldKey ? (
+        <ChartCard
+          key={`${panel.fieldKey}-${panel.filterKey}-${panel.filterValue}`}
+          title={field.field}
+          subtitle={field.namespace}
+          counts={result ? result.counts : null}
+          chartType="bar"
+          incidentCount={result ? result.incidentCount : 0}
+          incidentIdsByValue={result ? result.incidentIdsByValue : null}
+        />
+      ) : (
+        <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center text-gray-500">
+          <Trans>Select a field above to generate visualization {{ number: graphNumber }}.</Trans>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * A generic guided analysis tab. Given a config object describing:
+ * - which field the user selects from (selectorField or entity-based)
+ * - which charts to generate (charts array)
+ *
+ * It renders a searchable combobox populated from real data, and a grid of
+ * charts filtered by the user's selection.
+ *
+ * Config shape (classification-based):
+ * {
+ *   selectorField: { namespace: string, short_name: string },
+ *   selectorLabel: string,
+ *   charts: [{ title, subtitle?, namespace, field, type }]
+ * }
+ *
+ * Config shape (entity-based: for By Developer / By Deployer):
+ * {
+ *   selectorSource: 'entity',
+ *   selectorEntityField: 'developers' | 'deployers' | 'harmedParties',
+ *   selectorLabel: string,
+ *   charts: [{ title, subtitle?, namespace, field, type }]
+ * }
+ *
+ * Config shape (mode toggle: for "Who It Affected"):
+ * {
+ *   selectorLabel: string,
+ *   modes: [{ modeLabel, ...selector fields (either shape above), charts? }],
+ *   charts: [...]   // default lineup; a mode may override with its own charts
+ * }
+ * The active mode is merged over the base config to form the effective config used by
+ * every data hook, so each mode behaves exactly like a standalone classification/entity tab.
+ */
+export default function GuidedAnalysisTab({
+  config,
+  selectedValue,
+  onSelectValue,
+  activeModeIdx = 0,
+  onSelectMode = () => {},
+  groupedClassifications,
+  allClassifications,
+  incidentEntityMap,
+  totalIncidents,
+  fieldSelectOptions,
+}) {
+  const { t } = useTranslation();
+
+  // A mode (if the tab defines any) is merged over the base config, so each
+  // mode behaves like a standalone tab config.
+  const modes = config.modes;
+
+  // Mode index comes from the URL; guard against out-of-range values.
+  const modeIdx = modes && activeModeIdx >= 0 && activeModeIdx < modes.length ? activeModeIdx : 0;
+
+  const effectiveConfig = useMemo(
+    () => (modes ? { ...config, ...modes[modeIdx] } : config),
+    [config, modes, modeIdx]
+  );
+
+  const isEntitySource = effectiveConfig.selectorSource === 'entity';
+
+  // Ad-hoc visualizations added by the user beyond the hardcoded config.charts.
+  // Each panel: { id, fieldKey, filterKey, filterValue }. The data for each panel
+  // is computed inside AdHocChartPanel so changing its field/filter only re-renders
+  // that one panel.
+  const [adHocCharts, setAdHocCharts] = useState([]);
+
+  // Clear ad-hoc visualizations when the selected value or active mode changes
+  useEffect(() => {
+    setAdHocCharts([]);
+  }, [selectedValue, config, modeIdx]);
+
+  // Get available values for the selector dropdown, sorted by frequency
+  const selectorOptions = useMemo(() => {
+    if (isEntitySource) {
+      return getEntityValues(incidentEntityMap, effectiveConfig.selectorEntityField);
+    }
+
+    return getFieldValues(
+      allClassifications,
+      effectiveConfig.selectorField.namespace,
+      effectiveConfig.selectorField.short_name
+    );
+  }, [allClassifications, incidentEntityMap, effectiveConfig, isEntitySource]);
+
+  // Count total incidents for the selected value
+  const incidentCount = useMemo(() => {
+    if (!selectedValue) return 0;
+    if (isEntitySource) {
+      return countEntityIncidents(
+        incidentEntityMap,
+        effectiveConfig.selectorEntityField,
+        selectedValue
+      );
+    }
+
+    return countFilteredIncidents(
+      groupedClassifications,
+      effectiveConfig.selectorField.namespace,
+      effectiveConfig.selectorField.short_name,
+      selectedValue
+    );
+  }, [groupedClassifications, incidentEntityMap, effectiveConfig, selectedValue, isEntitySource]);
+
+  // Build chart data for each chart in the config
+  const chartData = useMemo(() => {
+    if (!selectedValue) return [];
+
+    return effectiveConfig.charts.map((chart) => {
+      let result;
+
+      if (isEntitySource) {
+        result = buildEntityFilteredCounts(
+          groupedClassifications,
+          incidentEntityMap,
+          effectiveConfig.selectorEntityField,
+          selectedValue,
+          chart.namespace,
+          chart.field
+        );
+      } else {
+        result = buildFilteredCounts(
+          groupedClassifications,
+          effectiveConfig.selectorField.namespace,
+          effectiveConfig.selectorField.short_name,
+          selectedValue,
+          chart.namespace,
+          chart.field
+        );
+      }
+
+      return {
+        ...chart,
+        counts: result.counts,
+        incidentCount: result.incidentCount,
+        incidentIdsByValue: result.incidentIdsByValue,
+      };
+    });
+  }, [groupedClassifications, incidentEntityMap, effectiveConfig, selectedValue, isEntitySource]);
+
+  const addAdHocChart = useCallback(() => {
+    setAdHocCharts((prev) => [
+      ...prev,
+      { id: Date.now(), fieldKey: '', filterKey: '', filterValue: '' },
+    ]);
+  }, []);
+
+  const updateAdHocChart = useCallback((id, key, value) => {
+    setAdHocCharts((prev) => prev.map((c) => (c.id === id ? { ...c, [key]: value } : c)));
+  }, []);
+
+  const removeAdHocChart = useCallback((id) => {
+    setAdHocCharts((prev) => prev.filter((c) => c.id !== id));
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Mode toggle: only on tabs that define multiple selector modes */}
+      {modes && (
+        <div className="flex flex-col gap-1">
+          <span className="text-sm font-medium text-gray-700">
+            <Trans>View by</Trans>
+          </span>
+          <div className="inline-flex rounded-lg border border-gray-200 p-0.5 self-start">
+            {modes.map((mode, i) => (
+              <button
+                key={mode.modeLabel}
+                type="button"
+                onClick={() => onSelectMode(i)}
+                className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                  modeIdx === i ? 'bg-blue-500 text-white' : 'text-gray-600 hover:text-gray-900'
+                }`}
+              >
+                {t(mode.modeLabel)}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Selector */}
+      <div className="flex flex-wrap items-end gap-4">
+        <div className="flex flex-col gap-1">
+          <label htmlFor="guided-selector" className="text-sm font-medium text-gray-700">
+            {t(effectiveConfig.selectorLabel)}
+          </label>
+          <SearchableSelect
+            id="guided-selector"
+            options={selectorOptions.map(({ value, count }) => ({
+              value,
+              label: value,
+              sublabel: `${count} ${count === 1 ? t('incident') : t('incidents')}`,
+            }))}
+            value={selectedValue}
+            onChange={onSelectValue}
+            placeholder={`— ${t('Search or select')} —`}
+          />
+        </div>
+      </div>
+
+      {/* Results */}
+      {selectedValue && (
+        <>
+          {/* Sample size header */}
+          <div className="text-sm text-gray-600">
+            <span className="font-semibold text-lg text-gray-900">N = {incidentCount}</span>{' '}
+            {isEntitySource ? (
+              <Trans>total incidents involving</Trans>
+            ) : (
+              <Trans>classified incidents involving</Trans>
+            )}{' '}
+            <span className="font-medium">&quot;{selectedValue}&quot;</span>
+            {!isEntitySource && totalIncidents > 0 && (
+              <span className="text-gray-400 ml-1">
+                (<Trans>out of {{ total: totalIncidents }} total in database</Trans>)
+              </span>
+            )}
+          </div>
+
+          {incidentCount < 3 && (
+            <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 text-yellow-800 text-sm">
+              <Trans>
+                Too few classified incidents ({{ incidents: incidentCount }}) to generate meaningful
+                visualizations. Try selecting a more commonly represented option.
+              </Trans>
+            </div>
+          )}
+
+          {incidentCount >= 3 && (
+            <>
+              {incidentCount < 10 && (
+                <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3 text-yellow-800 text-xs">
+                  <Trans>
+                    Small sample size ({{ incidents: incidentCount }} incidents). Results may not be
+                    representative.
+                  </Trans>
+                </div>
+              )}
+
+              {/* Chart grid: hardcoded config charts */}
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                {chartData.map((chart, i) => (
+                  <ChartCard
+                    key={`${selectedValue}-${i}`}
+                    title={chart.title}
+                    subtitle={chart.subtitle}
+                    counts={chart.counts}
+                    chartType={chart.type}
+                    incidentCount={chart.incidentCount}
+                    incidentIdsByValue={chart.incidentIdsByValue}
+                    sortBy={chart.sortBy || 'count'}
+                  />
+                ))}
+              </div>
+
+              {/* Ad-hoc visualizations added by the user, stacked full-width */}
+              {adHocCharts.map((panel, i) => (
+                <div key={panel.id} className="flex flex-col gap-0">
+                  {/* Divider connecting panels visually */}
+                  <div className="flex items-center gap-3 py-2">
+                    <div className="flex-1 border-t border-dashed border-gray-300" />
+                    <span className="text-xs text-gray-400 uppercase tracking-wide">
+                      <Trans>Visualization {{ number: i + 1 }}</Trans>
+                    </span>
+                    <div className="flex-1 border-t border-dashed border-gray-300" />
+                  </div>
+                  <AdHocChartPanel
+                    panel={panel}
+                    graphNumber={i + 1}
+                    onUpdate={updateAdHocChart}
+                    onRemove={removeAdHocChart}
+                    isEntitySource={isEntitySource}
+                    config={effectiveConfig}
+                    selectedValue={selectedValue}
+                    groupedClassifications={groupedClassifications}
+                    allClassifications={allClassifications}
+                    incidentEntityMap={incidentEntityMap}
+                    fieldSelectOptions={fieldSelectOptions}
+                  />
+                </div>
+              ))}
+
+              {/* Add a new visualization */}
+              {fieldSelectOptions && fieldSelectOptions.length > 0 && (
+                <div className="flex justify-center pt-2">
+                  <Button color="light" onClick={addAdHocChart}>
+                    + <Trans>New Visualization</Trans>
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </>
+      )}
+
+      {!selectedValue && (
+        <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center text-gray-500">
+          <Trans>Select an option above to generate visualizations.</Trans>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/site/gatsby-site/src/components/visualizations/GuidedAnalysisTab.js
+++ b/site/gatsby-site/src/components/visualizations/GuidedAnalysisTab.js
@@ -1,0 +1,499 @@
+import React, { useMemo, useState, useEffect, useCallback } from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+import { Card, Button } from 'flowbite-react';
+import ChartCard from './ChartCard';
+import SearchableSelect from './SearchableSelect';
+import {
+  buildFilteredCounts,
+  getFieldValues,
+  countFilteredIncidents,
+  getEntityValues,
+  countEntityIncidents,
+  buildEntityFilteredCounts,
+} from 'utils/crossTaxonomy';
+
+// Split "namespace::field" key into its parts (mirrors parseKey in cross-taxonomy.js).
+function parseKey(key) {
+  if (!key) return { namespace: '', field: '' };
+  const [namespace, ...rest] = key.split('::');
+
+  return { namespace, field: rest.join('::') };
+}
+
+// ---------------------------------------------------------------------------
+// AdHocChartPanel — a user-added visualization below the hardcoded charts.
+// Mirrors the Custom Explorer's ExplorerPanel layout: a controls card (field to
+// visualize + optional filter) followed by the chart. Keeping the selectors at
+// the top of a tall card gives the dropdown room to open instead of being
+// clipped against the bottom of the page.
+// ---------------------------------------------------------------------------
+function AdHocChartPanel({
+  panel,
+  graphNumber,
+  onUpdate,
+  onRemove,
+  isEntitySource,
+  config,
+  selectedValue,
+  groupedClassifications,
+  allClassifications,
+  incidentEntityMap,
+  fieldSelectOptions,
+}) {
+  const { t } = useTranslation();
+
+  const field = useMemo(() => parseKey(panel.fieldKey), [panel.fieldKey]);
+
+  const filter = useMemo(() => parseKey(panel.filterKey), [panel.filterKey]);
+
+  const result = useMemo(() => {
+    if (!field.namespace || !field.field || !selectedValue) return null;
+
+    if (isEntitySource) {
+      return buildEntityFilteredCounts(
+        groupedClassifications,
+        incidentEntityMap,
+        config.selectorEntityField,
+        selectedValue,
+        field.namespace,
+        field.field,
+        filter.namespace || null,
+        filter.field || null,
+        panel.filterValue || null
+      );
+    }
+
+    return buildFilteredCounts(
+      groupedClassifications,
+      config.selectorField.namespace,
+      config.selectorField.short_name,
+      selectedValue,
+      field.namespace,
+      field.field,
+      filter.namespace || null,
+      filter.field || null,
+      panel.filterValue || null
+    );
+  }, [
+    field,
+    filter,
+    panel.filterValue,
+    selectedValue,
+    isEntitySource,
+    groupedClassifications,
+    incidentEntityMap,
+    config,
+  ]);
+
+  const filterOptions = useMemo(() => {
+    if (!filter.namespace || !filter.field) return [];
+    return getFieldValues(allClassifications, filter.namespace, filter.field).map(
+      ({ value }) => value
+    );
+  }, [allClassifications, filter]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Card>
+        {/* Remove button */}
+        <div className="flex justify-end -mt-1 -mb-2">
+          <button
+            type="button"
+            onClick={() => onRemove(panel.id)}
+            className="text-xs text-gray-400 hover:text-red-500 transition-colors"
+          >
+            <Trans>Remove visualization</Trans>
+          </button>
+        </div>
+
+        <div className="flex flex-wrap gap-4 items-end">
+          <div className="flex flex-col gap-1">
+            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+            <label className="text-sm font-medium text-gray-700">
+              <Trans>Field to Visualize</Trans>
+            </label>
+            <SearchableSelect
+              options={fieldSelectOptions}
+              value={panel.fieldKey}
+              onChange={(v) => onUpdate(panel.id, 'fieldKey', v)}
+              placeholder={`— ${t('Search or select a field')} —`}
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-4 items-end mt-4 pt-4 border-t border-gray-200">
+          <div className="text-sm font-medium text-gray-700 self-center">
+            <Trans>Optional Filter:</Trans>
+          </div>
+          <div className="flex flex-col gap-1">
+            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+            <label className="text-sm font-medium text-gray-700">
+              <Trans>Filter Field</Trans>
+            </label>
+            <SearchableSelect
+              options={fieldSelectOptions}
+              value={panel.filterKey}
+              onChange={(v) => {
+                onUpdate(panel.id, 'filterKey', v);
+                onUpdate(panel.id, 'filterValue', '');
+              }}
+              placeholder={`— ${t('Search or select')} —`}
+            />
+          </div>
+
+          {panel.filterKey && (
+            <div className="flex flex-col gap-1">
+              {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+              <label className="text-sm font-medium text-gray-700">
+                <Trans>Filter Value</Trans>
+              </label>
+              <SearchableSelect
+                options={filterOptions.map((v) => ({ value: v, label: v }))}
+                value={panel.filterValue}
+                onChange={(v) => onUpdate(panel.id, 'filterValue', v)}
+                placeholder={`— ${t('All')} —`}
+              />
+            </div>
+          )}
+
+          {(panel.filterKey || panel.filterValue) && (
+            <Button
+              color="gray"
+              size="sm"
+              onClick={() => {
+                onUpdate(panel.id, 'filterKey', '');
+                onUpdate(panel.id, 'filterValue', '');
+              }}
+            >
+              <Trans>Clear Filter</Trans>
+            </Button>
+          )}
+        </div>
+      </Card>
+
+      {panel.fieldKey ? (
+        <ChartCard
+          key={`${panel.fieldKey}-${panel.filterKey}-${panel.filterValue}`}
+          title={field.field}
+          subtitle={field.namespace}
+          counts={result ? result.counts : null}
+          chartType="bar"
+          incidentCount={result ? result.incidentCount : 0}
+          incidentIdsByValue={result ? result.incidentIdsByValue : null}
+        />
+      ) : (
+        <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center text-gray-500">
+          <Trans>Select a field above to generate visualization {{ number: graphNumber }}.</Trans>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * A generic guided analysis tab. Given a config object describing:
+ * - which field the user selects from (selectorField or entity-based)
+ * - which charts to generate (charts array)
+ *
+ * It renders a searchable combobox populated from real data, and a grid of
+ * charts filtered by the user's selection.
+ *
+ * Config shape (classification-based):
+ * {
+ *   selectorField: { namespace: string, short_name: string },
+ *   selectorLabel: string,
+ *   charts: [{ title, subtitle?, namespace, field, type }]
+ * }
+ *
+ * Config shape (entity-based — for By Developer / By Deployer):
+ * {
+ *   selectorSource: 'entity',
+ *   selectorEntityField: 'developers' | 'deployers' | 'harmedParties',
+ *   selectorLabel: string,
+ *   charts: [{ title, subtitle?, namespace, field, type }]
+ * }
+ *
+ * Config shape (mode toggle — for "Who It Affected"):
+ * {
+ *   selectorLabel: string,
+ *   modes: [{ modeLabel, ...selector fields (either shape above), charts? }],
+ *   charts: [...]   // default lineup; a mode may override with its own charts
+ * }
+ * The active mode is merged over the base config to form the effective config used by
+ * every data hook, so each mode behaves exactly like a standalone classification/entity tab.
+ */
+export default function GuidedAnalysisTab({
+  config,
+  selectedValue,
+  onSelectValue,
+  groupedClassifications,
+  allClassifications,
+  incidentEntityMap,
+  totalIncidents,
+  fieldSelectOptions,
+}) {
+  const { t } = useTranslation();
+
+  // Some tabs ("Who It Affected") offer a mode toggle that switches the selector between
+  // two data sources (e.g. demographic basis vs. named groups). Each entry in config.modes
+  // supplies the selector fields (and optionally charts) for one mode; merging it over the
+  // base config yields the effective config every data hook below reads from. Tabs without
+  // modes pass config through unchanged.
+  const modes = config.modes;
+
+  const [activeModeIdx, setActiveModeIdx] = useState(0);
+
+  const effectiveConfig = useMemo(
+    () => (modes ? { ...config, ...modes[activeModeIdx] } : config),
+    [config, modes, activeModeIdx]
+  );
+
+  const isEntitySource = effectiveConfig.selectorSource === 'entity';
+
+  // Ad-hoc visualizations added by the user beyond the hardcoded config.charts.
+  // Each panel: { id, fieldKey, filterKey, filterValue }. The data for each panel
+  // is computed inside AdHocChartPanel so changing its field/filter only re-renders
+  // that one panel.
+  const [adHocCharts, setAdHocCharts] = useState([]);
+
+  // Clear ad-hoc visualizations when the selected value or active mode changes
+  useEffect(() => {
+    setAdHocCharts([]);
+  }, [selectedValue, config, activeModeIdx]);
+
+  // Get available values for the selector dropdown, sorted by frequency
+  const selectorOptions = useMemo(() => {
+    if (isEntitySource) {
+      return getEntityValues(incidentEntityMap, effectiveConfig.selectorEntityField);
+    }
+
+    return getFieldValues(
+      allClassifications,
+      effectiveConfig.selectorField.namespace,
+      effectiveConfig.selectorField.short_name
+    );
+  }, [allClassifications, incidentEntityMap, effectiveConfig, isEntitySource]);
+
+  // Count total incidents for the selected value
+  const incidentCount = useMemo(() => {
+    if (!selectedValue) return 0;
+    if (isEntitySource) {
+      return countEntityIncidents(
+        incidentEntityMap,
+        effectiveConfig.selectorEntityField,
+        selectedValue
+      );
+    }
+
+    return countFilteredIncidents(
+      groupedClassifications,
+      effectiveConfig.selectorField.namespace,
+      effectiveConfig.selectorField.short_name,
+      selectedValue
+    );
+  }, [groupedClassifications, incidentEntityMap, effectiveConfig, selectedValue, isEntitySource]);
+
+  // Build chart data for each chart in the config
+  const chartData = useMemo(() => {
+    if (!selectedValue) return [];
+
+    return effectiveConfig.charts.map((chart) => {
+      let result;
+
+      if (isEntitySource) {
+        result = buildEntityFilteredCounts(
+          groupedClassifications,
+          incidentEntityMap,
+          effectiveConfig.selectorEntityField,
+          selectedValue,
+          chart.namespace,
+          chart.field
+        );
+      } else {
+        result = buildFilteredCounts(
+          groupedClassifications,
+          effectiveConfig.selectorField.namespace,
+          effectiveConfig.selectorField.short_name,
+          selectedValue,
+          chart.namespace,
+          chart.field
+        );
+      }
+
+      return {
+        ...chart,
+        counts: result.counts,
+        incidentCount: result.incidentCount,
+        incidentIdsByValue: result.incidentIdsByValue,
+      };
+    });
+  }, [groupedClassifications, incidentEntityMap, effectiveConfig, selectedValue, isEntitySource]);
+
+  const addAdHocChart = useCallback(() => {
+    setAdHocCharts((prev) => [
+      ...prev,
+      { id: Date.now(), fieldKey: '', filterKey: '', filterValue: '' },
+    ]);
+  }, []);
+
+  const updateAdHocChart = useCallback((id, key, value) => {
+    setAdHocCharts((prev) => prev.map((c) => (c.id === id ? { ...c, [key]: value } : c)));
+  }, []);
+
+  const removeAdHocChart = useCallback((id) => {
+    setAdHocCharts((prev) => prev.filter((c) => c.id !== id));
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Mode toggle — only on tabs that define multiple selector modes */}
+      {modes && (
+        <div className="flex flex-col gap-1">
+          <span className="text-sm font-medium text-gray-700">
+            <Trans>View by</Trans>
+          </span>
+          <div className="inline-flex rounded-lg border border-gray-200 p-0.5 self-start">
+            {modes.map((mode, i) => (
+              <button
+                key={mode.modeLabel}
+                type="button"
+                onClick={() => {
+                  setActiveModeIdx(i);
+                  onSelectValue('');
+                }}
+                className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                  activeModeIdx === i
+                    ? 'bg-blue-500 text-white'
+                    : 'text-gray-600 hover:text-gray-900'
+                }`}
+              >
+                {t(mode.modeLabel)}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Selector */}
+      <div className="flex flex-wrap items-end gap-4">
+        <div className="flex flex-col gap-1">
+          <label htmlFor="guided-selector" className="text-sm font-medium text-gray-700">
+            {t(effectiveConfig.selectorLabel)}
+          </label>
+          <SearchableSelect
+            id="guided-selector"
+            options={selectorOptions.map(({ value, count }) => ({
+              value,
+              label: value,
+              sublabel: `${count} ${t('incidents')}`,
+            }))}
+            value={selectedValue}
+            onChange={onSelectValue}
+            placeholder={`— ${t('Search or select')} —`}
+          />
+        </div>
+      </div>
+
+      {/* Results */}
+      {selectedValue && (
+        <>
+          {/* Sample size header */}
+          <div className="text-sm text-gray-600">
+            <span className="font-semibold text-lg text-gray-900">N = {incidentCount}</span>{' '}
+            {isEntitySource ? (
+              <Trans>total incidents involving</Trans>
+            ) : (
+              <Trans>classified incidents involving</Trans>
+            )}{' '}
+            <span className="font-medium">&quot;{selectedValue}&quot;</span>
+            {!isEntitySource && totalIncidents > 0 && (
+              <span className="text-gray-400 ml-1">
+                (<Trans>out of {{ total: totalIncidents }} total in database</Trans>)
+              </span>
+            )}
+          </div>
+
+          {incidentCount < 3 && (
+            <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 text-yellow-800 text-sm">
+              <Trans>
+                Too few classified incidents ({{ count: incidentCount }}) to generate meaningful
+                visualizations. Try selecting a more commonly represented option.
+              </Trans>
+            </div>
+          )}
+
+          {incidentCount >= 3 && (
+            <>
+              {incidentCount < 10 && (
+                <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3 text-yellow-800 text-xs">
+                  <Trans>
+                    Small sample size ({{ count: incidentCount }} incidents). Results may not be
+                    representative.
+                  </Trans>
+                </div>
+              )}
+
+              {/* Chart grid — hardcoded config charts */}
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                {chartData.map((chart, i) => (
+                  <ChartCard
+                    key={`${selectedValue}-${i}`}
+                    title={chart.title}
+                    subtitle={chart.subtitle}
+                    counts={chart.counts}
+                    chartType={chart.type}
+                    incidentCount={chart.incidentCount}
+                    incidentIdsByValue={chart.incidentIdsByValue}
+                    sortBy={chart.sortBy || 'count'}
+                  />
+                ))}
+              </div>
+
+              {/* Ad-hoc visualizations added by the user, stacked full-width */}
+              {adHocCharts.map((panel, i) => (
+                <div key={panel.id} className="flex flex-col gap-0">
+                  {/* Divider connecting panels visually */}
+                  <div className="flex items-center gap-3 py-2">
+                    <div className="flex-1 border-t border-dashed border-gray-300" />
+                    <span className="text-xs text-gray-400 uppercase tracking-wide">
+                      <Trans>Visualization {{ number: i + 1 }}</Trans>
+                    </span>
+                    <div className="flex-1 border-t border-dashed border-gray-300" />
+                  </div>
+                  <AdHocChartPanel
+                    panel={panel}
+                    graphNumber={i + 1}
+                    onUpdate={updateAdHocChart}
+                    onRemove={removeAdHocChart}
+                    isEntitySource={isEntitySource}
+                    config={effectiveConfig}
+                    selectedValue={selectedValue}
+                    groupedClassifications={groupedClassifications}
+                    allClassifications={allClassifications}
+                    incidentEntityMap={incidentEntityMap}
+                    fieldSelectOptions={fieldSelectOptions}
+                  />
+                </div>
+              ))}
+
+              {/* Add a new visualization */}
+              {fieldSelectOptions && fieldSelectOptions.length > 0 && (
+                <div className="flex justify-center pt-2">
+                  <Button color="light" onClick={addAdHocChart}>
+                    + <Trans>New Visualization</Trans>
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </>
+      )}
+
+      {!selectedValue && (
+        <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center text-gray-500">
+          <Trans>Select an option above to generate visualizations.</Trans>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/site/gatsby-site/src/components/visualizations/SearchableSelect.js
+++ b/site/gatsby-site/src/components/visualizations/SearchableSelect.js
@@ -1,0 +1,238 @@
+import React, { useMemo, useState, useRef, useEffect } from 'react';
+import { Trans } from 'react-i18next';
+
+/**
+ * Searchable combobox that replaces a plain <select>.
+ *
+ * Props:
+ *   id          – HTML id for the <input> (links to a <label>)
+ *   options     – [{ value, label, sublabel? }]
+ *                   value    – the stored value passed to onChange
+ *                   label    – text shown in the input and list
+ *                   sublabel – optional secondary text (right-aligned, gray)
+ *   value       – currently selected value
+ *   onChange    – called with the new value string
+ *   placeholder – placeholder text when nothing is selected
+ *
+ * Behaviour:
+ *   - Typing filters the list in real time (matches label OR sublabel).
+ *   - Enter selects the top filtered match.
+ *   - Escape closes without changing selection.
+ *   - × button clears the current selection.
+ *   - Click outside closes the dropdown.
+ */
+export default function SearchableSelect({ id, options, value, onChange, placeholder }) {
+  const [query, setQuery] = useState('');
+
+  const [isOpen, setIsOpen] = useState(false);
+
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+
+  const containerRef = useRef(null);
+
+  const listRef = useRef(null);
+
+  const inputRef = useRef(null);
+
+  // Derived from the id prop; useId produces different values on the server
+  // and client here and breaks hydration.
+  const listboxId = id ? `${id}-listbox` : undefined;
+
+  // Forward wheel events from the input to the list so trackpad scroll works while typing
+  useEffect(() => {
+    if (!isOpen || !inputRef.current || !listRef.current) return;
+    const input = inputRef.current;
+
+    const list = listRef.current;
+
+    function handleWheel(e) {
+      e.preventDefault();
+      list.scrollTop += e.deltaY;
+    }
+    input.addEventListener('wheel', handleWheel, { passive: false });
+    return () => input.removeEventListener('wheel', handleWheel);
+  }, [isOpen]);
+
+  const filtered = useMemo(() => {
+    if (!query) return options;
+    const lower = query.toLowerCase();
+
+    return options.filter(
+      (o) => o.label.toLowerCase().includes(lower) || o.sublabel?.toLowerCase().includes(lower)
+    );
+  }, [options, query]);
+
+  // Reset highlight when filtered results change
+  useEffect(() => {
+    setHighlightedIndex(-1);
+  }, [query]);
+
+  // Scroll highlighted item into view within the list (never the page)
+  useEffect(() => {
+    if (highlightedIndex >= 0 && listRef.current) {
+      const list = listRef.current;
+
+      const item = list.children[highlightedIndex];
+
+      if (item) {
+        const itemBottom = item.offsetTop + item.offsetHeight;
+
+        const listBottom = list.scrollTop + list.clientHeight;
+
+        if (itemBottom > listBottom) {
+          list.scrollTop = itemBottom - list.clientHeight;
+        } else if (item.offsetTop < list.scrollTop) {
+          list.scrollTop = item.offsetTop;
+        }
+      }
+    }
+  }, [highlightedIndex]);
+
+  function open() {
+    setQuery('');
+    setHighlightedIndex(-1);
+    setIsOpen(true);
+  }
+
+  function close() {
+    setIsOpen(false);
+    setQuery('');
+    setHighlightedIndex(-1);
+  }
+
+  function select(v) {
+    onChange(v);
+    close();
+  }
+
+  // Close on click outside
+  useEffect(() => {
+    function handler(e) {
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        close();
+      }
+    }
+
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  // When closed: show the label of the selected option.
+  // When open: show what the user is typing.
+  const selectedLabel = options.find((o) => o.value === value)?.label || value || '';
+
+  const inputDisplayValue = isOpen ? query : selectedLabel;
+
+  return (
+    <div ref={containerRef} className="relative min-w-[220px]">
+      <div className="relative">
+        <input
+          id={id}
+          type="text"
+          value={inputDisplayValue}
+          placeholder={placeholder}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            if (!isOpen) setIsOpen(true);
+          }}
+          onFocus={open}
+          // Reopen on click; a focused input gets no focus event.
+          onClick={() => {
+            if (!isOpen) open();
+          }}
+          role="combobox"
+          aria-expanded={isOpen}
+          aria-controls={listboxId}
+          aria-autocomplete="list"
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') {
+              close();
+              return;
+            }
+            if (e.key === 'ArrowDown') {
+              e.preventDefault();
+              if (!isOpen) {
+                open();
+                return;
+              }
+              setHighlightedIndex((prev) => Math.min(prev + 1, filtered.length - 1));
+            } else if (e.key === 'ArrowUp') {
+              e.preventDefault();
+              setHighlightedIndex((prev) => Math.max(prev - 1, 0));
+            } else if (e.key === 'Enter') {
+              e.preventDefault();
+              // Only while open, or Enter on a closed input would replace
+              // the selection.
+              if (isOpen && filtered.length > 0) {
+                select(filtered[highlightedIndex >= 0 ? highlightedIndex : 0].value);
+              }
+            }
+          }}
+          autoComplete="off"
+          ref={inputRef}
+          className="w-full border border-gray-300 rounded-lg px-3 py-2 pr-8 text-sm bg-white focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+        />
+        {value ? (
+          <button
+            type="button"
+            aria-label="Clear selection"
+            onMouseDown={(e) => {
+              e.preventDefault();
+              onChange('');
+              close();
+            }}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 text-xl leading-none"
+          >
+            ×
+          </button>
+        ) : (
+          <span className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none text-xs">
+            ▾
+          </span>
+        )}
+      </div>
+
+      {isOpen && (
+        <ul
+          ref={listRef}
+          id={listboxId}
+          role="listbox"
+          onMouseDown={(e) => e.stopPropagation()}
+          style={{ maxHeight: '16rem', overflowY: 'scroll' }}
+          className="absolute z-50 w-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg overscroll-contain [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-gray-100 [&::-webkit-scrollbar-thumb]:bg-gray-300 [&::-webkit-scrollbar-thumb]:rounded-full hover:[&::-webkit-scrollbar-thumb]:bg-gray-400"
+        >
+          {filtered.length === 0 ? (
+            <li role="option" aria-selected={false} className="px-3 py-2 text-sm text-gray-400">
+              <Trans>No matches</Trans>
+            </li>
+          ) : (
+            filtered.map((opt, index) => (
+              <li
+                key={opt.value}
+                role="option"
+                aria-selected={opt.value === value}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  select(opt.value);
+                }}
+                onMouseEnter={() => setHighlightedIndex(index)}
+                className={`px-3 py-2 text-sm cursor-pointer flex justify-between items-center gap-2 ${
+                  opt.value === value
+                    ? 'bg-blue-50 text-blue-700 font-medium'
+                    : index === highlightedIndex
+                    ? 'bg-gray-100'
+                    : 'hover:bg-gray-50'
+                }`}
+              >
+                <span>{opt.label}</span>
+                {opt.sublabel && (
+                  <span className="text-xs text-gray-400 shrink-0">{opt.sublabel}</span>
+                )}
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/site/gatsby-site/src/components/visualizations/SearchableSelect.js
+++ b/site/gatsby-site/src/components/visualizations/SearchableSelect.js
@@ -1,0 +1,221 @@
+import React, { useMemo, useState, useRef, useEffect } from 'react';
+import { Trans } from 'react-i18next';
+
+/**
+ * Searchable combobox that replaces a plain <select>.
+ *
+ * Props:
+ *   id          – HTML id for the <input> (links to a <label>)
+ *   options     – [{ value, label, sublabel? }]
+ *                   value    – the stored value passed to onChange
+ *                   label    – text shown in the input and list
+ *                   sublabel – optional secondary text (right-aligned, gray)
+ *   value       – currently selected value
+ *   onChange    – called with the new value string
+ *   placeholder – placeholder text when nothing is selected
+ *
+ * Behaviour:
+ *   - Typing filters the list in real time (matches label OR sublabel).
+ *   - Enter selects the top filtered match.
+ *   - Escape closes without changing selection.
+ *   - × button clears the current selection.
+ *   - Click outside closes the dropdown.
+ */
+export default function SearchableSelect({ id, options, value, onChange, placeholder }) {
+  const [query, setQuery] = useState('');
+
+  const [isOpen, setIsOpen] = useState(false);
+
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+
+  const containerRef = useRef(null);
+
+  const listRef = useRef(null);
+
+  const inputRef = useRef(null);
+
+  // Forward wheel events from the input to the list so trackpad scroll works while typing
+  useEffect(() => {
+    if (!isOpen || !inputRef.current || !listRef.current) return;
+    const input = inputRef.current;
+
+    const list = listRef.current;
+
+    function handleWheel(e) {
+      e.preventDefault();
+      list.scrollTop += e.deltaY;
+    }
+    input.addEventListener('wheel', handleWheel, { passive: false });
+    return () => input.removeEventListener('wheel', handleWheel);
+  }, [isOpen]);
+
+  const filtered = useMemo(() => {
+    if (!query) return options;
+    const lower = query.toLowerCase();
+
+    return options.filter(
+      (o) => o.label.toLowerCase().includes(lower) || o.sublabel?.toLowerCase().includes(lower)
+    );
+  }, [options, query]);
+
+  // Reset highlight when filtered results change
+  useEffect(() => {
+    setHighlightedIndex(-1);
+  }, [query]);
+
+  // Scroll highlighted item into view within the list (never the page)
+  useEffect(() => {
+    if (highlightedIndex >= 0 && listRef.current) {
+      const list = listRef.current;
+
+      const item = list.children[highlightedIndex];
+
+      if (item) {
+        const itemBottom = item.offsetTop + item.offsetHeight;
+
+        const listBottom = list.scrollTop + list.clientHeight;
+
+        if (itemBottom > listBottom) {
+          list.scrollTop = itemBottom - list.clientHeight;
+        } else if (item.offsetTop < list.scrollTop) {
+          list.scrollTop = item.offsetTop;
+        }
+      }
+    }
+  }, [highlightedIndex]);
+
+  function open() {
+    setQuery('');
+    setHighlightedIndex(-1);
+    setIsOpen(true);
+  }
+
+  function close() {
+    setIsOpen(false);
+    setQuery('');
+    setHighlightedIndex(-1);
+  }
+
+  function select(v) {
+    onChange(v);
+    close();
+  }
+
+  // Close on click outside
+  useEffect(() => {
+    function handler(e) {
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        close();
+      }
+    }
+
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  // When closed: show the label of the selected option.
+  // When open: show what the user is typing.
+  const selectedLabel = options.find((o) => o.value === value)?.label || value || '';
+
+  const inputDisplayValue = isOpen ? query : selectedLabel;
+
+  return (
+    <div ref={containerRef} className="relative min-w-[220px]">
+      <div className="relative">
+        <input
+          id={id}
+          type="text"
+          value={inputDisplayValue}
+          placeholder={placeholder}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            if (!isOpen) setIsOpen(true);
+          }}
+          onFocus={open}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') {
+              close();
+              return;
+            }
+            if (e.key === 'ArrowDown') {
+              e.preventDefault();
+              if (!isOpen) {
+                open();
+                return;
+              }
+              setHighlightedIndex((prev) => Math.min(prev + 1, filtered.length - 1));
+            } else if (e.key === 'ArrowUp') {
+              e.preventDefault();
+              setHighlightedIndex((prev) => Math.max(prev - 1, 0));
+            } else if (e.key === 'Enter' && filtered.length > 0) {
+              e.preventDefault();
+              select(filtered[highlightedIndex >= 0 ? highlightedIndex : 0].value);
+            }
+          }}
+          autoComplete="off"
+          ref={inputRef}
+          className="w-full border border-gray-300 rounded-lg px-3 py-2 pr-8 text-sm bg-white focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+        />
+        {value ? (
+          <button
+            type="button"
+            aria-label="Clear selection"
+            onMouseDown={(e) => {
+              e.preventDefault();
+              onChange('');
+              close();
+            }}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 text-xl leading-none"
+          >
+            ×
+          </button>
+        ) : (
+          <span className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none text-xs">
+            ▾
+          </span>
+        )}
+      </div>
+
+      {isOpen && (
+        <ul
+          ref={listRef}
+          role="listbox"
+          onMouseDown={(e) => e.stopPropagation()}
+          style={{ maxHeight: '16rem', overflowY: 'scroll' }}
+          className="absolute z-50 w-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg overscroll-contain [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-gray-100 [&::-webkit-scrollbar-thumb]:bg-gray-300 [&::-webkit-scrollbar-thumb]:rounded-full hover:[&::-webkit-scrollbar-thumb]:bg-gray-400"
+        >
+          {filtered.length === 0 ? (
+            <li role="option" aria-selected={false} className="px-3 py-2 text-sm text-gray-400">
+              <Trans>No matches</Trans>
+            </li>
+          ) : (
+            filtered.map((opt, index) => (
+              <li
+                key={opt.value}
+                role="option"
+                aria-selected={opt.value === value}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  select(opt.value);
+                }}
+                onMouseEnter={() => setHighlightedIndex(index)}
+                className={`px-3 py-2 text-sm cursor-pointer flex justify-between items-center gap-2 ${
+                  opt.value === value
+                    ? 'bg-blue-50 text-blue-700 font-medium'
+                    : index === highlightedIndex
+                    ? 'bg-gray-100'
+                    : 'hover:bg-gray-50'
+                }`}
+              >
+                <span>{opt.label}</span>
+                {opt.sublabel && (
+                  <span className="text-xs text-gray-400 shrink-0">{opt.sublabel}</span>
+                )}
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/site/gatsby-site/src/pages/apps/cross-taxonomy.js
+++ b/site/gatsby-site/src/pages/apps/cross-taxonomy.js
@@ -1,0 +1,937 @@
+import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { graphql } from 'gatsby';
+import { Button, Card, Badge } from 'flowbite-react';
+import SearchableSelect from 'components/visualizations/SearchableSelect';
+import { Trans, useTranslation } from 'react-i18next';
+import HeadContent from 'components/HeadContent';
+import CrossTaxonomyChart from 'components/visualizations/CrossTaxonomyChart';
+import GuidedAnalysisTab from 'components/visualizations/GuidedAnalysisTab';
+import {
+  groupClassificationsByIncident,
+  getAvailableFields,
+  buildCrossData,
+  buildIncidentEntityMap,
+  getFieldValues,
+  parseKey,
+} from 'utils/crossTaxonomy';
+import {
+  transformTaxas,
+  transformClassifications,
+  transformIncidents,
+  buildTimeTaxa,
+  buildTimeClassifications,
+} from 'utils/crossTaxonomyStatic';
+
+// The 8 query params this page reads/writes. All are plain strings; '' means absent.
+const QUERY_PARAM_KEYS = [
+  'tab',
+  'sel',
+  'mode',
+  'chartType',
+  'x',
+  'y',
+  'filterField',
+  'filterValue',
+];
+
+// URL param state via history.pushState instead of use-query-params.
+// The site's QueryParamProvider goes through navigate(), which makes Gatsby
+// re-fetch this page's (large) page-data.json on every param change. pushState
+// keeps the same URLs and history behavior without touching the router.
+function useUrlQueryState() {
+  // Empty on first render so SSR and client markup match.
+  const emptyQuery = useMemo(() => Object.fromEntries(QUERY_PARAM_KEYS.map((k) => [k, ''])), []);
+
+  const [query, setQueryState] = useState(emptyQuery);
+
+  // Latest value, readable synchronously from setQuery.
+  const queryRef = useRef(emptyQuery);
+
+  const readFromLocation = useCallback(() => {
+    const params = new URLSearchParams(window.location.search);
+
+    return Object.fromEntries(QUERY_PARAM_KEYS.map((k) => [k, params.get(k) || '']));
+  }, []);
+
+  useEffect(() => {
+    const apply = () => {
+      const q = readFromLocation();
+
+      queryRef.current = q;
+      setQueryState(q);
+    };
+
+    apply();
+
+    // Re-read on back/forward.
+    window.addEventListener('popstate', apply);
+    return () => window.removeEventListener('popstate', apply);
+  }, [readFromLocation]);
+
+  // Partial merge; empty values drop the key. Keys sorted for stable URLs.
+  const setQuery = useCallback((partial) => {
+    const next = { ...queryRef.current };
+
+    for (const [k, v] of Object.entries(partial)) next[k] = v || '';
+
+    const pairs = QUERY_PARAM_KEYS.filter((k) => next[k])
+      .sort()
+      .map((k) => `${encodeURIComponent(k)}=${encodeURIComponent(next[k])}`);
+
+    const url = window.location.pathname + (pairs.length ? `?${pairs.join('&')}` : '');
+
+    if (url !== window.location.pathname + window.location.search) {
+      window.history.pushState(window.history.state, '', url);
+    }
+
+    queryRef.current = next;
+    setQueryState(next);
+  }, []);
+
+  return [query, setQuery];
+}
+
+const TABS = [
+  { id: 'developer', label: 'By Developer' },
+  { id: 'deployer', label: 'By Deployer' },
+  { id: 'technology', label: 'By Technology' },
+  { id: 'affected', label: 'By Affected' },
+  { id: 'custom', label: 'Custom Explorer' },
+];
+
+// Shared chart lineup for the "By Affected" tab. Both the demographic-basis
+// (classification path) and named-groups (entity path) modes count these same target
+// fields, so the lineup is defined once and reused by each mode.
+const AFFECTED_CHARTS = [
+  {
+    title: 'Sector of Deployment',
+    subtitle: 'Sectors where this group was affected',
+    namespace: 'CSETv1',
+    field: 'Sector of Deployment',
+    type: 'bar',
+  },
+  {
+    title: 'AI Technologies Involved',
+    subtitle: 'Technologies used in incidents affecting this group',
+    namespace: 'GMF',
+    field: 'Known AI Technology',
+    type: 'bar',
+  },
+  {
+    title: 'Failure Modes',
+    subtitle: 'Technical failures causing harm to this group',
+    namespace: 'GMF',
+    field: 'Known AI Technical Failure',
+    type: 'bar',
+  },
+  {
+    title: 'Harm Domain',
+    subtitle: 'Categories of harm experienced',
+    namespace: 'CSETv1',
+    field: 'Harm Domain',
+    type: 'bar',
+  },
+  {
+    title: 'Risk Domains',
+    subtitle: 'Risk categories from the MIT AI Risk Repository',
+    namespace: 'MIT',
+    field: 'Risk Domain',
+    type: 'bar',
+  },
+  {
+    title: 'Intent',
+    subtitle: 'Whether harms to this group were intentional or unintentional',
+    namespace: 'MIT',
+    field: 'Intent',
+    type: 'donut',
+  },
+  {
+    title: 'Incidents Over Time',
+    subtitle: 'Number of incidents per year',
+    namespace: 'Time',
+    field: 'Year',
+    type: 'bar',
+    sortBy: 'key',
+  },
+];
+
+// In named-groups mode the demographic basis is no longer the selector, so surface it as
+// an extra chart to show which demographics were affected within the selected group.
+const AFFECTED_DEMOGRAPHICS_CHART = {
+  title: 'Affected Demographics',
+  subtitle: 'Demographic groups disproportionately affected within this group',
+  namespace: 'CSETv1',
+  field: 'Harm Distribution Basis',
+  type: 'bar',
+};
+
+const GUIDED_TAB_CONFIGS = {
+  developer: {
+    selectorSource: 'entity',
+    selectorEntityField: 'developers',
+    selectorLabel: 'Select a Developer',
+    charts: [
+      {
+        title: 'Sector of Deployment',
+        subtitle: "Sectors where this developer's AI is deployed",
+        namespace: 'CSETv1',
+        field: 'Sector of Deployment',
+        type: 'bar',
+      },
+      {
+        title: 'Failure Modes',
+        subtitle: 'Known technical failures in incidents',
+        namespace: 'GMF',
+        field: 'Known AI Technical Failure',
+        type: 'bar',
+      },
+      {
+        title: 'Affected Demographics',
+        subtitle: 'Demographic groups disproportionately affected',
+        namespace: 'CSETv1',
+        field: 'Harm Distribution Basis',
+        type: 'bar',
+      },
+      {
+        title: 'Intent',
+        subtitle: 'Whether harms were intentional or unintentional',
+        namespace: 'MIT',
+        field: 'Intent',
+        type: 'donut',
+      },
+      {
+        title: 'Risk Domains',
+        subtitle: 'Risk categories from the MIT AI Risk Repository',
+        namespace: 'MIT',
+        field: 'Risk Domain',
+        type: 'bar',
+      },
+      {
+        title: 'Incidents Over Time',
+        subtitle: 'Number of incidents per year',
+        namespace: 'Time',
+        field: 'Year',
+        type: 'bar',
+        sortBy: 'key',
+      },
+    ],
+  },
+  deployer: {
+    selectorSource: 'entity',
+    selectorEntityField: 'deployers',
+    selectorLabel: 'Select a Deployer',
+    charts: [
+      {
+        title: 'AI Technologies Used',
+        subtitle: 'Known AI technologies involved in incidents',
+        namespace: 'GMF',
+        field: 'Known AI Technology',
+        type: 'bar',
+      },
+      {
+        title: 'What Goes Wrong',
+        subtitle: 'Technical failures in incidents involving this deployer',
+        namespace: 'GMF',
+        field: 'Known AI Technical Failure',
+        type: 'bar',
+      },
+      {
+        title: 'Who Is Affected',
+        subtitle: 'Demographic groups impacted',
+        namespace: 'CSETv1',
+        field: 'Harm Distribution Basis',
+        type: 'bar',
+      },
+      {
+        title: 'Sector of Deployment',
+        subtitle: 'Deployment sectors where incidents occurred',
+        namespace: 'CSETv1',
+        field: 'Sector of Deployment',
+        type: 'bar',
+      },
+      {
+        title: 'Risk Domains',
+        subtitle: 'Risk categories from the MIT AI Risk Repository',
+        namespace: 'MIT',
+        field: 'Risk Domain',
+        type: 'bar',
+      },
+      {
+        title: 'Incidents Over Time',
+        subtitle: 'Number of incidents per year',
+        namespace: 'Time',
+        field: 'Year',
+        type: 'bar',
+        sortBy: 'key',
+      },
+    ],
+  },
+  // Single tab, two selector modes: CSETv1 demographic basis vs. named
+  // harmed-party entities. Shared chart lineup.
+  affected: {
+    selectorLabel: 'By Affected',
+    modes: [
+      {
+        modeLabel: 'Demographic basis',
+        selectorField: { namespace: 'CSETv1', short_name: 'Harm Distribution Basis' },
+        selectorLabel: 'Select a demographic basis',
+      },
+      {
+        modeLabel: 'Named groups',
+        selectorSource: 'entity',
+        selectorEntityField: 'harmedParties',
+        selectorLabel: 'Select a harmed party',
+        charts: [AFFECTED_DEMOGRAPHICS_CHART, ...AFFECTED_CHARTS],
+      },
+    ],
+    charts: AFFECTED_CHARTS,
+  },
+  technology: {
+    selectorField: { namespace: 'GMF', short_name: 'Known AI Technology' },
+    selectorLabel: 'Select a Technology',
+    charts: [
+      {
+        title: 'Deployment Sectors',
+        subtitle: 'Where this technology is deployed',
+        namespace: 'CSETv1',
+        field: 'Sector of Deployment',
+        type: 'bar',
+      },
+      {
+        title: 'Failure Modes',
+        subtitle: 'Technical failures associated with this technology',
+        namespace: 'GMF',
+        field: 'Known AI Technical Failure',
+        type: 'bar',
+      },
+      {
+        title: 'Who Is Harmed',
+        subtitle: 'Demographic groups affected',
+        namespace: 'CSETv1',
+        field: 'Harm Distribution Basis',
+        type: 'bar',
+      },
+      {
+        title: 'Risk Domains',
+        subtitle: 'Risk categories from the MIT AI Risk Repository',
+        namespace: 'MIT',
+        field: 'Risk Domain',
+        type: 'bar',
+      },
+      {
+        title: 'Harm Domain',
+        subtitle: 'Types of harm caused by this technology',
+        namespace: 'CSETv1',
+        field: 'Harm Domain',
+        type: 'bar',
+      },
+      {
+        title: 'Incidents Over Time',
+        subtitle: 'Number of incidents per year',
+        namespace: 'Time',
+        field: 'Year',
+        type: 'bar',
+        sortBy: 'key',
+      },
+    ],
+  },
+};
+
+const CHART_TYPES = [
+  { value: 'bar', label: 'Bar Chart' },
+  { value: 'histogram', label: 'Stacked Bar Chart' },
+  { value: 'line', label: 'Line Chart' },
+];
+
+// ---------------------------------------------------------------------------
+// ExplorerPanel: one self-contained controls + chart unit.
+// The first panel on the page wires its callbacks to URL params so the chart
+// state is shareable. Extra panels use plain local state passed in from the
+// parent via the same prop interface.
+// ---------------------------------------------------------------------------
+function ExplorerPanel({
+  chartType,
+  onChartTypeChange,
+  xAxisKey,
+  onXAxisChange,
+  yAxisKey,
+  onYAxisChange,
+  filterKey,
+  onFilterKeyChange,
+  filterValue,
+  onFilterValueChange,
+  onRemove,
+  groupedClassifications,
+  allClassifications,
+  fieldSelectOptions,
+  totalIncidents,
+}) {
+  const { t } = useTranslation();
+
+  // parseKey returns a new object each call; memoize so the crossData /
+  // filterOptions memos below keep stable deps.
+  const xAxis = useMemo(() => parseKey(xAxisKey), [xAxisKey]);
+
+  const yAxis = useMemo(() => parseKey(yAxisKey), [yAxisKey]);
+
+  const filter = useMemo(() => parseKey(filterKey), [filterKey]);
+
+  const crossData = useMemo(() => {
+    if (!xAxis.namespace || !yAxis.namespace) return null;
+    return buildCrossData(
+      groupedClassifications,
+      xAxis.namespace,
+      xAxis.field,
+      yAxis.namespace,
+      yAxis.field,
+      filter.namespace || null,
+      filter.field || null,
+      filterValue || null
+    );
+  }, [groupedClassifications, xAxis, yAxis, filter, filterValue]);
+
+  const filterOptions = useMemo(() => {
+    if (!filter.namespace || !filter.field) return [];
+    return getFieldValues(allClassifications, filter.namespace, filter.field).map(
+      ({ value }) => value
+    );
+  }, [allClassifications, filter]);
+
+  const handleXAxisChange = useCallback(
+    (v) => {
+      onXAxisChange(v);
+      if (parseKey(v).namespace === 'Time') onChartTypeChange('line');
+    },
+    [onXAxisChange, onChartTypeChange]
+  );
+
+  const renderFieldSelect = (value, onChange, label) => (
+    <div className="flex flex-col gap-1">
+      {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+      <label className="text-sm font-medium text-gray-700">{label}</label>
+      <SearchableSelect
+        options={fieldSelectOptions}
+        value={value}
+        onChange={onChange}
+        placeholder={`— ${t('Search or select')} —`}
+      />
+    </div>
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Card>
+        {/* Remove button: only shown on extra panels */}
+        {onRemove && (
+          <div className="flex justify-end -mt-1 -mb-2">
+            <button
+              type="button"
+              onClick={onRemove}
+              className="text-xs text-gray-400 hover:text-red-500 transition-colors"
+            >
+              <Trans>Remove graph</Trans>
+            </button>
+          </div>
+        )}
+
+        <div className="flex flex-wrap gap-4 items-end">
+          <div className="flex flex-col gap-1">
+            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+            <label className="text-sm font-medium text-gray-700">
+              <Trans>Chart Type</Trans>
+            </label>
+            <SearchableSelect
+              options={CHART_TYPES.map((ct) => ({ value: ct.value, label: t(ct.label) }))}
+              value={chartType}
+              onChange={onChartTypeChange}
+              placeholder={`— ${t('Select type')} —`}
+            />
+          </div>
+
+          {renderFieldSelect(xAxisKey, handleXAxisChange, t('X-Axis Field'))}
+          {renderFieldSelect(yAxisKey, onYAxisChange, t('Y-Axis Field'))}
+        </div>
+
+        <div className="flex flex-wrap gap-4 items-end mt-4 pt-4 border-t border-gray-200">
+          <div className="text-sm font-medium text-gray-700 self-center">
+            <Trans>Optional Filter:</Trans>
+          </div>
+          {renderFieldSelect(filterKey, onFilterKeyChange, t('Filter Field'))}
+
+          {filterKey && (
+            <div className="flex flex-col gap-1">
+              {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+              <label className="text-sm font-medium text-gray-700">
+                <Trans>Filter Value</Trans>
+              </label>
+              <SearchableSelect
+                options={filterOptions.map((v) => ({ value: v, label: v }))}
+                value={filterValue}
+                onChange={onFilterValueChange}
+                placeholder={`— ${t('All')} —`}
+              />
+            </div>
+          )}
+
+          {(filterKey || filterValue) && (
+            <Button
+              color="gray"
+              size="sm"
+              onClick={() => {
+                onFilterKeyChange('');
+                onFilterValueChange('');
+              }}
+            >
+              <Trans>Clear Filter</Trans>
+            </Button>
+          )}
+        </div>
+      </Card>
+
+      {crossData && (
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center gap-2 text-sm text-gray-600 flex-wrap">
+            <span className="font-semibold text-lg text-gray-900">
+              N = {crossData.incidentCount}
+            </span>
+            <Trans>incidents with data for both selected fields</Trans>
+            {totalIncidents > 0 && (
+              <span className="text-gray-400">
+                (<Trans>out of {{ total: totalIncidents }} total in database</Trans>)
+              </span>
+            )}
+            {filterValue && (
+              <Badge color="info">
+                {filter.field} = &quot;{filterValue}&quot;
+              </Badge>
+            )}
+          </div>
+
+          {crossData.incidentCount < 5 && (
+            <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 text-yellow-800 text-sm">
+              <Trans>
+                Warning: Only {{ incidents: crossData.incidentCount }} incidents have
+                classifications for both selected fields. Results may not be representative.
+              </Trans>
+            </div>
+          )}
+
+          {crossData.incidentCount === 0 ? (
+            <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center text-gray-500">
+              <Trans>
+                No incidents found with classifications in both selected fields. Try selecting
+                fields from the same taxonomy or more commonly used fields.
+              </Trans>
+            </div>
+          ) : (
+            <Card>
+              <CrossTaxonomyChart
+                chartType={chartType}
+                crossData={crossData}
+                xLabel={xAxis.field}
+                yLabel={yAxis.field}
+              />
+            </Card>
+          )}
+        </div>
+      )}
+
+      {!crossData && (!xAxisKey || !yAxisKey) && (
+        <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center text-gray-500">
+          <Trans>Select fields for both axes above to generate a visualization.</Trans>
+        </div>
+      )}
+    </div>
+  );
+}
+// ---------------------------------------------------------------------------
+
+export default function CrossTaxonomyPage({ data }) {
+  const { t } = useTranslation();
+
+  const [coverageDismissed, setCoverageDismissed] = useState(false);
+
+  // Read the dismissal after mount; localStorage doesn't exist at build time
+  // and the first client render must match the built HTML.
+  useEffect(() => {
+    try {
+      if (localStorage.getItem('aiid-coverage-notice-dismissed') === '1') {
+        setCoverageDismissed(true);
+      }
+    } catch {
+      /* localStorage unavailable */
+    }
+  }, []);
+
+  const dismissCoverage = () => {
+    try {
+      localStorage.setItem('aiid-coverage-notice-dismissed', '1');
+    } catch {
+      /* localStorage unavailable */
+    }
+    setCoverageDismissed(true);
+  };
+
+  // Data comes from the build-time page query below; no runtime requests.
+  // The synthetic Time taxa lets incident years act as a normal taxonomy field.
+  const allTaxas = useMemo(() => [buildTimeTaxa(), ...transformTaxas(data?.taxas?.nodes)], [data]);
+
+  const incidentsData = useMemo(
+    () => transformIncidents(data?.incidents?.nodes, data?.entities?.nodes),
+    [data]
+  );
+
+  const allClassifications = useMemo(
+    () => [
+      ...transformClassifications(data?.classifications?.nodes),
+      ...buildTimeClassifications(incidentsData),
+    ],
+    [data, incidentsData]
+  );
+
+  const incidentEntityMap = useMemo(() => buildIncidentEntityMap(incidentsData), [incidentsData]);
+
+  // Extra graph panels (first panel uses URL params below)
+  const [extraPanels, setExtraPanels] = useState([]);
+
+  // Tab + first-panel state, kept in the URL (see useUrlQueryState)
+  const [query, setQuery] = useUrlQueryState();
+
+  // Apply URL params only after mount; the built HTML has none, and the first
+  // client render has to match it (hydration).
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // Unknown tab ids (e.g. stale shared links) fall back to the default tab.
+  const tabParamValid = TABS.some((t) => t.id === query.tab);
+
+  const activeTab = mounted && tabParamValid ? query.tab : 'developer';
+
+  // A sel from a stale tab belongs to that tab's value space; drop it too.
+  const guidedSelection = (mounted && (tabParamValid || !query.tab) && query.sel) || '';
+
+  // Mode index for tabs with a mode toggle; in the URL so links restore it.
+  const guidedModeIdx = mounted && /^\d+$/.test(query.mode) ? parseInt(query.mode, 10) : 0;
+
+  const chartTypeParam = (mounted && query.chartType) || 'bar';
+
+  // Ignore chart types the selector doesn't offer.
+  const chartType = CHART_TYPES.some((ct) => ct.value === chartTypeParam) ? chartTypeParam : 'bar';
+
+  const xAxisKey = (mounted && query.x) || '';
+
+  const yAxisKey = (mounted && query.y) || '';
+
+  const filterKey = (mounted && query.filterField) || '';
+
+  const filterValue = (mounted && query.filterValue) || '';
+
+  const setActiveTab = useCallback(
+    (tab) => setQuery({ tab: tab || undefined, sel: undefined, mode: undefined }),
+    [setQuery]
+  );
+
+  const setGuidedSelection = useCallback((v) => setQuery({ sel: v || undefined }), [setQuery]);
+
+  // Mode switch clears the selection; values don't carry across modes.
+  const setGuidedModeIdx = useCallback(
+    (i) => setQuery({ mode: i ? String(i) : undefined, sel: undefined }),
+    [setQuery]
+  );
+
+  const setChartType = useCallback((v) => setQuery({ chartType: v || undefined }), [setQuery]);
+
+  const setXAxisKey = useCallback((v) => setQuery({ x: v || undefined }), [setQuery]);
+
+  const setYAxisKey = useCallback((v) => setQuery({ y: v || undefined }), [setQuery]);
+
+  const setFilterKey = useCallback(
+    (v) => setQuery({ filterField: v || undefined, filterValue: undefined }),
+    [setQuery]
+  );
+
+  const setFilterValue = useCallback((v) => setQuery({ filterValue: v || undefined }), [setQuery]);
+
+  const copyShareLink = useCallback(() => {
+    if (typeof navigator !== 'undefined' && navigator.clipboard) {
+      navigator.clipboard.writeText(window.location.href);
+    }
+  }, [query]);
+
+  // Extra panel management
+  const addPanel = useCallback(() => {
+    setExtraPanels((prev) => [
+      ...prev,
+      {
+        id: Date.now(),
+        chartType: 'bar',
+        xAxisKey: '',
+        yAxisKey: '',
+        filterKey: '',
+        filterValue: '',
+      },
+    ]);
+  }, []);
+
+  const removePanel = useCallback((id) => {
+    setExtraPanels((prev) => prev.filter((p) => p.id !== id));
+  }, []);
+
+  const updatePanel = useCallback((id, field, value) => {
+    setExtraPanels((prev) => prev.map((p) => (p.id === id ? { ...p, [field]: value } : p)));
+  }, []);
+
+  // Shared computed data
+  const groupedClassifications = useMemo(
+    () => groupClassificationsByIncident(allClassifications),
+    [allClassifications]
+  );
+
+  const availableFields = useMemo(
+    () => getAvailableFields(allTaxas.filter((t) => !t.namespace.includes('_Annotator'))),
+    [allTaxas]
+  );
+
+  const fieldsByNamespace = useMemo(() => {
+    const grouped = {};
+
+    for (const f of availableFields) {
+      if (!grouped[f.namespace]) grouped[f.namespace] = [];
+      grouped[f.namespace].push(f);
+    }
+    return grouped;
+  }, [availableFields]);
+
+  // Options for the field selector: label = field name, sublabel = namespace.
+  const fieldSelectOptions = useMemo(
+    () =>
+      Object.entries(fieldsByNamespace).flatMap(([namespace, fields]) =>
+        fields.map((f) => ({
+          value: `${namespace}::${f.short_name}`,
+          label: f.short_name,
+          sublabel: namespace,
+        }))
+      ),
+    [fieldsByNamespace]
+  );
+
+  const hasSelection = activeTab === 'custom' ? xAxisKey && yAxisKey : guidedSelection;
+
+  return (
+    <div>
+      <div className="flex flex-col gap-6">
+        {/* Header */}
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-bold">
+              <Trans>Cross-Taxonomy Visualizations</Trans>
+            </h1>
+            <p className="text-gray-600 mt-1">
+              <Trans>
+                Explore patterns in AI incidents across taxonomies. Pick a lens below or build a
+                custom chart.
+              </Trans>
+            </p>
+          </div>
+          {hasSelection && (
+            <Button color="light" size="sm" onClick={copyShareLink}>
+              <Trans>Copy Share Link</Trans>
+            </Button>
+          )}
+        </div>
+
+        {/* Coverage notice */}
+        {!coverageDismissed && (
+          <div className="flex items-start justify-between gap-3 bg-gray-50 border border-gray-200 rounded-lg px-4 py-3 text-sm text-gray-600">
+            <span>
+              <Trans>
+                ⓘ Coverage is partial: charts reflect only incidents annotated by taxonomy
+                reviewers, not all {{ total: incidentEntityMap.size }} incidents in the database.
+              </Trans>
+            </span>
+            <button
+              type="button"
+              onClick={dismissCoverage}
+              className="text-gray-400 hover:text-gray-600 shrink-0 leading-none text-base"
+              aria-label={t('Dismiss')}
+            >
+              ×
+            </button>
+          </div>
+        )}
+
+        {/* Tab bar */}
+        <div className="border-b border-gray-200">
+          <nav className="flex flex-wrap -mb-px gap-0">
+            {TABS.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                className={`px-4 py-3 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
+                  activeTab === tab.id
+                    ? 'border-blue-500 text-blue-600'
+                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                }`}
+              >
+                {t(tab.label)}
+              </button>
+            ))}
+          </nav>
+        </div>
+
+        {/* Guided tabs */}
+        {activeTab !== 'custom' && GUIDED_TAB_CONFIGS[activeTab] && (
+          <GuidedAnalysisTab
+            config={GUIDED_TAB_CONFIGS[activeTab]}
+            selectedValue={guidedSelection}
+            onSelectValue={setGuidedSelection}
+            activeModeIdx={guidedModeIdx}
+            onSelectMode={setGuidedModeIdx}
+            groupedClassifications={groupedClassifications}
+            allClassifications={allClassifications}
+            incidentEntityMap={incidentEntityMap}
+            totalIncidents={incidentEntityMap.size}
+            fieldSelectOptions={fieldSelectOptions}
+          />
+        )}
+
+        {/* Custom explorer tab */}
+        {activeTab === 'custom' && (
+          <div className="flex flex-col gap-8">
+            {/* First panel: axes stored in URL params for shareability */}
+            <ExplorerPanel
+              chartType={chartType}
+              onChartTypeChange={setChartType}
+              xAxisKey={xAxisKey}
+              onXAxisChange={setXAxisKey}
+              yAxisKey={yAxisKey}
+              onYAxisChange={setYAxisKey}
+              filterKey={filterKey}
+              onFilterKeyChange={setFilterKey}
+              filterValue={filterValue}
+              onFilterValueChange={setFilterValue}
+              onRemove={null}
+              groupedClassifications={groupedClassifications}
+              allClassifications={allClassifications}
+              fieldSelectOptions={fieldSelectOptions}
+              totalIncidents={incidentEntityMap.size}
+            />
+
+            {/* Extra panels */}
+            {extraPanels.map((panel, i) => (
+              <div key={panel.id} className="flex flex-col gap-0">
+                {/* Divider connecting panels visually */}
+                <div className="flex items-center gap-3 py-2">
+                  <div className="flex-1 border-t border-dashed border-gray-300" />
+                  <span className="text-xs text-gray-400 uppercase tracking-wide">
+                    <Trans>Graph {{ number: i + 2 }}</Trans>
+                  </span>
+                  <div className="flex-1 border-t border-dashed border-gray-300" />
+                </div>
+                <ExplorerPanel
+                  chartType={panel.chartType}
+                  onChartTypeChange={(v) => updatePanel(panel.id, 'chartType', v)}
+                  xAxisKey={panel.xAxisKey}
+                  onXAxisChange={(v) => updatePanel(panel.id, 'xAxisKey', v)}
+                  yAxisKey={panel.yAxisKey}
+                  onYAxisChange={(v) => updatePanel(panel.id, 'yAxisKey', v)}
+                  filterKey={panel.filterKey}
+                  onFilterKeyChange={(v) => {
+                    updatePanel(panel.id, 'filterKey', v);
+                    updatePanel(panel.id, 'filterValue', '');
+                  }}
+                  filterValue={panel.filterValue}
+                  onFilterValueChange={(v) => updatePanel(panel.id, 'filterValue', v)}
+                  onRemove={() => removePanel(panel.id)}
+                  groupedClassifications={groupedClassifications}
+                  allClassifications={allClassifications}
+                  fieldSelectOptions={fieldSelectOptions}
+                  totalIncidents={incidentEntityMap.size}
+                />
+              </div>
+            ))}
+
+            {/* Add Graph button */}
+            <div className="flex justify-center pt-2">
+              <Button color="light" onClick={addPanel}>
+                + <Trans>New Graph</Trans>
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const Head = (props) => {
+  const {
+    location: { pathname },
+  } = props;
+
+  return (
+    <HeadContent
+      path={pathname}
+      metaTitle="Cross-Taxonomy Visualizations"
+      metaDescription="Visualize relationships between AI incident classification fields across different taxonomies."
+    />
+  );
+};
+
+// Build-time page query; the page makes no runtime API calls. Unpublished
+// classifications and *_Annotator namespaces are excluded here (never
+// chartable, and they dominate the payload). Non-public taxa fields are
+// filtered in transformTaxas.
+export const query = graphql`
+  query CrossTaxonomyPageQuery {
+    taxas: allMongodbAiidprodTaxa {
+      nodes {
+        namespace
+        weight
+        description
+        field_list {
+          field_number
+          short_name
+          long_name
+          display_type
+          mongo_type
+          permitted_values
+          instant_facet
+          public
+        }
+      }
+    }
+    classifications: allMongodbAiidprodClassifications(
+      filter: { publish: { eq: true }, namespace: { regex: "/^(?!.*_Annotator)/" } }
+    ) {
+      nodes {
+        namespace
+        incidents {
+          incident_id
+        }
+        attributes {
+          short_name
+          value_json
+        }
+      }
+    }
+    incidents: allMongodbAiidprodIncidents {
+      nodes {
+        incident_id
+        date
+        Alleged_deployer_of_AI_system
+        Alleged_developer_of_AI_system
+        Alleged_harmed_or_nearly_harmed_parties
+      }
+    }
+    entities: allMongodbAiidprodEntities {
+      nodes {
+        entity_id
+        name
+      }
+    }
+  }
+`;

--- a/site/gatsby-site/src/pages/apps/cross-taxonomy.js
+++ b/site/gatsby-site/src/pages/apps/cross-taxonomy.js
@@ -1,0 +1,940 @@
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { useApolloClient } from '@apollo/client';
+import gql from 'graphql-tag';
+import { FIND_CLASSIFICATION } from '../../graphql/classifications';
+import { Button, Spinner, Card, Badge } from 'flowbite-react';
+import SearchableSelect from 'components/visualizations/SearchableSelect';
+import { Trans, useTranslation } from 'react-i18next';
+import { useUserContext } from 'contexts/UserContext';
+import HeadContent from 'components/HeadContent';
+import CrossTaxonomyChart from 'components/visualizations/CrossTaxonomyChart';
+import GuidedAnalysisTab from 'components/visualizations/GuidedAnalysisTab';
+import {
+  groupClassificationsByIncident,
+  getAvailableFields,
+  buildCrossData,
+  buildIncidentEntityMap,
+  getFieldValues,
+} from 'utils/crossTaxonomy';
+import { StringParam, useQueryParams, withDefault } from 'use-query-params';
+
+const TABS = [
+  { id: 'developer', label: 'By Developer' },
+  { id: 'deployer', label: 'By Deployer' },
+  { id: 'technology', label: 'By Technology' },
+  { id: 'affected', label: 'By Affected' },
+  { id: 'custom', label: 'Custom Explorer' },
+];
+
+// Shared chart lineup for the "By Affected" tab. Both the demographic-basis
+// (classification path) and named-groups (entity path) modes count these same target
+// fields, so the lineup is defined once and reused by each mode.
+const AFFECTED_CHARTS = [
+  {
+    title: 'Sector of Deployment',
+    subtitle: 'Sectors where this group was affected',
+    namespace: 'CSETv1',
+    field: 'Sector of Deployment',
+    type: 'bar',
+  },
+  {
+    title: 'AI Technologies Involved',
+    subtitle: 'Technologies used in incidents affecting this group',
+    namespace: 'GMF',
+    field: 'Known AI Technology',
+    type: 'bar',
+  },
+  {
+    title: 'Failure Modes',
+    subtitle: 'Technical failures causing harm to this group',
+    namespace: 'GMF',
+    field: 'Known AI Technical Failure',
+    type: 'bar',
+  },
+  {
+    title: 'Harm Domain',
+    subtitle: 'Categories of harm experienced',
+    namespace: 'CSETv1',
+    field: 'Harm Domain',
+    type: 'bar',
+  },
+  {
+    title: 'Risk Domains',
+    subtitle: 'Risk categories from the MIT AI Risk Repository',
+    namespace: 'MIT',
+    field: 'Risk Domain',
+    type: 'bar',
+  },
+  {
+    title: 'Intent',
+    subtitle: 'Whether harms to this group were intentional or unintentional',
+    namespace: 'MIT',
+    field: 'Intent',
+    type: 'donut',
+  },
+  {
+    title: 'Incidents Over Time',
+    subtitle: 'Number of incidents per year',
+    namespace: 'Time',
+    field: 'Year',
+    type: 'bar',
+    sortBy: 'key',
+  },
+];
+
+// In named-groups mode the demographic basis is no longer the selector, so surface it as
+// an extra chart to show which demographics were affected within the selected group.
+const AFFECTED_DEMOGRAPHICS_CHART = {
+  title: 'Affected Demographics',
+  subtitle: 'Demographic groups disproportionately affected within this group',
+  namespace: 'CSETv1',
+  field: 'Harm Distribution Basis',
+  type: 'bar',
+};
+
+const GUIDED_TAB_CONFIGS = {
+  developer: {
+    selectorSource: 'entity',
+    selectorEntityField: 'developers',
+    selectorLabel: 'Select a Developer',
+    charts: [
+      {
+        title: 'Sector of Deployment',
+        subtitle: "Sectors where this developer's AI is deployed",
+        namespace: 'CSETv1',
+        field: 'Sector of Deployment',
+        type: 'bar',
+      },
+      {
+        title: 'Failure Modes',
+        subtitle: 'Known technical failures in incidents',
+        namespace: 'GMF',
+        field: 'Known AI Technical Failure',
+        type: 'bar',
+      },
+      {
+        title: 'Affected Demographics',
+        subtitle: 'Demographic groups disproportionately affected',
+        namespace: 'CSETv1',
+        field: 'Harm Distribution Basis',
+        type: 'bar',
+      },
+      {
+        title: 'Intent',
+        subtitle: 'Whether harms were intentional or unintentional',
+        namespace: 'MIT',
+        field: 'Intent',
+        type: 'donut',
+      },
+      {
+        title: 'Risk Domains',
+        subtitle: 'Risk categories from the MIT AI Risk Repository',
+        namespace: 'MIT',
+        field: 'Risk Domain',
+        type: 'bar',
+      },
+      {
+        title: 'Incidents Over Time',
+        subtitle: 'Number of incidents per year',
+        namespace: 'Time',
+        field: 'Year',
+        type: 'bar',
+        sortBy: 'key',
+      },
+    ],
+  },
+  deployer: {
+    selectorSource: 'entity',
+    selectorEntityField: 'deployers',
+    selectorLabel: 'Select a Deployer',
+    charts: [
+      {
+        title: 'AI Technologies Used',
+        subtitle: 'Known AI technologies involved in incidents',
+        namespace: 'GMF',
+        field: 'Known AI Technology',
+        type: 'bar',
+      },
+      {
+        title: 'What Goes Wrong',
+        subtitle: 'Technical failures in incidents involving this deployer',
+        namespace: 'GMF',
+        field: 'Known AI Technical Failure',
+        type: 'bar',
+      },
+      {
+        title: 'Who Is Affected',
+        subtitle: 'Demographic groups impacted',
+        namespace: 'CSETv1',
+        field: 'Harm Distribution Basis',
+        type: 'bar',
+      },
+      {
+        title: 'Sector of Deployment',
+        subtitle: 'Deployment sectors where incidents occurred',
+        namespace: 'CSETv1',
+        field: 'Sector of Deployment',
+        type: 'bar',
+      },
+      {
+        title: 'Risk Domains',
+        subtitle: 'Risk categories from the MIT AI Risk Repository',
+        namespace: 'MIT',
+        field: 'Risk Domain',
+        type: 'bar',
+      },
+      {
+        title: 'Incidents Over Time',
+        subtitle: 'Number of incidents per year',
+        namespace: 'Time',
+        field: 'Year',
+        type: 'bar',
+        sortBy: 'key',
+      },
+    ],
+  },
+  // "By Affected" — a single tab whose mode toggle flips the selector between the
+  // structured demographic basis (CSETv1 classification path) and the named harmed-party
+  // groups (entity path). Both modes reuse the same shared chart lineup.
+  affected: {
+    selectorLabel: 'By Affected',
+    modes: [
+      {
+        modeLabel: 'Demographic basis',
+        selectorField: { namespace: 'CSETv1', short_name: 'Harm Distribution Basis' },
+        selectorLabel: 'Select a demographic basis',
+      },
+      {
+        modeLabel: 'Named groups',
+        selectorSource: 'entity',
+        selectorEntityField: 'harmedParties',
+        selectorLabel: 'Select a harmed party',
+        charts: [AFFECTED_DEMOGRAPHICS_CHART, ...AFFECTED_CHARTS],
+      },
+    ],
+    charts: AFFECTED_CHARTS,
+  },
+  technology: {
+    selectorField: { namespace: 'GMF', short_name: 'Known AI Technology' },
+    selectorLabel: 'Select a Technology',
+    charts: [
+      {
+        title: 'Deployment Sectors',
+        subtitle: 'Where this technology is deployed',
+        namespace: 'CSETv1',
+        field: 'Sector of Deployment',
+        type: 'bar',
+      },
+      {
+        title: 'Failure Modes',
+        subtitle: 'Technical failures associated with this technology',
+        namespace: 'GMF',
+        field: 'Known AI Technical Failure',
+        type: 'bar',
+      },
+      {
+        title: 'Who Is Harmed',
+        subtitle: 'Demographic groups affected',
+        namespace: 'CSETv1',
+        field: 'Harm Distribution Basis',
+        type: 'bar',
+      },
+      {
+        title: 'Risk Domains',
+        subtitle: 'Risk categories from the MIT AI Risk Repository',
+        namespace: 'MIT',
+        field: 'Risk Domain',
+        type: 'bar',
+      },
+      {
+        title: 'Harm Domain',
+        subtitle: 'Types of harm caused by this technology',
+        namespace: 'CSETv1',
+        field: 'Harm Domain',
+        type: 'bar',
+      },
+      {
+        title: 'Incidents Over Time',
+        subtitle: 'Number of incidents per year',
+        namespace: 'Time',
+        field: 'Year',
+        type: 'bar',
+        sortBy: 'key',
+      },
+    ],
+  },
+};
+
+const CHART_TYPES = [
+  { value: 'bar', label: 'Bar Chart' },
+  { value: 'histogram', label: 'Stacked Bar Chart' },
+  { value: 'line', label: 'Line Chart' },
+];
+
+const FIND_TAXA = gql`
+  query FindTaxa {
+    taxas {
+      namespace
+      weight
+      description
+      field_list {
+        field_number
+        short_name
+        long_name
+        display_type
+        mongo_type
+        permitted_values
+        instant_facet
+        public
+      }
+    }
+  }
+`;
+
+const FIND_INCIDENTS_ENTITIES = gql`
+  query FindIncidentsEntities {
+    incidents(pagination: { limit: 9999, skip: 0 }) {
+      incident_id
+      date
+      AllegedDeveloperOfAISystem {
+        entity_id
+        name
+      }
+      AllegedDeployerOfAISystem {
+        entity_id
+        name
+      }
+      AllegedHarmedOrNearlyHarmedParties {
+        entity_id
+        name
+      }
+    }
+  }
+`;
+
+// Split "namespace::field" key into its parts.
+function parseKey(key) {
+  if (!key) return { namespace: '', field: '' };
+  const [namespace, ...rest] = key.split('::');
+
+  return { namespace, field: rest.join('::') };
+}
+
+// ---------------------------------------------------------------------------
+// ExplorerPanel — one self-contained controls + chart unit.
+// The first panel on the page wires its callbacks to URL params so the chart
+// state is shareable. Extra panels use plain local state passed in from the
+// parent via the same prop interface.
+// ---------------------------------------------------------------------------
+function ExplorerPanel({
+  chartType,
+  onChartTypeChange,
+  xAxisKey,
+  onXAxisChange,
+  yAxisKey,
+  onYAxisChange,
+  filterKey,
+  onFilterKeyChange,
+  filterValue,
+  onFilterValueChange,
+  onRemove,
+  groupedClassifications,
+  allClassifications,
+  fieldSelectOptions,
+  totalIncidents,
+}) {
+  const { t } = useTranslation();
+
+  // Memoize the parsed keys so the data-building memos below keep stable
+  // dependencies. parseKey returns a fresh object each call, so without this
+  // the useMemos for crossData/filterOptions would never hit their cache and
+  // would rerun buildCrossData/getFieldValues on every render.
+  const xAxis = useMemo(() => parseKey(xAxisKey), [xAxisKey]);
+
+  const yAxis = useMemo(() => parseKey(yAxisKey), [yAxisKey]);
+
+  const filter = useMemo(() => parseKey(filterKey), [filterKey]);
+
+  const crossData = useMemo(() => {
+    if (!xAxis.namespace || !yAxis.namespace) return null;
+    return buildCrossData(
+      groupedClassifications,
+      xAxis.namespace,
+      xAxis.field,
+      yAxis.namespace,
+      yAxis.field,
+      filter.namespace || null,
+      filter.field || null,
+      filterValue || null
+    );
+  }, [groupedClassifications, xAxis, yAxis, filter, filterValue]);
+
+  const filterOptions = useMemo(() => {
+    if (!filter.namespace || !filter.field) return [];
+    return getFieldValues(allClassifications, filter.namespace, filter.field).map(
+      ({ value }) => value
+    );
+  }, [allClassifications, filter]);
+
+  const handleXAxisChange = useCallback(
+    (v) => {
+      onXAxisChange(v);
+      if (parseKey(v).namespace === 'Time') onChartTypeChange('line');
+    },
+    [onXAxisChange, onChartTypeChange]
+  );
+
+  const renderFieldSelect = (value, onChange, label) => (
+    <div className="flex flex-col gap-1">
+      {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+      <label className="text-sm font-medium text-gray-700">{label}</label>
+      <SearchableSelect
+        options={fieldSelectOptions}
+        value={value}
+        onChange={onChange}
+        placeholder={`— ${t('Search or select')} —`}
+      />
+    </div>
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Card>
+        {/* Remove button — only shown on extra panels */}
+        {onRemove && (
+          <div className="flex justify-end -mt-1 -mb-2">
+            <button
+              type="button"
+              onClick={onRemove}
+              className="text-xs text-gray-400 hover:text-red-500 transition-colors"
+            >
+              <Trans>Remove graph</Trans>
+            </button>
+          </div>
+        )}
+
+        <div className="flex flex-wrap gap-4 items-end">
+          <div className="flex flex-col gap-1">
+            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+            <label className="text-sm font-medium text-gray-700">
+              <Trans>Chart Type</Trans>
+            </label>
+            <SearchableSelect
+              options={CHART_TYPES.map((ct) => ({ value: ct.value, label: t(ct.label) }))}
+              value={chartType}
+              onChange={onChartTypeChange}
+              placeholder={`— ${t('Select type')} —`}
+            />
+          </div>
+
+          {renderFieldSelect(xAxisKey, handleXAxisChange, t('X-Axis Field'))}
+          {renderFieldSelect(yAxisKey, onYAxisChange, t('Y-Axis Field'))}
+        </div>
+
+        <div className="flex flex-wrap gap-4 items-end mt-4 pt-4 border-t border-gray-200">
+          <div className="text-sm font-medium text-gray-700 self-center">
+            <Trans>Optional Filter:</Trans>
+          </div>
+          {renderFieldSelect(filterKey, onFilterKeyChange, t('Filter Field'))}
+
+          {filterKey && (
+            <div className="flex flex-col gap-1">
+              {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+              <label className="text-sm font-medium text-gray-700">
+                <Trans>Filter Value</Trans>
+              </label>
+              <SearchableSelect
+                options={filterOptions.map((v) => ({ value: v, label: v }))}
+                value={filterValue}
+                onChange={onFilterValueChange}
+                placeholder={`— ${t('All')} —`}
+              />
+            </div>
+          )}
+
+          {(filterKey || filterValue) && (
+            <Button
+              color="gray"
+              size="sm"
+              onClick={() => {
+                onFilterKeyChange('');
+                onFilterValueChange('');
+              }}
+            >
+              <Trans>Clear Filter</Trans>
+            </Button>
+          )}
+        </div>
+      </Card>
+
+      {crossData && (
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center gap-2 text-sm text-gray-600 flex-wrap">
+            <span className="font-semibold text-lg text-gray-900">
+              N = {crossData.incidentCount}
+            </span>
+            <Trans>incidents with data for both selected fields</Trans>
+            {totalIncidents > 0 && (
+              <span className="text-gray-400">
+                (<Trans>out of {{ total: totalIncidents }} total in database</Trans>)
+              </span>
+            )}
+            {filterValue && (
+              <Badge color="info">
+                {filter.field} = &quot;{filterValue}&quot;
+              </Badge>
+            )}
+          </div>
+
+          {crossData.incidentCount < 5 && (
+            <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 text-yellow-800 text-sm">
+              <Trans>
+                Warning: Only {{ count: crossData.incidentCount }} incidents have classifications
+                for both selected fields. Results may not be representative.
+              </Trans>
+            </div>
+          )}
+
+          {crossData.incidentCount === 0 ? (
+            <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center text-gray-500">
+              <Trans>
+                No incidents found with classifications in both selected fields. Try selecting
+                fields from the same taxonomy or more commonly used fields.
+              </Trans>
+            </div>
+          ) : (
+            <Card>
+              <CrossTaxonomyChart
+                chartType={chartType}
+                crossData={crossData}
+                xLabel={xAxis.field}
+                yLabel={yAxis.field}
+              />
+            </Card>
+          )}
+        </div>
+      )}
+
+      {!crossData && !xAxisKey && !yAxisKey && (
+        <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center text-gray-500">
+          <Trans>Select fields for both axes above to generate a visualization.</Trans>
+        </div>
+      )}
+    </div>
+  );
+}
+// ---------------------------------------------------------------------------
+
+export default function CrossTaxonomyPage(props) {
+  const { isAdmin } = useUserContext();
+
+  const { t } = useTranslation();
+
+  const client = useApolloClient();
+
+  const [loading, setLoading] = useState(true);
+
+  const [error, setError] = useState(null);
+
+  const [coverageDismissed, setCoverageDismissed] = useState(() => {
+    try {
+      return localStorage.getItem('aiid-coverage-notice-dismissed') === '1';
+    } catch {
+      return false;
+    }
+  });
+
+  const dismissCoverage = () => {
+    try {
+      localStorage.setItem('aiid-coverage-notice-dismissed', '1');
+    } catch {
+      /* localStorage unavailable */
+    }
+    setCoverageDismissed(true);
+  };
+
+  const [allTaxas, setAllTaxas] = useState([]);
+
+  const [allClassifications, setAllClassifications] = useState([]);
+
+  const [incidentEntityMap, setIncidentEntityMap] = useState(new Map());
+
+  // Extra graph panels (first panel uses URL params below)
+  const [extraPanels, setExtraPanels] = useState([]);
+
+  // URL query params for the first panel + tab state
+  const [query, setQuery] = useQueryParams({
+    tab: withDefault(StringParam, ''),
+    sel: withDefault(StringParam, ''),
+    chartType: withDefault(StringParam, ''),
+    x: withDefault(StringParam, ''),
+    y: withDefault(StringParam, ''),
+    filterField: withDefault(StringParam, ''),
+    filterValue: withDefault(StringParam, ''),
+  });
+
+  // Fall back to the default tab for unknown ids (e.g. stale ?tab=harmed URLs shared
+  // before the harmed-party tab was folded into the "By Affected" tab's mode toggle).
+  const activeTab = TABS.some((t) => t.id === query.tab) ? query.tab : 'developer';
+
+  const guidedSelection = query.sel || '';
+
+  const chartType = query.chartType || 'bar';
+
+  const xAxisKey = query.x || '';
+
+  const yAxisKey = query.y || '';
+
+  const filterKey = query.filterField || '';
+
+  const filterValue = query.filterValue || '';
+
+  const setActiveTab = useCallback(
+    (tab) => setQuery({ tab: tab || undefined, sel: undefined }),
+    [setQuery]
+  );
+
+  const setGuidedSelection = useCallback((v) => setQuery({ sel: v || undefined }), [setQuery]);
+
+  const setChartType = useCallback((v) => setQuery({ chartType: v || undefined }), [setQuery]);
+
+  const setXAxisKey = useCallback((v) => setQuery({ x: v || undefined }), [setQuery]);
+
+  const setYAxisKey = useCallback((v) => setQuery({ y: v || undefined }), [setQuery]);
+
+  const setFilterKey = useCallback(
+    (v) => setQuery({ filterField: v || undefined, filterValue: undefined }),
+    [setQuery]
+  );
+
+  const setFilterValue = useCallback((v) => setQuery({ filterValue: v || undefined }), [setQuery]);
+
+  const copyShareLink = useCallback(() => {
+    if (typeof navigator !== 'undefined' && navigator.clipboard) {
+      navigator.clipboard.writeText(window.location.href);
+    }
+  }, [query]);
+
+  // Extra panel management
+  const addPanel = useCallback(() => {
+    setExtraPanels((prev) => [
+      ...prev,
+      {
+        id: Date.now(),
+        chartType: 'bar',
+        xAxisKey: '',
+        yAxisKey: '',
+        filterKey: '',
+        filterValue: '',
+      },
+    ]);
+  }, []);
+
+  const removePanel = useCallback((id) => {
+    setExtraPanels((prev) => prev.filter((p) => p.id !== id));
+  }, []);
+
+  const updatePanel = useCallback((id, field, value) => {
+    setExtraPanels((prev) => prev.map((p) => (p.id === id ? { ...p, [field]: value } : p)));
+  }, []);
+
+  // Fetch all taxa and classifications on mount
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchData() {
+      setLoading(true);
+      setError(null);
+      try {
+        // no-cache: this page bulk-loads thousands of read-only docs and keeps
+        // them in React state. Skipping Apollo's normalization/cache writes for
+        // data we never re-read avoids a large load-time and memory cost.
+        const [taxaResult, classResult, incidentsResult] = await Promise.all([
+          client.query({ query: FIND_TAXA, fetchPolicy: 'no-cache' }),
+          client.query({
+            query: FIND_CLASSIFICATION,
+            variables: { filter: {} },
+            fetchPolicy: 'no-cache',
+          }),
+          client.query({ query: FIND_INCIDENTS_ENTITIES, fetchPolicy: 'no-cache' }),
+        ]);
+
+        if (cancelled) return;
+
+        let taxas = taxaResult.data.taxas;
+
+        if (!isAdmin) {
+          taxas = taxas.map((taxa) => ({
+            ...taxa,
+            field_list: taxa.field_list.filter((f) => f.public !== false),
+          }));
+        }
+
+        const classifications = classResult.data.classifications.filter(
+          (c) => c.attributes && (c.publish || isAdmin)
+        );
+
+        // Synthetic "Time" taxa and per-incident Year pseudo-classifications.
+        // Injecting them into the same arrays lets all existing data-processing
+        // functions (buildCrossData, buildFilteredCounts, etc.) work with time
+        // as if it were a regular taxonomy field, with zero changes to those utils.
+        const timeTaxa = {
+          namespace: 'Time',
+          weight: 0,
+          description: 'Year the incident was reported',
+          field_list: [
+            {
+              field_number: '0',
+              short_name: 'Year',
+              long_name: 'Year',
+              display_type: 'enum',
+              mongo_type: 'string',
+              permitted_values: [],
+              instant_facet: false,
+              public: true,
+            },
+          ],
+        };
+
+        const incidentsData = incidentsResult.data.incidents || [];
+
+        const timeClassifications = incidentsData
+          .filter((inc) => inc.date && inc.date.length >= 4)
+          .map((inc) => ({
+            namespace: 'Time',
+            incidents: [{ incident_id: inc.incident_id }],
+            attributes: [
+              { short_name: 'Year', value_json: JSON.stringify(inc.date.substring(0, 4)) },
+            ],
+            publish: true,
+          }));
+
+        setAllTaxas([timeTaxa, ...taxas]);
+        setAllClassifications([...classifications, ...timeClassifications]);
+        setIncidentEntityMap(buildIncidentEntityMap(incidentsData));
+      } catch (err) {
+        if (!cancelled) setError(err);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    fetchData();
+    return () => {
+      cancelled = true;
+    };
+  }, [isAdmin]);
+
+  // Shared computed data
+  const groupedClassifications = useMemo(
+    () => groupClassificationsByIncident(allClassifications),
+    [allClassifications]
+  );
+
+  const availableFields = useMemo(
+    () => getAvailableFields(allTaxas.filter((t) => !t.namespace.includes('_Annotator'))),
+    [allTaxas]
+  );
+
+  const fieldsByNamespace = useMemo(() => {
+    const grouped = {};
+
+    for (const f of availableFields) {
+      if (!grouped[f.namespace]) grouped[f.namespace] = [];
+      grouped[f.namespace].push(f);
+    }
+    return grouped;
+  }, [availableFields]);
+
+  // Flat options list for the searchable field selector.
+  // label = field short name, sublabel = namespace (shown right-aligned in dropdown).
+  const fieldSelectOptions = useMemo(
+    () =>
+      Object.entries(fieldsByNamespace).flatMap(([namespace, fields]) =>
+        fields.map((f) => ({
+          value: `${namespace}::${f.short_name}`,
+          label: f.short_name,
+          sublabel: namespace,
+        }))
+      ),
+    [fieldsByNamespace]
+  );
+
+  const hasSelection = activeTab === 'custom' ? xAxisKey && yAxisKey : guidedSelection;
+
+  return (
+    <div {...props}>
+      <div className="flex flex-col gap-6">
+        {/* Header */}
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-bold">
+              <Trans>Cross-Taxonomy Visualizations</Trans>
+            </h1>
+            <p className="text-gray-600 mt-1">
+              <Trans>
+                Explore patterns in AI incidents across taxonomies. Pick a lens below or build a
+                custom chart.
+              </Trans>
+            </p>
+          </div>
+          {hasSelection && (
+            <Button color="light" size="sm" onClick={copyShareLink}>
+              <Trans>Copy Share Link</Trans>
+            </Button>
+          )}
+        </div>
+
+        {loading && (
+          <div className="flex items-center gap-2 py-8 justify-center">
+            <Spinner size="lg" />
+            <Trans>Loading taxonomy data...</Trans>
+          </div>
+        )}
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-red-700 text-sm">
+            <Trans>Failed to load taxonomy data. Please refresh the page.</Trans>
+          </div>
+        )}
+
+        {!loading && !error && (
+          <>
+            {/* Coverage notice */}
+            {!coverageDismissed && (
+              <div className="flex items-start justify-between gap-3 bg-gray-50 border border-gray-200 rounded-lg px-4 py-3 text-sm text-gray-600">
+                <span>
+                  <Trans>
+                    ⓘ Coverage is partial: charts reflect only incidents annotated by taxonomy
+                    reviewers, not all {{ total: incidentEntityMap.size }} incidents in the
+                    database.
+                  </Trans>
+                </span>
+                <button
+                  type="button"
+                  onClick={dismissCoverage}
+                  className="text-gray-400 hover:text-gray-600 shrink-0 leading-none text-base"
+                  aria-label="Dismiss"
+                >
+                  ×
+                </button>
+              </div>
+            )}
+
+            {/* Tab bar */}
+            <div className="border-b border-gray-200">
+              <nav className="flex flex-wrap -mb-px gap-0">
+                {TABS.map((tab) => (
+                  <button
+                    key={tab.id}
+                    onClick={() => setActiveTab(tab.id)}
+                    className={`px-4 py-3 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
+                      activeTab === tab.id
+                        ? 'border-blue-500 text-blue-600'
+                        : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                    }`}
+                  >
+                    {t(tab.label)}
+                  </button>
+                ))}
+              </nav>
+            </div>
+
+            {/* Guided tabs */}
+            {activeTab !== 'custom' && GUIDED_TAB_CONFIGS[activeTab] && (
+              <GuidedAnalysisTab
+                config={GUIDED_TAB_CONFIGS[activeTab]}
+                selectedValue={guidedSelection}
+                onSelectValue={setGuidedSelection}
+                groupedClassifications={groupedClassifications}
+                allClassifications={allClassifications}
+                incidentEntityMap={incidentEntityMap}
+                totalIncidents={incidentEntityMap.size}
+                fieldSelectOptions={fieldSelectOptions}
+              />
+            )}
+
+            {/* Custom explorer tab */}
+            {activeTab === 'custom' && (
+              <div className="flex flex-col gap-8">
+                {/* First panel — axes stored in URL params for shareability */}
+                <ExplorerPanel
+                  chartType={chartType}
+                  onChartTypeChange={setChartType}
+                  xAxisKey={xAxisKey}
+                  onXAxisChange={setXAxisKey}
+                  yAxisKey={yAxisKey}
+                  onYAxisChange={setYAxisKey}
+                  filterKey={filterKey}
+                  onFilterKeyChange={setFilterKey}
+                  filterValue={filterValue}
+                  onFilterValueChange={setFilterValue}
+                  onRemove={null}
+                  groupedClassifications={groupedClassifications}
+                  allClassifications={allClassifications}
+                  fieldSelectOptions={fieldSelectOptions}
+                  totalIncidents={incidentEntityMap.size}
+                />
+
+                {/* Extra panels */}
+                {extraPanels.map((panel) => (
+                  <div key={panel.id} className="flex flex-col gap-0">
+                    {/* Divider connecting panels visually */}
+                    <div className="flex items-center gap-3 py-2">
+                      <div className="flex-1 border-t border-dashed border-gray-300" />
+                      <span className="text-xs text-gray-400 uppercase tracking-wide">
+                        <Trans>Graph {extraPanels.indexOf(panel) + 2}</Trans>
+                      </span>
+                      <div className="flex-1 border-t border-dashed border-gray-300" />
+                    </div>
+                    <ExplorerPanel
+                      chartType={panel.chartType}
+                      onChartTypeChange={(v) => updatePanel(panel.id, 'chartType', v)}
+                      xAxisKey={panel.xAxisKey}
+                      onXAxisChange={(v) => updatePanel(panel.id, 'xAxisKey', v)}
+                      yAxisKey={panel.yAxisKey}
+                      onYAxisChange={(v) => updatePanel(panel.id, 'yAxisKey', v)}
+                      filterKey={panel.filterKey}
+                      onFilterKeyChange={(v) => {
+                        updatePanel(panel.id, 'filterKey', v);
+                        updatePanel(panel.id, 'filterValue', '');
+                      }}
+                      filterValue={panel.filterValue}
+                      onFilterValueChange={(v) => updatePanel(panel.id, 'filterValue', v)}
+                      onRemove={() => removePanel(panel.id)}
+                      groupedClassifications={groupedClassifications}
+                      allClassifications={allClassifications}
+                      fieldSelectOptions={fieldSelectOptions}
+                      totalIncidents={incidentEntityMap.size}
+                    />
+                  </div>
+                ))}
+
+                {/* Add Graph button */}
+                <div className="flex justify-center pt-2">
+                  <Button color="light" onClick={addPanel}>
+                    + <Trans>New Graph</Trans>
+                  </Button>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const Head = (props) => {
+  const {
+    location: { pathname },
+  } = props;
+
+  return (
+    <HeadContent
+      path={pathname}
+      metaTitle="Cross-Taxonomy Visualizations"
+      metaDescription="Visualize relationships between AI incident classification fields across different taxonomies."
+    />
+  );
+};

--- a/site/gatsby-site/src/utils/__tests__/crossTaxonomy.test.js
+++ b/site/gatsby-site/src/utils/__tests__/crossTaxonomy.test.js
@@ -1,0 +1,1396 @@
+/* eslint-env jest */
+/**
+ * Unit tests for src/utils/crossTaxonomy.js
+ *
+ * Every function under test is a pure function: data in, data out.
+ * No React, GraphQL, Apollo, or DOM dependencies are needed.
+ */
+
+const {
+  groupClassificationsByIncident,
+  buildFilteredCounts,
+  buildCrossData,
+  toBillboardColumns,
+  toScatterData,
+  buildIncidentEntityMap,
+  getEntityValues,
+  countEntityIncidents,
+  buildEntityFilteredCounts,
+  getAvailableFields,
+  getFieldValues,
+  countFilteredIncidents,
+} = require('../crossTaxonomy');
+
+// ─────────────────────────────────────────────────────────────
+// Test helpers
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Factory: create a classification document matching the GraphQL schema.
+ *
+ * @param {string} namespace - Taxonomy namespace, e.g. "CSETv1", "GMF", "MIT"
+ * @param {number[]} incidentIds - Array of incident IDs this classification links to
+ * @param {Object} fields - Key-value pairs, e.g. { "Sector of Deployment": "Education" }
+ *                          Values are auto-serialised to value_json (JSON.stringify).
+ * @returns {Object} A classification document shaped like the GraphQL response.
+ */
+function makeClassification(namespace, incidentIds, fields = {}) {
+  return {
+    _id: `${namespace}-${incidentIds.join('-')}-${Math.random().toString(36).slice(2, 6)}`,
+    namespace,
+    incidents: incidentIds.map((id) => ({ incident_id: id })),
+    publish: true,
+    attributes: Object.entries(fields).map(([short_name, value]) => ({
+      short_name,
+      value_json: JSON.stringify(value),
+    })),
+  };
+}
+
+/**
+ * Factory: create an incident document matching the FindIncidentsEntities query shape.
+ *
+ * @param {number} id - incident_id
+ * @param {Object} opts - Optional entity arrays.
+ * @param {Array<{entity_id:string, name:string}>} [opts.developers=[]]
+ * @param {Array<{entity_id:string, name:string}>} [opts.deployers=[]]
+ * @param {Array<{entity_id:string, name:string}>} [opts.harmedParties=[]]
+ * @returns {Object} An incident document.
+ */
+function makeIncident(id, { developers = [], deployers = [], harmedParties = [] } = {}) {
+  return {
+    incident_id: id,
+    AllegedDeveloperOfAISystem: developers.map((name) =>
+      typeof name === 'string' ? { entity_id: name.toLowerCase().replace(/\s/g, '-'), name } : name
+    ),
+    AllegedDeployerOfAISystem: deployers.map((name) =>
+      typeof name === 'string' ? { entity_id: name.toLowerCase().replace(/\s/g, '-'), name } : name
+    ),
+    AllegedHarmedOrNearlyHarmedParties: harmedParties.map((name) =>
+      typeof name === 'string' ? { entity_id: name.toLowerCase().replace(/\s/g, '-'), name } : name
+    ),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────
+// groupClassificationsByIncident
+// ─────────────────────────────────────────────────────────────
+
+describe('groupClassificationsByIncident', () => {
+  test('groups 3 classifications across 2 incidents correctly', () => {
+    // Two classifications belong to incident 1, one to incident 2.
+    // Verifies the fundamental grouping: the Map should have 2 keys,
+    // with incident 1 holding 2 entries and incident 2 holding 1.
+    const c1 = makeClassification('CSETv1', [1], { Severity: 'Minor' });
+
+    const c2 = makeClassification('GMF', [1], { 'Known AI Technology': ['NLP'] });
+
+    const c3 = makeClassification('MIT', [2], { Intent: 'Accident' });
+
+    const grouped = groupClassificationsByIncident([c1, c2, c3]);
+
+    expect(grouped.size).toBe(2);
+    expect(grouped.get(1)).toHaveLength(2);
+    expect(grouped.get(1)).toContain(c1);
+    expect(grouped.get(1)).toContain(c2);
+    expect(grouped.get(2)).toHaveLength(1);
+    expect(grouped.get(2)).toContain(c3);
+  });
+
+  test('one classification linked to 2 incident IDs appears in both groups', () => {
+    // A single classification can reference multiple incidents.
+    // It should appear in the array for every incident it references.
+    const c = makeClassification('CSETv1', [10, 20], { Severity: 'Severe' });
+
+    const grouped = groupClassificationsByIncident([c]);
+
+    expect(grouped.size).toBe(2);
+    expect(grouped.get(10)).toContain(c);
+    expect(grouped.get(20)).toContain(c);
+  });
+
+  test('empty input returns an empty Map', () => {
+    // Edge case: no classifications at all should produce an empty Map,
+    // not null or undefined.
+    const grouped = groupClassificationsByIncident([]);
+
+    expect(grouped).toBeInstanceOf(Map);
+    expect(grouped.size).toBe(0);
+  });
+
+  test('two classifications for the same incident both appear in its array', () => {
+    // Verifies that duplicates within the same incident are accumulated,
+    // not overwritten.
+    const c1 = makeClassification('CSETv1', [5], { Severity: 'Minor' });
+
+    const c2 = makeClassification('GMF', [5], { 'Known AI Technology': ['CV'] });
+
+    const grouped = groupClassificationsByIncident([c1, c2]);
+
+    expect(grouped.size).toBe(1);
+    expect(grouped.get(5)).toHaveLength(2);
+    expect(grouped.get(5)).toEqual(expect.arrayContaining([c1, c2]));
+  });
+
+  test('classification with empty incidents array is skipped', () => {
+    // If a classification has an empty incidents array it should not appear
+    // in any group, and should not cause an error.
+    const c = { ...makeClassification('MIT', [], { Intent: 'Accident' }), incidents: [] };
+
+    const grouped = groupClassificationsByIncident([c]);
+
+    expect(grouped.size).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// buildFilteredCounts  (also tests extractValues indirectly)
+// ─────────────────────────────────────────────────────────────
+
+describe('buildFilteredCounts', () => {
+  // Helper: group a flat array into the Map that buildFilteredCounts expects.
+  const group = (arr) => groupClassificationsByIncident(arr);
+
+  test('plain string value is extracted correctly', () => {
+    // Verifies the simplest value_json shape: a JSON string like '"Education"'.
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor', 'Sector of Deployment': 'Education' }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'CSETv1',
+      'Sector of Deployment'
+    );
+
+    expect(result.counts.get('Education')).toBe(1);
+    expect(result.incidentCount).toBe(1);
+  });
+
+  test('JSON array value extracts each element separately', () => {
+    // value_json = '["NLP","Computer Vision"]' should produce two separate counts.
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor' }),
+      makeClassification('GMF', [1], { 'Known AI Technology': ['NLP', 'Computer Vision'] }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'GMF',
+      'Known AI Technology'
+    );
+
+    expect(result.counts.get('NLP')).toBe(1);
+    expect(result.counts.get('Computer Vision')).toBe(1);
+    expect(result.total).toBe(2);
+    expect(result.incidentCount).toBe(1);
+  });
+
+  test('boolean true is extracted as "Yes"', () => {
+    // Booleans stored as value_json: 'true' should be converted to "Yes".
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor', Critical: true }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'CSETv1',
+      'Critical'
+    );
+
+    expect(result.counts.get('Yes')).toBe(1);
+  });
+
+  test('boolean false is extracted as "No"', () => {
+    // Booleans stored as value_json: 'false' should be converted to "No".
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor', Critical: false }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'CSETv1',
+      'Critical'
+    );
+
+    expect(result.counts.get('No')).toBe(1);
+  });
+
+  test('semicolon-separated string is split into individual values', () => {
+    // CSETv1 sometimes stores multi-values as "A; B; C".
+    // extractValues should split on "; " and count each part.
+    const classifications = [
+      makeClassification('CSETv1', [1], {
+        Severity: 'Minor',
+        'System Developer': 'Google; DeepMind',
+      }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'CSETv1',
+      'System Developer'
+    );
+
+    expect(result.counts.get('Google')).toBe(1);
+    expect(result.counts.get('DeepMind')).toBe(1);
+    expect(result.total).toBe(2);
+  });
+
+  test('null value produces no counts for that field', () => {
+    // value_json = 'null' should be treated as empty; the incident is skipped
+    // for the target field.
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor', 'Sector of Deployment': null }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'CSETv1',
+      'Sector of Deployment'
+    );
+
+    expect(result.counts.size).toBe(0);
+    expect(result.incidentCount).toBe(0);
+  });
+
+  test('empty string value produces no counts for that field', () => {
+    // value_json = '""' should be treated as empty.
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor', 'Sector of Deployment': '' }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'CSETv1',
+      'Sector of Deployment'
+    );
+
+    expect(result.counts.size).toBe(0);
+    expect(result.incidentCount).toBe(0);
+  });
+
+  test('array containing nulls and empty strings filters them out', () => {
+    // value_json = '["NLP", null, ""]' should keep only "NLP".
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor' }),
+      makeClassification('GMF', [1], { 'Known AI Technology': ['NLP', null, ''] }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'GMF',
+      'Known AI Technology'
+    );
+
+    expect(result.counts.size).toBe(1);
+    expect(result.counts.get('NLP')).toBe(1);
+  });
+
+  test('numeric value is converted to string via toString fallback', () => {
+    // value_json = '42' should be stringified to "42".
+    const classifications = [makeClassification('CSETv1', [1], { Severity: 'Minor', Score: 42 })];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'CSETv1',
+      'Score'
+    );
+
+    expect(result.counts.get('42')).toBe(1);
+  });
+
+  test('field not present on classification returns no counts', () => {
+    // If the target field does not exist in the classification's attributes,
+    // getClassificationValue returns undefined, and extractValues returns [].
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor' }),
+      // No GMF classification for incident 1 at all
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'CSETv1',
+      'NonExistentField'
+    );
+
+    expect(result.counts.size).toBe(0);
+    expect(result.incidentCount).toBe(0);
+  });
+
+  test('filter matches no incidents returns empty results', () => {
+    // When no incident has the filter value, everything should be zero.
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor', 'Sector of Deployment': 'Education' }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Severe', // No incident has Severe
+      'CSETv1',
+      'Sector of Deployment'
+    );
+
+    expect(result.counts.size).toBe(0);
+    expect(result.total).toBe(0);
+    expect(result.incidentCount).toBe(0);
+  });
+
+  test('target namespace absent on matching incident skips it', () => {
+    // Incident matches the filter (CSETv1 Severity=Minor) but has no GMF
+    // classification, so it cannot produce target values.
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor' }),
+      // No GMF classification for incident 1
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'GMF',
+      'Known AI Technology'
+    );
+
+    expect(result.counts.size).toBe(0);
+    expect(result.incidentCount).toBe(0);
+  });
+
+  test('multi-value target field counts each value separately', () => {
+    // An incident whose target field has 3 values should increment
+    // all 3 in the counts Map, and incidentCount should still be 1.
+    const classifications = [
+      makeClassification('CSETv1', [1], {
+        Severity: 'Minor',
+        'Sector of Deployment': 'Education; Healthcare; Government',
+      }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'CSETv1',
+      'Sector of Deployment'
+    );
+
+    expect(result.counts.get('Education')).toBe(1);
+    expect(result.counts.get('Healthcare')).toBe(1);
+    expect(result.counts.get('Government')).toBe(1);
+    expect(result.total).toBe(3);
+    expect(result.incidentCount).toBe(1);
+  });
+
+  test('optional secondary filter narrows the matched incidents', () => {
+    // Both incidents match the primary filter (Severity=Minor) and have a Sector,
+    // but only incident 1 also has Intent=Accident. With the secondary filter on
+    // Intent=Accident, only incident 1's Sector should be counted.
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor', 'Sector of Deployment': 'Education' }),
+      makeClassification('MIT', [1], { Intent: 'Accident' }),
+      makeClassification('CSETv1', [2], {
+        Severity: 'Minor',
+        'Sector of Deployment': 'Healthcare',
+      }),
+      makeClassification('MIT', [2], { Intent: 'Deliberate' }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'CSETv1',
+      'Sector of Deployment',
+      'MIT',
+      'Intent',
+      'Accident'
+    );
+
+    expect(result.counts.get('Education')).toBe(1);
+    expect(result.counts.has('Healthcare')).toBe(false);
+    expect(result.incidentCount).toBe(1);
+    expect(result.total).toBe(1);
+  });
+
+  test('passing null secondary filter args is identical to omitting them', () => {
+    // The secondary filter is opt-in: explicit nulls must not exclude anything.
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor', 'Sector of Deployment': 'Education' }),
+    ];
+
+    const withNulls = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'CSETv1',
+      'Sector of Deployment',
+      null,
+      null,
+      null
+    );
+
+    expect(withNulls.counts.get('Education')).toBe(1);
+    expect(withNulls.incidentCount).toBe(1);
+  });
+
+  test('incidentIdsByValue maps each value to its contributing incident_ids', () => {
+    // Education comes from incidents 1 and 2; Healthcare only from 2.
+    // Incident 3 is filtered out (Severity=Severe), so Government is absent.
+    // Lists are deduped and sorted ascending.
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor', 'Sector of Deployment': 'Education' }),
+      makeClassification('CSETv1', [2], {
+        Severity: 'Minor',
+        'Sector of Deployment': 'Education; Healthcare',
+      }),
+      makeClassification('CSETv1', [3], {
+        Severity: 'Severe',
+        'Sector of Deployment': 'Government',
+      }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'CSETv1',
+      'Sector of Deployment'
+    );
+
+    expect(result.incidentIdsByValue.get('Education')).toEqual([1, 2]);
+    expect(result.incidentIdsByValue.get('Healthcare')).toEqual([2]);
+    expect(result.incidentIdsByValue.has('Government')).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// buildCrossData
+// ─────────────────────────────────────────────────────────────
+
+describe('buildCrossData', () => {
+  const group = (arr) => groupClassificationsByIncident(arr);
+
+  test('happy path: 2 incidents with X and Y values', () => {
+    // Two incidents, each with values for both axes.
+    // Should produce a 2x2 matrix with correct counts.
+    const classifications = [
+      makeClassification('MIT', [1], { Intent: 'Accident' }),
+      makeClassification('CSETv1', [1], { Severity: 'Minor' }),
+      makeClassification('MIT', [2], { Intent: 'Deliberate' }),
+      makeClassification('CSETv1', [2], { Severity: 'Severe' }),
+    ];
+
+    const result = buildCrossData(
+      group(classifications),
+      'MIT',
+      'Intent',
+      'CSETv1',
+      'Severity',
+      null,
+      null,
+      null
+    );
+
+    expect(result.incidentCount).toBe(2);
+    expect(result.xValues).toContain('Accident');
+    expect(result.xValues).toContain('Deliberate');
+    expect(result.yValues).toContain('Minor');
+    expect(result.yValues).toContain('Severe');
+    expect(result.matrix.get('Accident').get('Minor')).toBe(1);
+    expect(result.matrix.get('Deliberate').get('Severe')).toBe(1);
+  });
+
+  test('multi-value X field generates multiple pairs', () => {
+    // If the X field has semicolon-separated values "A; B", two pairs
+    // should be generated: (A, Y) and (B, Y).
+    const classifications = [
+      makeClassification('CSETv1', [1], { 'Sector of Deployment': 'Education; Healthcare' }),
+      makeClassification('MIT', [1], { Intent: 'Accident' }),
+    ];
+
+    const result = buildCrossData(
+      group(classifications),
+      'CSETv1',
+      'Sector of Deployment',
+      'MIT',
+      'Intent',
+      null,
+      null,
+      null
+    );
+
+    expect(result.incidentCount).toBe(1);
+    expect(result.xValues).toEqual(expect.arrayContaining(['Education', 'Healthcare']));
+    expect(result.totalPairs).toBe(2);
+    expect(result.matrix.get('Education').get('Accident')).toBe(1);
+    expect(result.matrix.get('Healthcare').get('Accident')).toBe(1);
+  });
+
+  test('filter excludes non-matching incidents', () => {
+    // 2 incidents, but the filter only matches incident 2.
+    // Incident 1 should be excluded from the results.
+    const classifications = [
+      makeClassification('MIT', [1], { Intent: 'Accident' }),
+      makeClassification('CSETv1', [1], { Severity: 'Minor', 'Harm Domain': 'Physical' }),
+      makeClassification('MIT', [2], { Intent: 'Deliberate' }),
+      makeClassification('CSETv1', [2], { Severity: 'Severe', 'Harm Domain': 'Psychological' }),
+    ];
+
+    const result = buildCrossData(
+      group(classifications),
+      'MIT',
+      'Intent',
+      'CSETv1',
+      'Severity',
+      'CSETv1',
+      'Harm Domain',
+      'Psychological' // Only incident 2 matches
+    );
+
+    expect(result.incidentCount).toBe(1);
+    expect(result.xValues).toEqual(['Deliberate']);
+    expect(result.yValues).toEqual(['Severe']);
+  });
+
+  test('filter that matches nothing returns zero counts', () => {
+    // Filter value exists in no classification. Everything should be empty.
+    const classifications = [
+      makeClassification('MIT', [1], { Intent: 'Accident' }),
+      makeClassification('CSETv1', [1], { Severity: 'Minor', 'Harm Domain': 'Physical' }),
+    ];
+
+    const result = buildCrossData(
+      group(classifications),
+      'MIT',
+      'Intent',
+      'CSETv1',
+      'Severity',
+      'CSETv1',
+      'Harm Domain',
+      'NonExistent'
+    );
+
+    expect(result.incidentCount).toBe(0);
+    expect(result.xValues).toHaveLength(0);
+    expect(result.yValues).toHaveLength(0);
+    expect(result.pairs).toHaveLength(0);
+  });
+
+  test('incident missing X classification is skipped', () => {
+    // Incident 1 has CSETv1 (Y axis) but no MIT (X axis).
+    // It should be silently skipped, not cause an error.
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor' }),
+      // No MIT classification for incident 1
+    ];
+
+    const result = buildCrossData(
+      group(classifications),
+      'MIT',
+      'Intent',
+      'CSETv1',
+      'Severity',
+      null,
+      null,
+      null
+    );
+
+    expect(result.incidentCount).toBe(0);
+    expect(result.xValues).toHaveLength(0);
+  });
+
+  test('incident missing Y classification is skipped', () => {
+    // Incident 1 has MIT (X axis) but no CSETv1 (Y axis).
+    const classifications = [
+      makeClassification('MIT', [1], { Intent: 'Accident' }),
+      // No CSETv1 for incident 1
+    ];
+
+    const result = buildCrossData(
+      group(classifications),
+      'MIT',
+      'Intent',
+      'CSETv1',
+      'Severity',
+      null,
+      null,
+      null
+    );
+
+    expect(result.incidentCount).toBe(0);
+    expect(result.yValues).toHaveLength(0);
+  });
+
+  test('X and Y from the same taxonomy namespace work correctly', () => {
+    // Both axes reference CSETv1 fields. The function should find the
+    // single CSETv1 classification and extract both fields from it.
+    const classifications = [
+      makeClassification('CSETv1', [1], {
+        Severity: 'Minor',
+        'Sector of Deployment': 'Education',
+      }),
+    ];
+
+    const result = buildCrossData(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'CSETv1',
+      'Sector of Deployment',
+      null,
+      null,
+      null
+    );
+
+    expect(result.incidentCount).toBe(1);
+    expect(result.matrix.get('Minor').get('Education')).toBe(1);
+  });
+
+  test('each pair carries the sorted, deduped ids of incidents in that cell', () => {
+    // (Accident, Minor) holds incidents 1 and 2; (Deliberate, Severe) holds 3.
+    const classifications = [
+      makeClassification('MIT', [1], { Intent: 'Accident' }),
+      makeClassification('CSETv1', [1], { Severity: 'Minor' }),
+      makeClassification('MIT', [2], { Intent: 'Accident' }),
+      makeClassification('CSETv1', [2], { Severity: 'Minor' }),
+      makeClassification('MIT', [3], { Intent: 'Deliberate' }),
+      makeClassification('CSETv1', [3], { Severity: 'Severe' }),
+    ];
+
+    const result = buildCrossData(
+      group(classifications),
+      'MIT',
+      'Intent',
+      'CSETv1',
+      'Severity',
+      null,
+      null,
+      null
+    );
+
+    expect(result.pairs.find((p) => p.x === 'Accident' && p.y === 'Minor').ids).toEqual([1, 2]);
+    expect(result.pairs.find((p) => p.x === 'Deliberate' && p.y === 'Severe').ids).toEqual([3]);
+  });
+
+  test('a multi-value X field lists the same incident under each x cell', () => {
+    // Incident 1 has X = "Education; Healthcare", so it appears in both cells.
+    const classifications = [
+      makeClassification('CSETv1', [1], { 'Sector of Deployment': 'Education; Healthcare' }),
+      makeClassification('MIT', [1], { Intent: 'Accident' }),
+    ];
+
+    const result = buildCrossData(
+      group(classifications),
+      'CSETv1',
+      'Sector of Deployment',
+      'MIT',
+      'Intent',
+      null,
+      null,
+      null
+    );
+
+    expect(result.pairs.find((p) => p.x === 'Education').ids).toEqual([1]);
+    expect(result.pairs.find((p) => p.x === 'Healthcare').ids).toEqual([1]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// toBillboardColumns
+// ─────────────────────────────────────────────────────────────
+
+describe('toBillboardColumns', () => {
+  test('2x2 matrix produces correct Billboard.js column format', () => {
+    // A 2x2 matrix should yield: an x-axis column with 2 categories,
+    // plus 2 data-series columns, each with a value per x category.
+    const crossData = {
+      xValues: ['Accident', 'Deliberate'],
+      yValues: ['Minor', 'Severe'],
+      matrix: new Map([
+        [
+          'Accident',
+          new Map([
+            ['Minor', 3],
+            ['Severe', 1],
+          ]),
+        ],
+        [
+          'Deliberate',
+          new Map([
+            ['Minor', 0],
+            ['Severe', 2],
+          ]),
+        ],
+      ]),
+    };
+
+    const columns = toBillboardColumns(crossData);
+
+    expect(columns).toEqual([
+      ['x', 'Accident', 'Deliberate'],
+      ['Minor', 3, 0],
+      ['Severe', 1, 2],
+    ]);
+  });
+
+  test('single cell matrix', () => {
+    // Minimal case: one X value, one Y value.
+    const crossData = {
+      xValues: ['Accident'],
+      yValues: ['Minor'],
+      matrix: new Map([['Accident', new Map([['Minor', 5]])]]),
+    };
+
+    const columns = toBillboardColumns(crossData);
+
+    expect(columns).toEqual([
+      ['x', 'Accident'],
+      ['Minor', 5],
+    ]);
+  });
+
+  test('zero count values are preserved, not omitted', () => {
+    // If xValue "Deliberate" has no entry for yValue "Minor" in the matrix,
+    // the output should contain 0, not skip the entry.
+    const crossData = {
+      xValues: ['Accident', 'Deliberate'],
+      yValues: ['Minor'],
+      matrix: new Map([
+        ['Accident', new Map([['Minor', 2]])],
+        ['Deliberate', new Map()], // no Minor entry
+      ]),
+    };
+
+    const columns = toBillboardColumns(crossData);
+
+    expect(columns).toEqual([
+      ['x', 'Accident', 'Deliberate'],
+      ['Minor', 2, 0],
+    ]);
+  });
+
+  test('empty cross data produces only an empty x column', () => {
+    // When there are no values at all, the output should be just ['x']
+    // with no data series.
+    const crossData = {
+      xValues: [],
+      yValues: [],
+      matrix: new Map(),
+    };
+
+    const columns = toBillboardColumns(crossData);
+
+    expect(columns).toEqual([['x']]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// buildIncidentEntityMap
+// ─────────────────────────────────────────────────────────────
+
+describe('buildIncidentEntityMap', () => {
+  test('3 incidents with full entity arrays produce correct Map', () => {
+    // Verifies that all three entity types are correctly extracted
+    // and mapped by incident_id.
+    const incidents = [
+      makeIncident(1, {
+        developers: ['OpenAI'],
+        deployers: ['Uber'],
+        harmedParties: ['Pedestrians'],
+      }),
+      makeIncident(2, { developers: ['Google', 'DeepMind'], deployers: ['Google'] }),
+      makeIncident(3, { developers: ['Meta'] }),
+    ];
+
+    const map = buildIncidentEntityMap(incidents);
+
+    expect(map.size).toBe(3);
+    expect(map.get(1).developers).toEqual(['OpenAI']);
+    expect(map.get(1).deployers).toEqual(['Uber']);
+    expect(map.get(1).harmedParties).toEqual(['Pedestrians']);
+    expect(map.get(2).developers).toEqual(['Google', 'DeepMind']);
+    expect(map.get(2).deployers).toEqual(['Google']);
+    expect(map.get(2).harmedParties).toEqual([]);
+    expect(map.get(3).developers).toEqual(['Meta']);
+    expect(map.get(3).deployers).toEqual([]);
+  });
+
+  test('incident with empty developer array produces empty developers list', () => {
+    // Explicit empty array should result in an empty array, not undefined.
+    const incidents = [makeIncident(1, { developers: [] })];
+
+    const map = buildIncidentEntityMap(incidents);
+
+    expect(map.get(1).developers).toEqual([]);
+  });
+
+  test('incident where AllegedDeveloperOfAISystem is null or undefined', () => {
+    // If the GraphQL response has null for an entity field, the code uses
+    // the || [] fallback. This should not throw.
+    const incident = {
+      incident_id: 1,
+      AllegedDeveloperOfAISystem: null,
+      AllegedDeployerOfAISystem: undefined,
+      AllegedHarmedOrNearlyHarmedParties: [{ entity_id: 'people', name: 'People' }],
+    };
+
+    const map = buildIncidentEntityMap([incident]);
+
+    expect(map.get(1).developers).toEqual([]);
+    expect(map.get(1).deployers).toEqual([]);
+    expect(map.get(1).harmedParties).toEqual(['People']);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// getEntityValues
+// ─────────────────────────────────────────────────────────────
+
+describe('getEntityValues', () => {
+  test('returns values sorted by count descending', () => {
+    // OpenAI appears in 3 incidents, Google in 1. OpenAI should come first.
+    const incidents = [
+      makeIncident(1, { developers: ['OpenAI'] }),
+      makeIncident(2, { developers: ['OpenAI', 'Google'] }),
+      makeIncident(3, { developers: ['OpenAI'] }),
+    ];
+
+    const map = buildIncidentEntityMap(incidents);
+
+    const values = getEntityValues(map, 'developers');
+
+    expect(values[0]).toEqual({ value: 'OpenAI', count: 3 });
+    expect(values[1]).toEqual({ value: 'Google', count: 1 });
+  });
+
+  test('empty map returns empty array', () => {
+    // No incidents at all should produce [], not an error.
+    const values = getEntityValues(new Map(), 'developers');
+
+    expect(values).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// countEntityIncidents
+// ─────────────────────────────────────────────────────────────
+
+describe('countEntityIncidents', () => {
+  test('entity present in 5 incidents returns 5', () => {
+    // Count how many incidents involve a specific entity.
+    const incidents = [
+      makeIncident(1, { developers: ['OpenAI'] }),
+      makeIncident(2, { developers: ['OpenAI'] }),
+      makeIncident(3, { developers: ['Google'] }),
+      makeIncident(4, { developers: ['OpenAI'] }),
+      makeIncident(5, { developers: ['OpenAI', 'Meta'] }),
+      makeIncident(6, { developers: ['OpenAI'] }),
+    ];
+
+    const map = buildIncidentEntityMap(incidents);
+
+    expect(countEntityIncidents(map, 'developers', 'OpenAI')).toBe(5);
+  });
+
+  test('entity not found returns 0', () => {
+    // An entity name that doesn't exist in any incident should return 0.
+    const incidents = [makeIncident(1, { developers: ['OpenAI'] })];
+
+    const map = buildIncidentEntityMap(incidents);
+
+    expect(countEntityIncidents(map, 'developers', 'UnknownCorp')).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// buildEntityFilteredCounts
+// ─────────────────────────────────────────────────────────────
+
+describe('buildEntityFilteredCounts', () => {
+  test('OpenAI incidents with CSETv1 Sector returns correct counts', () => {
+    // Two incidents have OpenAI as developer. Both have CSETv1 classifications.
+    // Sector values should be counted correctly.
+    const classifications = [
+      makeClassification('CSETv1', [1], { 'Sector of Deployment': 'Education' }),
+      makeClassification('CSETv1', [2], { 'Sector of Deployment': 'Healthcare' }),
+      makeClassification('CSETv1', [3], { 'Sector of Deployment': 'Government' }),
+    ];
+
+    const incidents = [
+      makeIncident(1, { developers: ['OpenAI'] }),
+      makeIncident(2, { developers: ['OpenAI'] }),
+      makeIncident(3, { developers: ['Google'] }), // Not OpenAI
+    ];
+
+    const grouped = groupClassificationsByIncident(classifications);
+
+    const entityMap = buildIncidentEntityMap(incidents);
+
+    const result = buildEntityFilteredCounts(
+      grouped,
+      entityMap,
+      'developers',
+      'OpenAI',
+      'CSETv1',
+      'Sector of Deployment'
+    );
+
+    expect(result.counts.get('Education')).toBe(1);
+    expect(result.counts.get('Healthcare')).toBe(1);
+    expect(result.counts.has('Government')).toBe(false); // Google's incident
+    expect(result.incidentCount).toBe(2);
+    expect(result.total).toBe(2);
+  });
+
+  test('entity matches incidents but those incidents have no target taxonomy', () => {
+    // OpenAI has 2 incidents, but neither has a CSETv1 classification.
+    // The function should return incidentCount=0 and empty counts.
+    const classifications = [
+      // Only GMF classifications, no CSETv1
+      makeClassification('GMF', [1], { 'Known AI Technology': ['NLP'] }),
+      makeClassification('GMF', [2], { 'Known AI Technology': ['CV'] }),
+    ];
+
+    const incidents = [
+      makeIncident(1, { developers: ['OpenAI'] }),
+      makeIncident(2, { developers: ['OpenAI'] }),
+    ];
+
+    const grouped = groupClassificationsByIncident(classifications);
+
+    const entityMap = buildIncidentEntityMap(incidents);
+
+    const result = buildEntityFilteredCounts(
+      grouped,
+      entityMap,
+      'developers',
+      'OpenAI',
+      'CSETv1',
+      'Sector of Deployment'
+    );
+
+    expect(result.counts.size).toBe(0);
+    expect(result.incidentCount).toBe(0);
+    expect(result.total).toBe(0);
+  });
+
+  test('entity not in any incident returns empty counts', () => {
+    // The entity name doesn't match any incident's developers.
+    const classifications = [
+      makeClassification('CSETv1', [1], { 'Sector of Deployment': 'Education' }),
+    ];
+
+    const incidents = [makeIncident(1, { developers: ['Google'] })];
+
+    const grouped = groupClassificationsByIncident(classifications);
+
+    const entityMap = buildIncidentEntityMap(incidents);
+
+    const result = buildEntityFilteredCounts(
+      grouped,
+      entityMap,
+      'developers',
+      'UnknownCorp',
+      'CSETv1',
+      'Sector of Deployment'
+    );
+
+    expect(result.counts.size).toBe(0);
+    expect(result.incidentCount).toBe(0);
+    expect(result.total).toBe(0);
+  });
+
+  test('optional secondary filter narrows entity-matched incidents', () => {
+    // Both OpenAI incidents have a Sector, but only incident 1 also has
+    // Intent=Accident. The secondary filter should keep only incident 1.
+    const classifications = [
+      makeClassification('CSETv1', [1], { 'Sector of Deployment': 'Education' }),
+      makeClassification('MIT', [1], { Intent: 'Accident' }),
+      makeClassification('CSETv1', [2], { 'Sector of Deployment': 'Healthcare' }),
+      makeClassification('MIT', [2], { Intent: 'Deliberate' }),
+    ];
+
+    const incidents = [
+      makeIncident(1, { developers: ['OpenAI'] }),
+      makeIncident(2, { developers: ['OpenAI'] }),
+    ];
+
+    const grouped = groupClassificationsByIncident(classifications);
+
+    const entityMap = buildIncidentEntityMap(incidents);
+
+    const result = buildEntityFilteredCounts(
+      grouped,
+      entityMap,
+      'developers',
+      'OpenAI',
+      'CSETv1',
+      'Sector of Deployment',
+      'MIT',
+      'Intent',
+      'Accident'
+    );
+
+    expect(result.counts.get('Education')).toBe(1);
+    expect(result.counts.has('Healthcare')).toBe(false);
+    expect(result.incidentCount).toBe(1);
+    expect(result.total).toBe(1);
+  });
+
+  test('incidentIdsByValue lists the entity-matched incidents per value', () => {
+    // Incidents 1 and 2 are OpenAI; 3 is Google and must not appear.
+    const classifications = [
+      makeClassification('CSETv1', [1], { 'Sector of Deployment': 'Education' }),
+      makeClassification('CSETv1', [2], { 'Sector of Deployment': 'Healthcare' }),
+      makeClassification('CSETv1', [3], { 'Sector of Deployment': 'Government' }),
+    ];
+
+    const incidents = [
+      makeIncident(1, { developers: ['OpenAI'] }),
+      makeIncident(2, { developers: ['OpenAI'] }),
+      makeIncident(3, { developers: ['Google'] }),
+    ];
+
+    const result = buildEntityFilteredCounts(
+      groupClassificationsByIncident(classifications),
+      buildIncidentEntityMap(incidents),
+      'developers',
+      'OpenAI',
+      'CSETv1',
+      'Sector of Deployment'
+    );
+
+    expect(result.incidentIdsByValue.get('Education')).toEqual([1]);
+    expect(result.incidentIdsByValue.get('Healthcare')).toEqual([2]);
+    expect(result.incidentIdsByValue.has('Government')).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// getAvailableFields
+// ─────────────────────────────────────────────────────────────
+
+describe('getAvailableFields', () => {
+  test('includes categorical / permitted-value fields and excludes free text', () => {
+    // enum, multi, list, bool types are categorical and always included.
+    // A field with a non-categorical display_type is only included if it has
+    // permitted_values. A plain free-text field is excluded.
+    const taxas = [
+      {
+        namespace: 'CSETv1',
+        field_list: [
+          {
+            short_name: 'Severity',
+            long_name: 'Severity',
+            display_type: 'enum',
+            permitted_values: ['Minor', 'Severe'],
+          },
+          { short_name: 'Flag', long_name: 'Flag', display_type: 'bool', permitted_values: [] },
+          {
+            short_name: 'Notes',
+            long_name: 'Notes',
+            display_type: 'long_string',
+            permitted_values: [],
+          },
+          {
+            short_name: 'Region',
+            long_name: 'Region',
+            display_type: 'string',
+            permitted_values: ['NA', 'EU'],
+          },
+        ],
+      },
+    ];
+
+    const fields = getAvailableFields(taxas);
+
+    const names = fields.map((f) => f.short_name);
+
+    expect(names).toEqual(expect.arrayContaining(['Severity', 'Flag', 'Region']));
+    expect(names).not.toContain('Notes'); // free text, no permitted values
+    expect(fields).toHaveLength(3);
+  });
+
+  test('deduplicates fields that share a namespace::short_name key', () => {
+    // The same field appearing in two taxa entries should only be listed once.
+    const taxas = [
+      {
+        namespace: 'GMF',
+        field_list: [
+          {
+            short_name: 'Known AI Technology',
+            long_name: 'Tech',
+            display_type: 'multi',
+            permitted_values: [],
+          },
+        ],
+      },
+      {
+        namespace: 'GMF',
+        field_list: [
+          {
+            short_name: 'Known AI Technology',
+            long_name: 'Tech',
+            display_type: 'multi',
+            permitted_values: [],
+          },
+        ],
+      },
+    ];
+
+    const fields = getAvailableFields(taxas);
+
+    expect(fields).toHaveLength(1);
+    expect(fields[0]).toMatchObject({ namespace: 'GMF', short_name: 'Known AI Technology' });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// getFieldValues
+// ─────────────────────────────────────────────────────────────
+
+describe('getFieldValues', () => {
+  test('counts values within a namespace, sorted by frequency descending', () => {
+    // NLP appears in two GMF classifications, CV in one. A same-named field
+    // under a different namespace must be ignored.
+    const classifications = [
+      makeClassification('GMF', [1], { 'Known AI Technology': ['NLP', 'CV'] }),
+      makeClassification('GMF', [2], { 'Known AI Technology': ['NLP'] }),
+      makeClassification('CSETv1', [3], { 'Known AI Technology': ['NLP'] }), // wrong namespace
+    ];
+
+    const values = getFieldValues(classifications, 'GMF', 'Known AI Technology');
+
+    expect(values).toEqual([
+      { value: 'NLP', count: 2 },
+      { value: 'CV', count: 1 },
+    ]);
+  });
+
+  test('returns an empty array when no classification matches the namespace', () => {
+    const classifications = [makeClassification('GMF', [1], { 'Known AI Technology': ['NLP'] })];
+
+    expect(getFieldValues(classifications, 'MIT', 'Risk Domain')).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// countFilteredIncidents
+// ─────────────────────────────────────────────────────────────
+
+describe('countFilteredIncidents', () => {
+  test('counts incidents whose classification field includes the value', () => {
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor' }),
+      makeClassification('CSETv1', [2], { Severity: 'Minor' }),
+      makeClassification('CSETv1', [3], { Severity: 'Severe' }),
+    ];
+
+    const grouped = groupClassificationsByIncident(classifications);
+
+    expect(countFilteredIncidents(grouped, 'CSETv1', 'Severity', 'Minor')).toBe(2);
+    expect(countFilteredIncidents(grouped, 'CSETv1', 'Severity', 'Severe')).toBe(1);
+    expect(countFilteredIncidents(grouped, 'CSETv1', 'Severity', 'Nonexistent')).toBe(0);
+  });
+
+  test('a multi-value field counts the incident once per matching value', () => {
+    // The incident is counted once because the value is present, even though
+    // the field holds several values.
+    const classifications = [
+      makeClassification('CSETv1', [1], { 'Sector of Deployment': 'Education; Healthcare' }),
+    ];
+
+    const grouped = groupClassificationsByIncident(classifications);
+
+    expect(countFilteredIncidents(grouped, 'CSETv1', 'Sector of Deployment', 'Healthcare')).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// MIT numeric-prefix stripping  (extractValues quirk, tested indirectly)
+// ─────────────────────────────────────────────────────────────
+
+describe('numeric prefix stripping', () => {
+  const group = (arr) => groupClassificationsByIncident(arr);
+
+  test('strips a leading "N. " index from a string value (MIT Risk Domain)', () => {
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor' }),
+      makeClassification('MIT', [1], { 'Risk Domain': '3. Misinformation' }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'MIT',
+      'Risk Domain'
+    );
+
+    expect(result.counts.get('Misinformation')).toBe(1);
+    expect(result.counts.has('3. Misinformation')).toBe(false);
+  });
+
+  test('strips the index from each element of an array value', () => {
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor' }),
+      makeClassification('MIT', [1], { 'Risk Domain': ['1. AI safety', '12. Privacy'] }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'MIT',
+      'Risk Domain'
+    );
+
+    expect(result.counts.get('AI safety')).toBe(1);
+    expect(result.counts.get('Privacy')).toBe(1);
+  });
+
+  test('leaves values without a numeric prefix unchanged', () => {
+    const classifications = [
+      makeClassification('CSETv1', [1], { Severity: 'Minor', 'Harm Domain': 'Physical Health' }),
+    ];
+
+    const result = buildFilteredCounts(
+      group(classifications),
+      'CSETv1',
+      'Severity',
+      'Minor',
+      'CSETv1',
+      'Harm Domain'
+    );
+
+    expect(result.counts.get('Physical Health')).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// toScatterData
+// ─────────────────────────────────────────────────────────────
+
+describe('toScatterData', () => {
+  const group = (arr) => groupClassificationsByIncident(arr);
+
+  test('maps categorical x-values to numeric indices per y-series', () => {
+    // Two incidents share the Y value "Minor" but have different X values.
+    // Scatter output should map each X category to its sorted index.
+    const classifications = [
+      makeClassification('MIT', [1], { Intent: 'Accident' }),
+      makeClassification('CSETv1', [1], { Severity: 'Minor' }),
+      makeClassification('MIT', [2], { Intent: 'Deliberate' }),
+      makeClassification('CSETv1', [2], { Severity: 'Minor' }),
+    ];
+
+    const crossData = buildCrossData(
+      group(classifications),
+      'MIT',
+      'Intent',
+      'CSETv1',
+      'Severity',
+      null,
+      null,
+      null
+    );
+
+    const scatter = toScatterData(crossData);
+
+    // xValues are sorted alphabetically: Accident -> 0, Deliberate -> 1
+    expect(scatter.xValues).toEqual(['Accident', 'Deliberate']);
+    expect(scatter.xs).toEqual({ Minor: 'Minor_x' });
+    expect(scatter.columns).toEqual(
+      expect.arrayContaining([
+        ['Minor_x', 0, 1],
+        ['Minor', 1, 1],
+      ])
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// Full pipeline: group -> buildCrossData -> toBillboardColumns
+// ─────────────────────────────────────────────────────────────
+
+describe('full pipeline integration', () => {
+  test('raw classifications flow end-to-end into Billboard column format', () => {
+    // Exercises the real chain a Custom Explorer chart uses: flat documents
+    // are grouped, cross-tabulated, then shaped for Billboard.js — including
+    // a multi-value field and a numeric-prefix value along the way.
+    const classifications = [
+      makeClassification('MIT', [1], { Intent: 'Accident' }),
+      makeClassification('CSETv1', [1], { 'Sector of Deployment': 'Education; Healthcare' }),
+      makeClassification('MIT', [2], { Intent: 'Accident' }),
+      makeClassification('CSETv1', [2], { 'Sector of Deployment': 'Education' }),
+      makeClassification('MIT', [3], { Intent: 'Deliberate' }),
+      makeClassification('CSETv1', [3], { 'Sector of Deployment': 'Healthcare' }),
+    ];
+
+    const grouped = groupClassificationsByIncident(classifications);
+
+    const crossData = buildCrossData(
+      grouped,
+      'CSETv1',
+      'Sector of Deployment',
+      'MIT',
+      'Intent',
+      null,
+      null,
+      null
+    );
+
+    expect(crossData.incidentCount).toBe(3);
+    expect(crossData.xValues).toEqual(['Education', 'Healthcare']); // sorted
+    expect(crossData.yValues).toEqual(['Accident', 'Deliberate']); // sorted
+
+    // Education: incident 1 (Accident) + incident 2 (Accident) = 2 Accident
+    // Healthcare: incident 1 (Accident) + incident 3 (Deliberate)
+    const columns = toBillboardColumns(crossData);
+
+    expect(columns).toEqual([
+      ['x', 'Education', 'Healthcare'],
+      ['Accident', 2, 1],
+      ['Deliberate', 0, 1],
+    ]);
+  });
+});

--- a/site/gatsby-site/src/utils/__tests__/crossTaxonomyStatic.test.js
+++ b/site/gatsby-site/src/utils/__tests__/crossTaxonomyStatic.test.js
@@ -1,0 +1,348 @@
+/* eslint-env jest */
+/**
+ * Unit tests for src/utils/crossTaxonomyStatic.js
+ *
+ * Covers the build-time node transforms in isolation, plus an end-to-end pass
+ * of transformed fixtures through the crossTaxonomy data pipeline.
+ */
+import {
+  transformTaxas,
+  transformClassifications,
+  transformIncidents,
+  buildTimeTaxa,
+  buildTimeClassifications,
+} from '../crossTaxonomyStatic';
+import {
+  groupClassificationsByIncident,
+  getAvailableFields,
+  buildCrossData,
+  buildIncidentEntityMap,
+  getFieldValues,
+  getEntityValues,
+} from '../crossTaxonomy';
+
+// ── Fixtures mirroring Gatsby build-time query node shapes ──────────────────
+
+const taxaNodes = [
+  {
+    namespace: 'CSETv1',
+    weight: 70,
+    description: 'CSET taxonomy',
+    field_list: [
+      {
+        field_number: '1',
+        short_name: 'Harm Distribution Basis',
+        long_name: 'Harm Distribution Basis',
+        display_type: 'multi',
+        mongo_type: 'array',
+        permitted_values: ['race', 'sex'],
+        instant_facet: true,
+        public: true,
+      },
+      {
+        field_number: '2',
+        short_name: 'Internal Notes',
+        long_name: 'Internal Notes',
+        display_type: 'long_string',
+        mongo_type: 'string',
+        permitted_values: [],
+        instant_facet: false,
+        public: false,
+      },
+      {
+        field_number: '3',
+        short_name: 'Sector of Deployment',
+        long_name: 'Sector of Deployment',
+        display_type: 'multi',
+        mongo_type: 'array',
+        permitted_values: [],
+        instant_facet: true,
+        public: null,
+      },
+    ],
+  },
+  { namespace: 'Broken', weight: 0, description: 'no field list', field_list: null },
+];
+
+const classificationNodes = [
+  {
+    namespace: 'CSETv1',
+    incidents: [{ incident_id: 1 }, { incident_id: 2 }],
+    attributes: [
+      { short_name: 'Harm Distribution Basis', value_json: '["race"]' },
+      { short_name: 'Sector of Deployment', value_json: '["public safety"]' },
+    ],
+  },
+  {
+    namespace: 'GMF',
+    // A null entry mimics a Gatsby @link to an incident that no longer exists.
+    incidents: [{ incident_id: 1 }, null],
+    attributes: [{ short_name: 'Known AI Technology', value_json: '["Face Recognition"]' }],
+  },
+  {
+    namespace: 'CSETv1',
+    incidents: null,
+    attributes: [{ short_name: 'Harm Distribution Basis', value_json: '["sex"]' }],
+  },
+  // No attributes array — must be dropped, matching the runtime page filter.
+  { namespace: 'CSETv1', incidents: [{ incident_id: 3 }], attributes: null },
+];
+
+const entityNodes = [
+  { entity_id: 'google', name: 'Google' },
+  { entity_id: 'facial-corp', name: 'Facial Corp' },
+  { entity_id: 'unnamed', name: '' },
+  { entity_id: null, name: 'Ghost' },
+];
+
+const incidentNodes = [
+  {
+    incident_id: 1,
+    date: '2021-05-10',
+    Alleged_deployer_of_AI_system: ['facial-corp'],
+    Alleged_developer_of_AI_system: ['google', 'missing-entity'],
+    Alleged_harmed_or_nearly_harmed_parties: ['unnamed'],
+  },
+  {
+    incident_id: 2,
+    date: '2019-01-01',
+    Alleged_deployer_of_AI_system: null,
+    Alleged_developer_of_AI_system: ['google'],
+    Alleged_harmed_or_nearly_harmed_parties: [],
+  },
+  {
+    incident_id: 3,
+    date: null,
+    Alleged_deployer_of_AI_system: ['google'],
+    Alleged_developer_of_AI_system: [],
+    Alleged_harmed_or_nearly_harmed_parties: [],
+  },
+];
+
+// ── transformTaxas ──────────────────────────────────────────────────────────
+
+describe('transformTaxas', () => {
+  it('keeps fields whose public flag is true or unset, drops public: false', () => {
+    const taxas = transformTaxas(taxaNodes);
+
+    const cset = taxas.find((t) => t.namespace === 'CSETv1');
+
+    expect(cset.field_list.map((f) => f.short_name)).toEqual([
+      'Harm Distribution Basis',
+      'Sector of Deployment',
+    ]);
+  });
+
+  it('drops taxa without a field_list array', () => {
+    const taxas = transformTaxas(taxaNodes);
+
+    expect(taxas.map((t) => t.namespace)).toEqual(['CSETv1']);
+  });
+
+  it('handles null and empty input', () => {
+    expect(transformTaxas(null)).toEqual([]);
+    expect(transformTaxas([])).toEqual([]);
+  });
+
+  it('produces taxa consumable by getAvailableFields', () => {
+    const fields = getAvailableFields(transformTaxas(taxaNodes));
+
+    expect(fields.map((f) => f.short_name)).toEqual([
+      'Harm Distribution Basis',
+      'Sector of Deployment',
+    ]);
+  });
+});
+
+// ── transformClassifications ────────────────────────────────────────────────
+
+describe('transformClassifications', () => {
+  it('drops classifications without an attributes array', () => {
+    const classifications = transformClassifications(classificationNodes);
+
+    expect(classifications).toHaveLength(3);
+    expect(classifications.every((c) => Array.isArray(c.attributes))).toBe(true);
+  });
+
+  it('drops null incident links and normalizes missing incident arrays', () => {
+    const classifications = transformClassifications(classificationNodes);
+
+    const gmf = classifications.find((c) => c.namespace === 'GMF');
+
+    expect(gmf.incidents).toEqual([{ incident_id: 1 }]);
+
+    const orphan = classifications.find(
+      (c) => c.namespace === 'CSETv1' && c.incidents.length === 0
+    );
+
+    expect(orphan.incidents).toEqual([]);
+  });
+
+  it('handles null and empty input', () => {
+    expect(transformClassifications(null)).toEqual([]);
+    expect(transformClassifications([])).toEqual([]);
+  });
+});
+
+// ── transformIncidents ──────────────────────────────────────────────────────
+
+describe('transformIncidents', () => {
+  it('resolves entity ids to { entity_id, name } objects', () => {
+    const incidents = transformIncidents(incidentNodes, entityNodes);
+
+    const first = incidents.find((i) => i.incident_id === 1);
+
+    expect(first.AllegedDeployerOfAISystem).toEqual([
+      { entity_id: 'facial-corp', name: 'Facial Corp' },
+    ]);
+  });
+
+  it('skips ids without a matching entity, mirroring the runtime resolver', () => {
+    const incidents = transformIncidents(incidentNodes, entityNodes);
+
+    const first = incidents.find((i) => i.incident_id === 1);
+
+    expect(first.AllegedDeveloperOfAISystem).toEqual([{ entity_id: 'google', name: 'Google' }]);
+  });
+
+  it('skips entities without a usable name or id', () => {
+    const incidents = transformIncidents(incidentNodes, entityNodes);
+
+    const first = incidents.find((i) => i.incident_id === 1);
+
+    expect(first.AllegedHarmedOrNearlyHarmedParties).toEqual([]);
+  });
+
+  it('normalizes null entity arrays to empty arrays', () => {
+    const incidents = transformIncidents(incidentNodes, entityNodes);
+
+    const second = incidents.find((i) => i.incident_id === 2);
+
+    expect(second.AllegedDeployerOfAISystem).toEqual([]);
+  });
+
+  it('handles null and empty input', () => {
+    expect(transformIncidents(null, null)).toEqual([]);
+    expect(transformIncidents([], [])).toEqual([]);
+  });
+
+  it('produces incidents consumable by buildIncidentEntityMap and getEntityValues', () => {
+    const incidents = transformIncidents(incidentNodes, entityNodes);
+
+    const map = buildIncidentEntityMap(incidents);
+
+    expect(map.get(1).deployers).toEqual(['Facial Corp']);
+    expect(map.get(2).developers).toEqual(['Google']);
+
+    const developers = getEntityValues(map, 'developers');
+
+    expect(developers).toEqual([{ value: 'Google', count: 2 }]);
+  });
+});
+
+// ── Synthetic Time taxonomy ─────────────────────────────────────────────────
+
+describe('buildTimeTaxa / buildTimeClassifications', () => {
+  it('exposes Year as a public enum field', () => {
+    const fields = getAvailableFields([buildTimeTaxa()]);
+
+    expect(fields).toEqual([
+      expect.objectContaining({ namespace: 'Time', short_name: 'Year', display_type: 'enum' }),
+    ]);
+  });
+
+  it('derives one Year pseudo-classification per dated incident', () => {
+    const incidents = transformIncidents(incidentNodes, entityNodes);
+
+    const timeClassifications = buildTimeClassifications(incidents);
+
+    expect(timeClassifications).toHaveLength(2);
+    expect(timeClassifications[0]).toEqual({
+      namespace: 'Time',
+      incidents: [{ incident_id: 1 }],
+      attributes: [{ short_name: 'Year', value_json: '"2021"' }],
+    });
+  });
+
+  it('skips incidents with missing or too-short dates', () => {
+    const timeClassifications = buildTimeClassifications([
+      { incident_id: 10, date: '20' },
+      { incident_id: 11, date: null },
+      { incident_id: 12 },
+    ]);
+
+    expect(timeClassifications).toEqual([]);
+  });
+
+  it('handles null input', () => {
+    expect(buildTimeClassifications(null)).toEqual([]);
+  });
+});
+
+// ── End-to-end: build-time nodes through the full data pipeline ─────────────
+
+describe('build-time data pipeline integration', () => {
+  const allClassifications = [
+    ...transformClassifications(classificationNodes),
+    ...buildTimeClassifications(transformIncidents(incidentNodes, entityNodes)),
+  ];
+
+  const grouped = groupClassificationsByIncident(allClassifications);
+
+  it('groups transformed classifications by incident', () => {
+    // Incident 1 carries CSETv1, GMF, and Time; incident 2 carries CSETv1 and Time.
+    expect(
+      grouped
+        .get(1)
+        .map((c) => c.namespace)
+        .sort()
+    ).toEqual(['CSETv1', 'GMF', 'Time']);
+    expect(
+      grouped
+        .get(2)
+        .map((c) => c.namespace)
+        .sort()
+    ).toEqual(['CSETv1', 'Time']);
+  });
+
+  it('cross-tabulates a taxonomy field against another taxonomy', () => {
+    const crossData = buildCrossData(
+      grouped,
+      'CSETv1',
+      'Harm Distribution Basis',
+      'GMF',
+      'Known AI Technology',
+      null,
+      null,
+      null
+    );
+
+    expect(crossData.incidentCount).toBe(1);
+    expect(crossData.pairs).toEqual([{ x: 'race', y: 'Face Recognition', count: 1, ids: [1] }]);
+  });
+
+  it('cross-tabulates a taxonomy field against the synthetic Time taxonomy', () => {
+    const crossData = buildCrossData(
+      grouped,
+      'Time',
+      'Year',
+      'CSETv1',
+      'Harm Distribution Basis',
+      null,
+      null,
+      null
+    );
+
+    expect(crossData.incidentCount).toBe(2);
+    expect(crossData.xValues).toEqual(['2019', '2021']);
+  });
+
+  it('computes field value frequencies over transformed classifications', () => {
+    const values = getFieldValues(allClassifications, 'CSETv1', 'Harm Distribution Basis');
+
+    expect(values).toEqual([
+      { value: 'race', count: 1 },
+      { value: 'sex', count: 1 },
+    ]);
+  });
+});

--- a/site/gatsby-site/src/utils/crossTaxonomy.js
+++ b/site/gatsby-site/src/utils/crossTaxonomy.js
@@ -1,0 +1,515 @@
+import { getClassificationValue } from './classifications';
+
+/**
+ * Splits a "namespace::field" selector key into its parts. Shared contract
+ * between the field-selector options and every consumer of those keys.
+ */
+export function parseKey(key) {
+  if (!key) return { namespace: '', field: '' };
+  const [namespace, ...rest] = key.split('::');
+
+  return { namespace, field: rest.join('::') };
+}
+
+/**
+ * Groups a flat array of classification documents by incident_id.
+ * Returns a Map<number, Classification[]>.
+ */
+export function groupClassificationsByIncident(classifications) {
+  const grouped = new Map();
+
+  for (const c of classifications) {
+    if (!c.incidents || c.incidents.length === 0) continue;
+    for (const incident of c.incidents) {
+      const id = incident.incident_id;
+
+      if (!grouped.has(id)) {
+        grouped.set(id, []);
+      }
+      grouped.get(id).push(c);
+    }
+  }
+  return grouped;
+}
+
+/**
+ * Returns a flat list of fields suitable for axis selection dropdowns,
+ * filtered to categorical/enumerable types.
+ */
+export function getAvailableFields(taxas) {
+  const categoricalTypes = ['enum', 'multi', 'list', 'bool'];
+
+  const seen = new Set();
+
+  const fields = [];
+
+  for (const taxa of taxas) {
+    for (const field of taxa.field_list) {
+      const key = `${taxa.namespace}::${field.short_name}`;
+
+      if (seen.has(key)) continue;
+      if (
+        categoricalTypes.includes(field.display_type) ||
+        (field.permitted_values && field.permitted_values.length > 0)
+      ) {
+        seen.add(key);
+        fields.push({
+          namespace: taxa.namespace,
+          short_name: field.short_name,
+          long_name: field.long_name,
+          display_type: field.display_type,
+          permitted_values: field.permitted_values,
+        });
+      }
+    }
+  }
+  return fields;
+}
+
+/**
+ * Strips a leading numeric index prefix from a category label.
+ * e.g. "3. Misinformation" -> "Misinformation", "12. Something" -> "Something"
+ * Matches the pattern used by the MIT AI Risk Repository taxonomy.
+ * Has no effect on values that don't start with a number.
+ */
+function stripNumericPrefix(v) {
+  return v.replace(/^\d+\.\s*/, '');
+}
+
+/**
+ * Extracts a flat array of string values from a classification for a given field.
+ * Handles strings, arrays, booleans, and nulls.
+ */
+function extractValues(classification, fieldName) {
+  const raw = getClassificationValue(classification, fieldName);
+
+  if (raw === null || raw === undefined || raw === '') return [];
+  if (typeof raw === 'boolean') return [raw ? 'Yes' : 'No'];
+  if (Array.isArray(raw))
+    return raw
+      .filter((v) => v !== null && v !== undefined && v !== '')
+      .map((v) => stripNumericPrefix(String(v)));
+  if (typeof raw === 'string') {
+    // Handle semicolon-separated values (e.g., CSETv1 "System Developer": "Google; DeepMind")
+    if (raw.includes('; ')) {
+      return raw
+        .split('; ')
+        .map((v) => stripNumericPrefix(v.trim()))
+        .filter((v) => v !== '');
+    }
+
+    return [stripNumericPrefix(raw)];
+  }
+  return [stripNumericPrefix(String(raw))];
+}
+
+/**
+ * Builds cross-taxonomy co-occurrence data from grouped classifications.
+ *
+ * Returns {
+ *   pairs: Array<{ x: string, y: string, count: number, ids: number[] }>,  // every x/y value pair
+ *   matrix: Map<string, Map<string, number>>, // xValue -> yValue -> count
+ *   xValues: string[],
+ *   yValues: string[],
+ *   incidentCount: number,  // incidents contributing data
+ *   totalPairs: number,
+ * }
+ */
+export function buildCrossData(
+  groupedClassifications,
+  xNamespace,
+  xField,
+  yNamespace,
+  yField,
+  filterNamespace,
+  filterField,
+  filterValue
+) {
+  const matrix = new Map();
+
+  const xValuesSet = new Set();
+
+  const yValuesSet = new Set();
+
+  // xValue -> yValue -> Set<incident_id>, mirrors `matrix` but tracks which
+  // incidents land in each cell so the chart's "Incident IDs" view can list them.
+  const idMatrix = new Map();
+
+  let incidentCount = 0;
+
+  let totalPairs = 0;
+
+  for (const [incidentId, classifications] of groupedClassifications) {
+    // Apply optional filter
+    if (filterNamespace && filterField && filterValue) {
+      const filterClassification = classifications.find((c) => c.namespace === filterNamespace);
+
+      if (!filterClassification) continue;
+
+      const filterValues = extractValues(filterClassification, filterField);
+
+      if (!filterValues.includes(filterValue)) continue;
+    }
+
+    const xClassification = classifications.find((c) => c.namespace === xNamespace);
+
+    const yClassification = classifications.find((c) => c.namespace === yNamespace);
+
+    if (!xClassification || !yClassification) continue;
+
+    const xVals = extractValues(xClassification, xField);
+
+    const yVals = extractValues(yClassification, yField);
+
+    if (xVals.length === 0 || yVals.length === 0) continue;
+
+    incidentCount++;
+
+    for (const xv of xVals) {
+      xValuesSet.add(xv);
+      if (!matrix.has(xv)) matrix.set(xv, new Map());
+      const row = matrix.get(xv);
+
+      if (!idMatrix.has(xv)) idMatrix.set(xv, new Map());
+      const idRow = idMatrix.get(xv);
+
+      for (const yv of yVals) {
+        yValuesSet.add(yv);
+        row.set(yv, (row.get(yv) || 0) + 1);
+        totalPairs++;
+
+        if (!idRow.has(yv)) idRow.set(yv, new Set());
+        idRow.get(yv).add(incidentId);
+      }
+    }
+  }
+
+  const xValues = Array.from(xValuesSet).sort();
+
+  const yValues = Array.from(yValuesSet).sort();
+
+  const pairs = [];
+
+  for (const xv of xValues) {
+    for (const yv of yValues) {
+      const count = matrix.get(xv)?.get(yv) || 0;
+
+      if (count > 0) {
+        const ids = Array.from(idMatrix.get(xv)?.get(yv) || []).sort((a, b) => a - b);
+
+        pairs.push({ x: xv, y: yv, count, ids });
+      }
+    }
+  }
+
+  return { pairs, matrix, xValues, yValues, incidentCount, totalPairs };
+}
+
+/**
+ * Converts cross-data matrix into Billboard.js column format for bar/line charts.
+ * Each y-value becomes a data series; x-values are the categories.
+ */
+export function toBillboardColumns(crossData) {
+  const { xValues, yValues, matrix } = crossData;
+
+  const xColumn = ['x', ...xValues];
+
+  const dataColumns = yValues.map((yv) => [
+    yv,
+    ...xValues.map((xv) => matrix.get(xv)?.get(yv) || 0),
+  ]);
+
+  return [xColumn, ...dataColumns];
+}
+
+/**
+ * Converts cross-data into scatter-plot xs/columns format for Billboard.js.
+ * Each y-value series gets its own x-axis series keyed as `${yv}_x`.
+ */
+export function toScatterData(crossData) {
+  const { pairs, yValues } = crossData;
+
+  const { xValues } = crossData;
+
+  // For scatter, we map categorical values to numeric indices
+  const xIndex = new Map(xValues.map((v, i) => [v, i]));
+
+  const xs = {};
+
+  const columns = [];
+
+  for (const yv of yValues) {
+    const xKey = `${yv}_x`;
+
+    xs[yv] = xKey;
+    const xCol = [xKey];
+
+    const yCol = [yv];
+
+    for (const p of pairs) {
+      if (p.y === yv) {
+        xCol.push(xIndex.get(p.x));
+        yCol.push(p.count);
+      }
+    }
+    columns.push(xCol, yCol);
+  }
+
+  return { xs, columns, xValues };
+}
+
+/**
+ * Counts occurrences of a target field's values across incidents that match a filter.
+ * Used by guided analysis tabs to build single-field distributions.
+ *
+ * An optional secondary filter (extraNamespace/extraField/extraValue) further narrows
+ * the matched incidents. Pass null for all three to skip it. Used by ad-hoc charts in
+ * the guided tabs to layer an additional condition on top of the tab's primary selection.
+ *
+ * Returns {
+ *   counts: Map<string, number>,
+ *   total: number,
+ *   incidentCount: number,
+ *   incidentIdsByValue: Map<string, number[]>,  // target value -> contributing incident_ids
+ * }
+ */
+export function buildFilteredCounts(
+  groupedClassifications,
+  filterNamespace,
+  filterField,
+  filterValue,
+  targetNamespace,
+  targetField,
+  extraNamespace = null,
+  extraField = null,
+  extraValue = null
+) {
+  const counts = new Map();
+
+  // target value -> Set<incident_id>; deduped so an incident with a repeated
+  // value is listed once, then frozen into sorted arrays before returning.
+  const idsByValue = new Map();
+
+  let incidentCount = 0;
+
+  for (const [incidentId, classifications] of groupedClassifications) {
+    // Apply filter
+    const filterClassification = classifications.find((c) => c.namespace === filterNamespace);
+
+    if (!filterClassification) continue;
+
+    const filterValues = extractValues(filterClassification, filterField);
+
+    if (!filterValues.includes(filterValue)) continue;
+
+    // Apply optional secondary filter
+    if (extraNamespace && extraField && extraValue) {
+      const extraClassification = classifications.find((c) => c.namespace === extraNamespace);
+
+      if (!extraClassification) continue;
+
+      const extraValues = extractValues(extraClassification, extraField);
+
+      if (!extraValues.includes(extraValue)) continue;
+    }
+
+    // Extract target values
+    const targetClassification = classifications.find((c) => c.namespace === targetNamespace);
+
+    if (!targetClassification) continue;
+
+    const targetVals = extractValues(targetClassification, targetField);
+
+    if (targetVals.length === 0) continue;
+
+    incidentCount++;
+
+    for (const v of targetVals) {
+      counts.set(v, (counts.get(v) || 0) + 1);
+      if (!idsByValue.has(v)) idsByValue.set(v, new Set());
+      idsByValue.get(v).add(incidentId);
+    }
+  }
+
+  const total = Array.from(counts.values()).reduce((s, n) => s + n, 0);
+
+  const incidentIdsByValue = freezeIdsByValue(idsByValue);
+
+  return { counts, total, incidentCount, incidentIdsByValue };
+}
+
+/**
+ * Converts a Map<value, Set<incident_id>> into Map<value, number[]> with each
+ * id list sorted ascending. Shared by the filtered-count builders.
+ */
+function freezeIdsByValue(idsByValue) {
+  return new Map(
+    Array.from(idsByValue.entries()).map(([value, ids]) => [
+      value,
+      Array.from(ids).sort((a, b) => a - b),
+    ])
+  );
+}
+
+/**
+ * Collects all unique values for a given field across all classifications,
+ * sorted by frequency descending.
+ */
+export function getFieldValues(allClassifications, namespace, fieldName) {
+  const counts = new Map();
+
+  for (const c of allClassifications) {
+    if (c.namespace !== namespace) continue;
+    const vals = extractValues(c, fieldName);
+
+    for (const v of vals) {
+      counts.set(v, (counts.get(v) || 0) + 1);
+    }
+  }
+
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([value, count]) => ({ value, count }));
+}
+
+/**
+ * Counts total incidents matching a filter field/value.
+ */
+export function countFilteredIncidents(groupedClassifications, namespace, field, value) {
+  let count = 0;
+
+  for (const [, classifications] of groupedClassifications) {
+    const classification = classifications.find((c) => c.namespace === namespace);
+
+    if (!classification) continue;
+    const vals = extractValues(classification, field);
+
+    if (vals.includes(value)) count++;
+  }
+  return count;
+}
+
+// ── Entity-based helpers (developer / deployer / harmed parties) ──
+
+/**
+ * Builds a map from incident_id to entity names.
+ * Input: array of incident objects from GraphQL with entity sub-objects.
+ * Returns Map<number, { developers: string[], deployers: string[], harmedParties: string[] }>
+ */
+export function buildIncidentEntityMap(incidents) {
+  const map = new Map();
+
+  for (const inc of incidents) {
+    map.set(inc.incident_id, {
+      developers: (inc.AllegedDeveloperOfAISystem || []).map((e) => e.name),
+      deployers: (inc.AllegedDeployerOfAISystem || []).map((e) => e.name),
+      harmedParties: (inc.AllegedHarmedOrNearlyHarmedParties || []).map((e) => e.name),
+    });
+  }
+  return map;
+}
+
+/**
+ * Returns unique entity values sorted by frequency descending.
+ * entityField is 'developers', 'deployers', or 'harmedParties'.
+ */
+export function getEntityValues(incidentEntityMap, entityField) {
+  const counts = new Map();
+
+  for (const [, entities] of incidentEntityMap) {
+    const values = entities[entityField] || [];
+
+    for (const v of values) {
+      counts.set(v, (counts.get(v) || 0) + 1);
+    }
+  }
+
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([value, count]) => ({ value, count }));
+}
+
+/**
+ * Counts incidents that include a specific entity value.
+ */
+export function countEntityIncidents(incidentEntityMap, entityField, entityValue) {
+  let count = 0;
+
+  for (const [, entities] of incidentEntityMap) {
+    if ((entities[entityField] || []).includes(entityValue)) count++;
+  }
+  return count;
+}
+
+/**
+ * Builds classification field counts for incidents that match an entity filter.
+ * Finds incidents with the given entity, looks up their classifications, and
+ * extracts values for the target field.
+ *
+ * An optional secondary classification filter (extraNamespace/extraField/extraValue)
+ * further narrows the matched incidents. Pass null for all three to skip it. Used by
+ * ad-hoc charts in the entity guided tabs to layer an extra condition on the selection.
+ *
+ * Returns {
+ *   counts: Map<string, number>,
+ *   total: number,
+ *   incidentCount: number,
+ *   incidentIdsByValue: Map<string, number[]>,  // target value -> contributing incident_ids
+ * }
+ */
+export function buildEntityFilteredCounts(
+  groupedClassifications,
+  incidentEntityMap,
+  entityField,
+  entityValue,
+  targetNamespace,
+  targetField,
+  extraNamespace = null,
+  extraField = null,
+  extraValue = null
+) {
+  const counts = new Map();
+
+  const idsByValue = new Map();
+
+  let incidentCount = 0;
+
+  for (const [incidentId, classifications] of groupedClassifications) {
+    const entities = incidentEntityMap.get(incidentId);
+
+    if (!entities || !(entities[entityField] || []).includes(entityValue)) continue;
+
+    // Apply optional secondary filter
+    if (extraNamespace && extraField && extraValue) {
+      const extraClassification = classifications.find((c) => c.namespace === extraNamespace);
+
+      if (!extraClassification) continue;
+
+      const extraValues = extractValues(extraClassification, extraField);
+
+      if (!extraValues.includes(extraValue)) continue;
+    }
+
+    const targetClassification = classifications.find((c) => c.namespace === targetNamespace);
+
+    if (!targetClassification) continue;
+
+    const targetVals = extractValues(targetClassification, targetField);
+
+    if (targetVals.length === 0) continue;
+
+    incidentCount++;
+
+    for (const v of targetVals) {
+      counts.set(v, (counts.get(v) || 0) + 1);
+      if (!idsByValue.has(v)) idsByValue.set(v, new Set());
+      idsByValue.get(v).add(incidentId);
+    }
+  }
+
+  const total = Array.from(counts.values()).reduce((s, n) => s + n, 0);
+
+  const incidentIdsByValue = freezeIdsByValue(idsByValue);
+
+  return { counts, total, incidentCount, incidentIdsByValue };
+}

--- a/site/gatsby-site/src/utils/crossTaxonomy.js
+++ b/site/gatsby-site/src/utils/crossTaxonomy.js
@@ -1,0 +1,504 @@
+import { getClassificationValue } from './classifications';
+
+/**
+ * Groups a flat array of classification documents by incident_id.
+ * Returns a Map<number, Classification[]>.
+ */
+export function groupClassificationsByIncident(classifications) {
+  const grouped = new Map();
+
+  for (const c of classifications) {
+    if (!c.incidents || c.incidents.length === 0) continue;
+    for (const incident of c.incidents) {
+      const id = incident.incident_id;
+
+      if (!grouped.has(id)) {
+        grouped.set(id, []);
+      }
+      grouped.get(id).push(c);
+    }
+  }
+  return grouped;
+}
+
+/**
+ * Returns a flat list of fields suitable for axis selection dropdowns,
+ * filtered to categorical/enumerable types.
+ */
+export function getAvailableFields(taxas) {
+  const categoricalTypes = ['enum', 'multi', 'list', 'bool'];
+
+  const seen = new Set();
+
+  const fields = [];
+
+  for (const taxa of taxas) {
+    for (const field of taxa.field_list) {
+      const key = `${taxa.namespace}::${field.short_name}`;
+
+      if (seen.has(key)) continue;
+      if (
+        categoricalTypes.includes(field.display_type) ||
+        (field.permitted_values && field.permitted_values.length > 0)
+      ) {
+        seen.add(key);
+        fields.push({
+          namespace: taxa.namespace,
+          short_name: field.short_name,
+          long_name: field.long_name,
+          display_type: field.display_type,
+          permitted_values: field.permitted_values,
+        });
+      }
+    }
+  }
+  return fields;
+}
+
+/**
+ * Strips a leading numeric index prefix from a category label.
+ * e.g. "3. Misinformation" -> "Misinformation", "12. Something" -> "Something"
+ * Matches the pattern used by the MIT AI Risk Repository taxonomy.
+ * Has no effect on values that don't start with a number.
+ */
+function stripNumericPrefix(v) {
+  return v.replace(/^\d+\.\s*/, '');
+}
+
+/**
+ * Extracts a flat array of string values from a classification for a given field.
+ * Handles strings, arrays, booleans, and nulls.
+ */
+function extractValues(classification, fieldName) {
+  const raw = getClassificationValue(classification, fieldName);
+
+  if (raw === null || raw === undefined || raw === '') return [];
+  if (typeof raw === 'boolean') return [raw ? 'Yes' : 'No'];
+  if (Array.isArray(raw))
+    return raw
+      .filter((v) => v !== null && v !== undefined && v !== '')
+      .map((v) => stripNumericPrefix(String(v)));
+  if (typeof raw === 'string') {
+    // Handle semicolon-separated values (e.g., CSETv1 "System Developer": "Google; DeepMind")
+    if (raw.includes('; ')) {
+      return raw
+        .split('; ')
+        .map((v) => stripNumericPrefix(v.trim()))
+        .filter((v) => v !== '');
+    }
+
+    return [stripNumericPrefix(raw)];
+  }
+  return [stripNumericPrefix(String(raw))];
+}
+
+/**
+ * Builds cross-taxonomy co-occurrence data from grouped classifications.
+ *
+ * Returns {
+ *   pairs: Array<{ x: string, y: string, count: number, ids: number[] }>,  // every x/y value pair
+ *   matrix: Map<string, Map<string, number>>, // xValue -> yValue -> count
+ *   xValues: string[],
+ *   yValues: string[],
+ *   incidentCount: number,  // incidents contributing data
+ *   totalPairs: number,
+ * }
+ */
+export function buildCrossData(
+  groupedClassifications,
+  xNamespace,
+  xField,
+  yNamespace,
+  yField,
+  filterNamespace,
+  filterField,
+  filterValue
+) {
+  const matrix = new Map();
+
+  const xValuesSet = new Set();
+
+  const yValuesSet = new Set();
+
+  // xValue -> yValue -> Set<incident_id>, mirrors `matrix` but tracks which
+  // incidents land in each cell so the chart's "Incident IDs" view can list them.
+  const idMatrix = new Map();
+
+  let incidentCount = 0;
+
+  let totalPairs = 0;
+
+  for (const [incidentId, classifications] of groupedClassifications) {
+    // Apply optional filter
+    if (filterNamespace && filterField && filterValue) {
+      const filterClassification = classifications.find((c) => c.namespace === filterNamespace);
+
+      if (!filterClassification) continue;
+
+      const filterValues = extractValues(filterClassification, filterField);
+
+      if (!filterValues.includes(filterValue)) continue;
+    }
+
+    const xClassification = classifications.find((c) => c.namespace === xNamespace);
+
+    const yClassification = classifications.find((c) => c.namespace === yNamespace);
+
+    if (!xClassification || !yClassification) continue;
+
+    const xVals = extractValues(xClassification, xField);
+
+    const yVals = extractValues(yClassification, yField);
+
+    if (xVals.length === 0 || yVals.length === 0) continue;
+
+    incidentCount++;
+
+    for (const xv of xVals) {
+      xValuesSet.add(xv);
+      if (!matrix.has(xv)) matrix.set(xv, new Map());
+      const row = matrix.get(xv);
+
+      if (!idMatrix.has(xv)) idMatrix.set(xv, new Map());
+      const idRow = idMatrix.get(xv);
+
+      for (const yv of yVals) {
+        yValuesSet.add(yv);
+        row.set(yv, (row.get(yv) || 0) + 1);
+        totalPairs++;
+
+        if (!idRow.has(yv)) idRow.set(yv, new Set());
+        idRow.get(yv).add(incidentId);
+      }
+    }
+  }
+
+  const xValues = Array.from(xValuesSet).sort();
+
+  const yValues = Array.from(yValuesSet).sort();
+
+  const pairs = [];
+
+  for (const xv of xValues) {
+    for (const yv of yValues) {
+      const count = matrix.get(xv)?.get(yv) || 0;
+
+      if (count > 0) {
+        const ids = Array.from(idMatrix.get(xv)?.get(yv) || []).sort((a, b) => a - b);
+
+        pairs.push({ x: xv, y: yv, count, ids });
+      }
+    }
+  }
+
+  return { pairs, matrix, xValues, yValues, incidentCount, totalPairs };
+}
+
+/**
+ * Converts cross-data matrix into Billboard.js column format for bar/line charts.
+ * Each y-value becomes a data series; x-values are the categories.
+ */
+export function toBillboardColumns(crossData) {
+  const { xValues, yValues, matrix } = crossData;
+
+  const xColumn = ['x', ...xValues];
+
+  const dataColumns = yValues.map((yv) => [
+    yv,
+    ...xValues.map((xv) => matrix.get(xv)?.get(yv) || 0),
+  ]);
+
+  return [xColumn, ...dataColumns];
+}
+
+/**
+ * Converts cross-data into scatter-plot xs/columns format for Billboard.js.
+ * Each y-value series gets its own x-axis series keyed as `${yv}_x`.
+ */
+export function toScatterData(crossData) {
+  const { pairs, yValues } = crossData;
+
+  const { xValues } = crossData;
+
+  // For scatter, we map categorical values to numeric indices
+  const xIndex = new Map(xValues.map((v, i) => [v, i]));
+
+  const xs = {};
+
+  const columns = [];
+
+  for (const yv of yValues) {
+    const xKey = `${yv}_x`;
+
+    xs[yv] = xKey;
+    const xCol = [xKey];
+
+    const yCol = [yv];
+
+    for (const p of pairs) {
+      if (p.y === yv) {
+        xCol.push(xIndex.get(p.x));
+        yCol.push(p.count);
+      }
+    }
+    columns.push(xCol, yCol);
+  }
+
+  return { xs, columns, xValues };
+}
+
+/**
+ * Counts occurrences of a target field's values across incidents that match a filter.
+ * Used by guided analysis tabs to build single-field distributions.
+ *
+ * An optional secondary filter (extraNamespace/extraField/extraValue) further narrows
+ * the matched incidents. Pass null for all three to skip it. Used by ad-hoc charts in
+ * the guided tabs to layer an additional condition on top of the tab's primary selection.
+ *
+ * Returns {
+ *   counts: Map<string, number>,
+ *   total: number,
+ *   incidentCount: number,
+ *   incidentIdsByValue: Map<string, number[]>,  // target value -> contributing incident_ids
+ * }
+ */
+export function buildFilteredCounts(
+  groupedClassifications,
+  filterNamespace,
+  filterField,
+  filterValue,
+  targetNamespace,
+  targetField,
+  extraNamespace = null,
+  extraField = null,
+  extraValue = null
+) {
+  const counts = new Map();
+
+  // target value -> Set<incident_id>; deduped so an incident with a repeated
+  // value is listed once, then frozen into sorted arrays before returning.
+  const idsByValue = new Map();
+
+  let incidentCount = 0;
+
+  for (const [incidentId, classifications] of groupedClassifications) {
+    // Apply filter
+    const filterClassification = classifications.find((c) => c.namespace === filterNamespace);
+
+    if (!filterClassification) continue;
+
+    const filterValues = extractValues(filterClassification, filterField);
+
+    if (!filterValues.includes(filterValue)) continue;
+
+    // Apply optional secondary filter
+    if (extraNamespace && extraField && extraValue) {
+      const extraClassification = classifications.find((c) => c.namespace === extraNamespace);
+
+      if (!extraClassification) continue;
+
+      const extraValues = extractValues(extraClassification, extraField);
+
+      if (!extraValues.includes(extraValue)) continue;
+    }
+
+    // Extract target values
+    const targetClassification = classifications.find((c) => c.namespace === targetNamespace);
+
+    if (!targetClassification) continue;
+
+    const targetVals = extractValues(targetClassification, targetField);
+
+    if (targetVals.length === 0) continue;
+
+    incidentCount++;
+
+    for (const v of targetVals) {
+      counts.set(v, (counts.get(v) || 0) + 1);
+      if (!idsByValue.has(v)) idsByValue.set(v, new Set());
+      idsByValue.get(v).add(incidentId);
+    }
+  }
+
+  const total = Array.from(counts.values()).reduce((s, n) => s + n, 0);
+
+  const incidentIdsByValue = freezeIdsByValue(idsByValue);
+
+  return { counts, total, incidentCount, incidentIdsByValue };
+}
+
+/**
+ * Converts a Map<value, Set<incident_id>> into Map<value, number[]> with each
+ * id list sorted ascending. Shared by the filtered-count builders.
+ */
+function freezeIdsByValue(idsByValue) {
+  return new Map(
+    Array.from(idsByValue.entries()).map(([value, ids]) => [
+      value,
+      Array.from(ids).sort((a, b) => a - b),
+    ])
+  );
+}
+
+/**
+ * Collects all unique values for a given field across all classifications,
+ * sorted by frequency descending.
+ */
+export function getFieldValues(allClassifications, namespace, fieldName) {
+  const counts = new Map();
+
+  for (const c of allClassifications) {
+    if (c.namespace !== namespace) continue;
+    const vals = extractValues(c, fieldName);
+
+    for (const v of vals) {
+      counts.set(v, (counts.get(v) || 0) + 1);
+    }
+  }
+
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([value, count]) => ({ value, count }));
+}
+
+/**
+ * Counts total incidents matching a filter field/value.
+ */
+export function countFilteredIncidents(groupedClassifications, namespace, field, value) {
+  let count = 0;
+
+  for (const [, classifications] of groupedClassifications) {
+    const classification = classifications.find((c) => c.namespace === namespace);
+
+    if (!classification) continue;
+    const vals = extractValues(classification, field);
+
+    if (vals.includes(value)) count++;
+  }
+  return count;
+}
+
+// ── Entity-based helpers (developer / deployer / harmed parties) ──
+
+/**
+ * Builds a map from incident_id to entity names.
+ * Input: array of incident objects from GraphQL with entity sub-objects.
+ * Returns Map<number, { developers: string[], deployers: string[], harmedParties: string[] }>
+ */
+export function buildIncidentEntityMap(incidents) {
+  const map = new Map();
+
+  for (const inc of incidents) {
+    map.set(inc.incident_id, {
+      developers: (inc.AllegedDeveloperOfAISystem || []).map((e) => e.name),
+      deployers: (inc.AllegedDeployerOfAISystem || []).map((e) => e.name),
+      harmedParties: (inc.AllegedHarmedOrNearlyHarmedParties || []).map((e) => e.name),
+    });
+  }
+  return map;
+}
+
+/**
+ * Returns unique entity values sorted by frequency descending.
+ * entityField is 'developers', 'deployers', or 'harmedParties'.
+ */
+export function getEntityValues(incidentEntityMap, entityField) {
+  const counts = new Map();
+
+  for (const [, entities] of incidentEntityMap) {
+    const values = entities[entityField] || [];
+
+    for (const v of values) {
+      counts.set(v, (counts.get(v) || 0) + 1);
+    }
+  }
+
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([value, count]) => ({ value, count }));
+}
+
+/**
+ * Counts incidents that include a specific entity value.
+ */
+export function countEntityIncidents(incidentEntityMap, entityField, entityValue) {
+  let count = 0;
+
+  for (const [, entities] of incidentEntityMap) {
+    if ((entities[entityField] || []).includes(entityValue)) count++;
+  }
+  return count;
+}
+
+/**
+ * Builds classification field counts for incidents that match an entity filter.
+ * Finds incidents with the given entity, looks up their classifications, and
+ * extracts values for the target field.
+ *
+ * An optional secondary classification filter (extraNamespace/extraField/extraValue)
+ * further narrows the matched incidents. Pass null for all three to skip it. Used by
+ * ad-hoc charts in the entity guided tabs to layer an extra condition on the selection.
+ *
+ * Returns {
+ *   counts: Map<string, number>,
+ *   total: number,
+ *   incidentCount: number,
+ *   incidentIdsByValue: Map<string, number[]>,  // target value -> contributing incident_ids
+ * }
+ */
+export function buildEntityFilteredCounts(
+  groupedClassifications,
+  incidentEntityMap,
+  entityField,
+  entityValue,
+  targetNamespace,
+  targetField,
+  extraNamespace = null,
+  extraField = null,
+  extraValue = null
+) {
+  const counts = new Map();
+
+  const idsByValue = new Map();
+
+  let incidentCount = 0;
+
+  for (const [incidentId, classifications] of groupedClassifications) {
+    const entities = incidentEntityMap.get(incidentId);
+
+    if (!entities || !(entities[entityField] || []).includes(entityValue)) continue;
+
+    // Apply optional secondary filter
+    if (extraNamespace && extraField && extraValue) {
+      const extraClassification = classifications.find((c) => c.namespace === extraNamespace);
+
+      if (!extraClassification) continue;
+
+      const extraValues = extractValues(extraClassification, extraField);
+
+      if (!extraValues.includes(extraValue)) continue;
+    }
+
+    const targetClassification = classifications.find((c) => c.namespace === targetNamespace);
+
+    if (!targetClassification) continue;
+
+    const targetVals = extractValues(targetClassification, targetField);
+
+    if (targetVals.length === 0) continue;
+
+    incidentCount++;
+
+    for (const v of targetVals) {
+      counts.set(v, (counts.get(v) || 0) + 1);
+      if (!idsByValue.has(v)) idsByValue.set(v, new Set());
+      idsByValue.get(v).add(incidentId);
+    }
+  }
+
+  const total = Array.from(counts.values()).reduce((s, n) => s + n, 0);
+
+  const incidentIdsByValue = freezeIdsByValue(idsByValue);
+
+  return { counts, total, incidentCount, incidentIdsByValue };
+}

--- a/site/gatsby-site/src/utils/crossTaxonomyStatic.js
+++ b/site/gatsby-site/src/utils/crossTaxonomyStatic.js
@@ -1,0 +1,114 @@
+/**
+ * Transforms Gatsby build-time query nodes into the plain shapes that the
+ * cross-taxonomy data-processing utils (utils/crossTaxonomy.js) consume.
+ *
+ * The /apps/cross-taxonomy page loads all of its data from the static build
+ * (see the page's `pageQuery`) instead of the runtime GraphQL API, so these
+ * functions are the seam between the Gatsby node shapes and the shapes the
+ * runtime API used to return. They are pure so they can be unit tested
+ * without Gatsby or a database.
+ */
+
+/**
+ * Filters taxa to publicly visible fields.
+ * Input: nodes from `allMongodbAiidprodTaxa`.
+ * Output: same shape, with field_list restricted to entries where public !== false.
+ * Taxa without a namespace or a field_list array are dropped.
+ */
+export function transformTaxas(taxaNodes) {
+  return (taxaNodes || [])
+    .filter((taxa) => taxa && taxa.namespace && Array.isArray(taxa.field_list))
+    .map((taxa) => ({
+      ...taxa,
+      field_list: taxa.field_list.filter((f) => f && f.public !== false),
+    }));
+}
+
+/**
+ * Normalizes classification nodes for the data-processing utils.
+ * Drops documents without an attributes array, and drops broken incident
+ * links (Gatsby's `@link(by: "incident_id")` resolves references to missing
+ * incidents as null entries).
+ * Output shape: { namespace, incidents: [{ incident_id }], attributes: [{ short_name, value_json }] }
+ */
+export function transformClassifications(classificationNodes) {
+  return (classificationNodes || [])
+    .filter((c) => c && c.namespace && Array.isArray(c.attributes))
+    .map((c) => ({
+      namespace: c.namespace,
+      attributes: c.attributes,
+      incidents: (c.incidents || []).filter((i) => i && typeof i.incident_id === 'number'),
+    }));
+}
+
+/**
+ * Resolves the raw entity-id arrays on incident nodes into { entity_id, name }
+ * objects, matching the shape the runtime GraphQL relationship fields returned
+ * and that buildIncidentEntityMap consumes.
+ * Ids with no matching entity are skipped, mirroring the runtime resolver
+ * (a find() over the entities collection returns nothing for them).
+ */
+export function transformIncidents(incidentNodes, entityNodes) {
+  const namesById = new Map(
+    (entityNodes || [])
+      .filter((e) => e && e.entity_id && typeof e.name === 'string' && e.name !== '')
+      .map((e) => [e.entity_id, e.name])
+  );
+
+  const resolveEntities = (ids) =>
+    (ids || [])
+      .filter((id) => namesById.has(id))
+      .map((id) => ({ entity_id: id, name: namesById.get(id) }));
+
+  return (incidentNodes || [])
+    .filter((inc) => inc && typeof inc.incident_id === 'number')
+    .map((inc) => ({
+      incident_id: inc.incident_id,
+      date: inc.date,
+      AllegedDeployerOfAISystem: resolveEntities(inc.Alleged_deployer_of_AI_system),
+      AllegedDeveloperOfAISystem: resolveEntities(inc.Alleged_developer_of_AI_system),
+      AllegedHarmedOrNearlyHarmedParties: resolveEntities(
+        inc.Alleged_harmed_or_nearly_harmed_parties
+      ),
+    }));
+}
+
+/**
+ * Synthetic "Time" taxa. Injecting it alongside the real taxa lets the
+ * existing data-processing functions treat the incident year as a regular
+ * taxonomy field, with zero changes to those utils.
+ */
+export function buildTimeTaxa() {
+  return {
+    namespace: 'Time',
+    weight: 0,
+    description: 'Year the incident was reported',
+    field_list: [
+      {
+        field_number: '0',
+        short_name: 'Year',
+        long_name: 'Year',
+        display_type: 'enum',
+        mongo_type: 'string',
+        permitted_values: [],
+        instant_facet: false,
+        public: true,
+      },
+    ],
+  };
+}
+
+/**
+ * Per-incident "Time" pseudo-classifications derived from incident dates.
+ * Incidents without a parseable date (string of at least 4 characters) are
+ * skipped. Expects incidents in the shape produced by transformIncidents.
+ */
+export function buildTimeClassifications(incidents) {
+  return (incidents || [])
+    .filter((inc) => inc && typeof inc.date === 'string' && inc.date.length >= 4)
+    .map((inc) => ({
+      namespace: 'Time',
+      incidents: [{ incident_id: inc.incident_id }],
+      attributes: [{ short_name: 'Year', value_json: JSON.stringify(inc.date.substring(0, 4)) }],
+    }));
+}


### PR DESCRIPTION
# Add cross-taxonomy visualization feature

## Summary

Adds a new analytics page at `/apps/cross-taxonomy` for exploring patterns across
AIID taxonomy fields (CSETv1, GMF, MIT) and incident entities (developers, deployers,
harmed parties).

It provides four guided views plus a freeform explorer:

- **By Developer / By Deployer** — pick an entity, see a dashboard of how incidents
  involving it break down across sectors, failure modes, affected demographics,
  intent, risk domains, and time.
- **By Technology** — same idea, keyed on a GMF AI technology.
- **By Affected** — a single tab with a mode toggle: structured demographic basis
  (CSETv1) or named harmed-party groups.
- **Custom Explorer** — choose any two taxonomy fields as X/Y axes and cross-reference
  them as a bar, stacked-bar, line, or scatter chart, with an optional filter.

Every chart supports bar/line/donut types, a `%` normalization toggle, and an
**Incident IDs** view that lists links back to the contributing `/cite` pages, so any
number on a chart traces back to its source incidents.

## Screenshots

<img width="1624" height="1056" alt="Screenshot 2026-06-11 at 2 31 23 PM" src="https://github.com/user-attachments/assets/1a94c281-9ce7-4042-b089-58f496f3db88" />
<img width="1624" height="1056" alt="Screenshot 2026-06-11 at 2 31 55 PM" src="https://github.com/user-attachments/assets/d259d37a-6b87-4243-b696-eb741b7411bd" />
<img width="1624" height="1056" alt="Screenshot 2026-06-11 at 2 32 23 PM" src="https://github.com/user-attachments/assets/b5a19522-2c1a-4670-a831-b1801484e8e0" />


## Scope & self-containment

This feature is deliberately self-contained for easy review:

- **No new dependencies** (no `package.json` / lockfile changes).
- **No existing files changed except one 6-line nav entry** in `config.js`.
- All new code lives under `site/gatsby-site/`:
  - `src/pages/apps/cross-taxonomy.js` — page + data load + URL state
  - `src/utils/crossTaxonomy.js` — pure data-processing layer
  - `src/components/visualizations/{ChartCard,CrossTaxonomyChart,GuidedAnalysisTab,SearchableSelect}.js`
  - `src/utils/__tests__/crossTaxonomy.test.js` + `jest.utils.config.js`
- All processing is client-side; no backend changes.

## Testing

- **57 unit tests** cover the pure data layer (`crossTaxonomy.js`), including the
  tricky data quirks: semicolon-separated multi-values (`"Google; DeepMind"`),
  MIT numeric-prefix stripping (`"3. Misinformation"` → `"Misinformation"`),
  boolean → Yes/No normalization, and `value_json` JSON-parsing.
- Run with: `npx jest --config jest.utils.config.js src/utils/__tests__/crossTaxonomy.test.js`
  (a separate node-env config so it runs without MongoDB/DOM).
- UI was verified manually against a full local DB snapshot.

## Responses to review feedback

**Commit history:** squashed to a single clean commit containing only the feature files.

**Claude Code prompt / time in app:** this was built with Claude Code across many
iterative sessions, so there isn't a single prompt I can quote — it was developed
incrementally through many prompts that refined behavior and visuals over time. I've
spent significant time running the app locally against a full data snapshot, clicking
through every tab and chart type to validate the output and tune the visuals.

**Level of human code review:** I have personally reviewed all of the code and
understand each design decision and its tradeoffs. The design and product direction were
mine — I decided what to build, which visualizations to include, and how the interactions
should behave — and the implementation was AI-assisted, with me reviewing and validating
each part. I wrote the unit tests to lock down the data-layer edge cases. For full
transparency, the notable design decisions and known limitations are listed below.

## Design decisions (intentional)

- **Two Billboard.js wrappers.** `ChartCard` uses a small hand-rolled wrapper
  (`bb.generate` in `useLayoutEffect` + guarded `destroy`) to avoid a React 18 Strict
  Mode unmount crash in Billboard's official React wrapper; `CrossTaxonomyChart` uses the
  official wrapper where it only remounts on user action and is safe.
- **Synthetic "Time" taxonomy.** A fake `Time` namespace with a `Year` field is derived
  client-side from each incident's date and injected into the same arrays as real
  classifications, so time flows through every data function with no special-casing.
- **Two data paths, one output shape.** Entity-based and classification-based filtering
  both return an identical `{ counts, total, incidentCount, incidentIdsByValue }` shape,
  so a single `ChartCard` renders both without knowing the source.

## Known limitations

- The incidents query uses a hardcoded `limit: 9999`. This is fine at the current
  incident count but would need pagination at larger scale.
- The page issues three large unpaginated `no-cache` queries on load (taxa, all
  classifications, all incidents) — relevant to the GraphQL rate-limiting already being
  considered.
- Dynamic chart titles are translated at runtime via `t(variable)`, so they won't be
  picked up by automated i18n string extraction; full localization would need manual key
  registration. Static UI chrome uses `<Trans>`.
- Automated tests cover the data layer only; the React components and page are verified
  manually.
- The field selector is a custom combobox with partial (not full WAI-ARIA) combobox
  semantics.
- Extra Custom Explorer graph panels are not URL-shareable (only the first panel writes
  to URL params).

## Open design questions

**Navigation placement.** The `config.js` change adds Cross-Taxonomy as its own
top-level nav item right after "Taxonomies". It could alternatively be folded into the
existing Taxonomies page as a second view — happy to go either way based on maintainer
preference.

## Future directions (feedback welcome)

A few enhancements I'm considering and would value maintainer input on before building:

- **Grouping / filtering the field selector.** The field picker currently lists every
  categorical field in one flat list, which is a lot to scan, and some fields only have
  one or two annotated incidents. I'd like to group fields by descriptors (optgroup-style)
  and optionally hide or de-emphasize very-low-coverage fields so the most useful
  dimensions surface first. Open question: should low-coverage fields be hidden, or just
  labeled with their incident count?
- **Reference/overlay series.** An option to draw a comparison line behind a chart — e.g.
  the overall distribution as a faint baseline behind the currently filtered selection —
  so users can see how a slice compares to the database as a whole.
- **Selectable time granularity.** The synthetic Time taxonomy currently derives only the
  year (first four characters of each incident's date). Making the bucket selectable
  (year / month / full date) would let users zoom the temporal resolution. 
