### PR TITLE
images, footer, etc. on email notifications

### DIFF
--- a/site/gatsby-site/server/emails/index.ts
+++ b/site/gatsby-site/server/emails/index.ts
@@ -8,6 +8,8 @@ export interface SendBulkEmailParams {
     recipients: {
         email: string;
         userId?: string;
+        // Per-recipient subject override; falls back to the shared `subject` below.
+        subject?: string;
         // Per-recipient overrides; merged on top of the shared dynamicData below.
         dynamicData?: Record<string, any>;
     }[];
@@ -126,7 +128,11 @@ export const sendBulkEmails = async ({ recipients, subject, dynamicData, templat
             .setFrom({ email: config.NOTIFICATIONS_SENDER, name: config.NOTIFICATIONS_SENDER_NAME })
             .setTo([new Recipient(recipient.email)])
             .setPersonalization(personalizations)
-            .setSubject(subject)
+            .setSubject(recipient.subject ?? subject)
+            // Lets mail clients surface a native unsubscribe control. MailerSend forwards this
+            // to the List-Unsubscribe header. NOTE: verify the value format MailerSend expects
+            // with a test send; a true one-click (RFC 8058) flow also needs a POST endpoint.
+            .setListUnsubscribe(`${config.SITE_URL}/account/`)
             .setHtml(html);
         //TODO: add a text version of the email
         // .setText("Greetings from the team, you got this message through MailerSend.");

--- a/site/gatsby-site/server/emails/templates/Notifications.ts
+++ b/site/gatsby-site/server/emails/templates/Notifications.ts
@@ -24,8 +24,34 @@ const getEmailTemplate = () => {
     border-radius: 4px;
   `);
 
+  const imageStyle = ignoreWhitespace(`
+    display: block;
+    width: 100%;
+    max-height: 200px;
+    object-fit: cover;
+    border: 0;
+    margin: 0 0 12px 0;
+  `);
+
+  const preheaderStyle = ignoreWhitespace(`
+    display: none;
+    max-height: 0px;
+    overflow: hidden;
+    mso-hide: all;
+  `);
+
+  const footerStyle = ignoreWhitespace(`
+    margin-top: 32px;
+    font-size: 85%;
+    color: #666;
+  `);
+
   return insertContent(
     `
+      <div style="${preheaderStyle}">
+        The latest incidents and updates from the AI Incident Database matching your subscriptions.
+      </div>
+
       <p style="margin-top: 0px;">
         Greetings,
       </p>
@@ -38,20 +64,31 @@ const getEmailTemplate = () => {
 
       {% if newIncidents and newIncidents|length > 0 %}
         <div style="${sectionStyle}">
-          <h2 style="font-size: 110%;">New Incidents</h2>
+          <h2 style="font-size: 110%;">New Incidents ({{ newIncidents|length }})</h2>
           {% for incident in newIncidents %}
             <div style="${incidentStyle}">
+              {% if incident.reportImageUrl %}
+                <img src="{{ incident.reportImageUrl }}" alt="Incident image" style="${imageStyle}">
+              {% endif %}
               <h3 style="font-size: 100%; margin-top: 0px;">
                 <a href="{{ incident.incidentUrl }}">Incident {{ incident.incidentId }}: {{ incident.incidentTitle }}</a>
               </h3>
               <p style="font-size: 85%;">{{ incident.incidentDate }}</p>
               <p style="font-size: 85%;">{{ incident.incidentDescription }}</p>
+              {% if incident.editorNotes %}
+                <p style="font-size: 85%;"><strong>Editor Notes</strong>: {{ incident.editorNotes }}</p>
+              {% endif %}
               <p style="margin-bottom: 0px; line-height: 1.75;">
                 <strong>Alleged</strong>:
                 <span style="${entityStyle}">{{ incident.developers }}</span> developed an AI system deployed by
                 <span style="${entityStyle}">{{ incident.deployers }}</span> which harmed
                 <span style="${entityStyle}">{{ incident.entitiesHarmed }}</span>.
               </p>
+              {% if incident.implicatedSystems %}
+                <p style="margin-bottom: 0px; margin-top: 8px; font-size: 85%;">
+                  AI systems implicated: <span style="${entityStyle}">{{ incident.implicatedSystems }}</span>.
+                </p>
+              {% endif %}
             </div>
           {% endfor %}
         </div>
@@ -59,7 +96,7 @@ const getEmailTemplate = () => {
 
       {% if entityEvents and entityEvents|length > 0 %}
         <div style="${sectionStyle}">
-          <h2 style="font-size: 110%;">Entity Updates</h2>
+          <h2 style="font-size: 110%;">Entity Updates ({{ entityEvents|length }})</h2>
           {% for event in entityEvents %}
             <div style="${incidentStyle}">
               <p style="margin-top: 0px;">
@@ -69,6 +106,9 @@ const getEmailTemplate = () => {
                   A new incident involving <a href="{{ event.entityUrl }}">{{ event.entityName }}</a> was added.
                 {% endif %}
               </p>
+              {% if event.reportImageUrl %}
+                <img src="{{ event.reportImageUrl }}" alt="Incident image" style="${imageStyle}">
+              {% endif %}
               <h3 style="font-size: 100%;">
                 <a href="{{ event.incidentUrl }}">Incident {{ event.incidentId }}: {{ event.incidentTitle }}</a>
               </h3>
@@ -80,6 +120,11 @@ const getEmailTemplate = () => {
                 <span style="${entityStyle}">{{ event.deployers }}</span> which harmed
                 <span style="${entityStyle}">{{ event.entitiesHarmed }}</span>.
               </p>
+              {% if event.implicatedSystems %}
+                <p style="margin-bottom: 0px; margin-top: 8px; font-size: 85%;">
+                  AI systems implicated: <span style="${entityStyle}">{{ event.implicatedSystems }}</span>.
+                </p>
+              {% endif %}
             </div>
           {% endfor %}
         </div>
@@ -87,7 +132,7 @@ const getEmailTemplate = () => {
 
       {% if incidentUpdates and incidentUpdates|length > 0 %}
         <div style="${sectionStyle}">
-          <h2 style="font-size: 110%;">Updates to Incidents You Follow</h2>
+          <h2 style="font-size: 110%;">Updates to Incidents You Follow ({{ incidentUpdates|length }})</h2>
           {% for update in incidentUpdates %}
             <div style="${incidentStyle}">
               {% if update.reportTitle %}
@@ -108,9 +153,12 @@ const getEmailTemplate = () => {
 
       {% if submissionsPromoted and submissionsPromoted|length > 0 %}
         <div style="${sectionStyle}">
-          <h2 style="font-size: 110%;">Your Approved Submissions</h2>
+          <h2 style="font-size: 110%;">Your Approved Submissions ({{ submissionsPromoted|length }})</h2>
           {% for submission in submissionsPromoted %}
             <div style="${incidentStyle}">
+              {% if submission.reportImageUrl %}
+                <img src="{{ submission.reportImageUrl }}" alt="Incident image" style="${imageStyle}">
+              {% endif %}
               <p style="margin-top: 0px;">
                 Your submission has been approved! View
                 <a href="{{ submission.incidentUrl }}">Incident {{ submission.incidentId }}: {{ submission.incidentTitle }}</a>.
@@ -122,9 +170,14 @@ const getEmailTemplate = () => {
         </div>
       {% endif %}
 
-      <p style="margin-bottom: 32px; margin-top: 32px;">
+      <p style="margin-bottom: 0px; margin-top: 32px;">
         Sincerely,<br>
         Responsible AI Collaborative
+      </p>
+
+      <p style="${footerStyle}">
+        You are receiving this email because you subscribed to notifications from the AI Incident Database.
+        <a href="https://incidentdatabase.ai/account/">Manage your subscriptions or unsubscribe</a>.
       </p>
     `,
     { title: 'AI Incident Database Notifications' }

--- a/site/gatsby-site/server/tests/notifications.spec.ts
+++ b/site/gatsby-site/server/tests/notifications.spec.ts
@@ -11,6 +11,10 @@ import templates from '../emails/templates';
 import { processNotifications } from '../../src/scripts/process-notifications';
 import nunjucks from 'nunjucks';
 
+// Mirrors formatIncidentDate() in process-notifications.ts so date assertions stay in sync.
+const formatDate = (date?: string) =>
+    date ? new Date(date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' }) : undefined;
+
 describe(`Notifications`, () => {
     let server: ApolloServer, url: string;
 
@@ -169,13 +173,15 @@ describe(`Notifications`, () => {
                 {
                     email: "test@test.com",
                     userId: "5f8f4b3b9b3e6f001f3b3b3b",
+                    subject: "AI Incident Database: 1 new incident",
                     dynamicData: {
                         newIncidents: [{
                             incidentId: "1",
                             incidentTitle: "Incident 1",
                             incidentUrl: config.SITE_URL + "/cite/1",
                             incidentDescription: "Incident 1 description",
-                            incidentDate: incidents[0].date,
+                            incidentDate: formatDate(incidents[0].date),
+                            reportImageUrl: "image_url",
                             developers: "",
                             deployers: "",
                             entitiesHarmed: "",
@@ -307,6 +313,7 @@ describe(`Notifications`, () => {
                 {
                     email: "test@test.com",
                     userId: "5f8f4b3b9b3e6f001f3b3b3b",
+                    subject: "AI Incident Database: 1 entity update",
                     dynamicData: {
                         newIncidents: [],
                         entityEvents: [{
@@ -314,7 +321,8 @@ describe(`Notifications`, () => {
                             incidentTitle: "Incident 1",
                             incidentUrl: config.SITE_URL + "/cite/1",
                             incidentDescription: "Incident 1 description",
-                            incidentDate: incidents[0].date,
+                            incidentDate: formatDate(incidents[0].date),
+                            reportImageUrl: "image_url",
                             entityName: "Entity 1",
                             entityUrl: config.SITE_URL + "/entities/entity-1",
                             developers: "",
@@ -446,6 +454,7 @@ describe(`Notifications`, () => {
                 {
                     email: "test@test.com",
                     userId: "5f8f4b3b9b3e6f001f3b3b3b",
+                    subject: "AI Incident Database: 1 incident update",
                     dynamicData: {
                         newIncidents: [],
                         entityEvents: [],
@@ -578,6 +587,7 @@ describe(`Notifications`, () => {
                 {
                     email: "test@test.com",
                     userId: "5f8f4b3b9b3e6f001f3b3b3b",
+                    subject: "AI Incident Database: 1 incident update",
                     dynamicData: {
                         newIncidents: [],
                         entityEvents: [],
@@ -740,6 +750,7 @@ describe(`Notifications`, () => {
                 {
                     email: "test@test.com",
                     userId: "5f8f4b3b9b3e6f001f3b3b3b",
+                    subject: "AI Incident Database: 1 approved submission",
                     dynamicData: {
                         newIncidents: [],
                         entityEvents: [],
@@ -749,13 +760,15 @@ describe(`Notifications`, () => {
                             incidentTitle: "Incident 1",
                             incidentUrl: config.SITE_URL + "/cite/1",
                             incidentDescription: "Incident 1 description",
-                            incidentDate: incidents[0].date,
+                            incidentDate: formatDate(incidents[0].date),
+                            reportImageUrl: "image_url",
                         }],
                     },
                 },
                 {
                     email: "user2@test.com",
                     userId: "60a7c5b7b4f5b8a6d8f9c7e4",
+                    subject: "AI Incident Database: 1 approved submission",
                     dynamicData: {
                         newIncidents: [],
                         entityEvents: [],
@@ -765,7 +778,7 @@ describe(`Notifications`, () => {
                             incidentTitle: "Incident 2",
                             incidentUrl: config.SITE_URL + "/cite/2",
                             incidentDescription: "Incident 2 description",
-                            incidentDate: incidents[1].date,
+                            incidentDate: formatDate(incidents[1].date),
                         }],
                     },
                 },
@@ -1437,7 +1450,8 @@ describe(`Notifications`, () => {
             incidentTitle: "Incident 1",
             incidentUrl: "http://localhost:8000/cite/1",
             incidentDescription: "Incident 1 description",
-            incidentDate: incidents[0].date,
+            incidentDate: formatDate(incidents[0].date),
+            reportImageUrl: "image_url",
             deployers: "<a href=\"http://localhost:8000/entities/entity-1\">Entity 1</a>",
             developers: "<a href=\"http://localhost:8000/entities/entity-1\">Entity 1</a>",
             entitiesHarmed: "<a href=\"http://localhost:8000/entities/entity-1\">Entity 1</a>",
@@ -1453,7 +1467,7 @@ describe(`Notifications`, () => {
                 name: config.NOTIFICATIONS_SENDER_NAME,
             },
             to: [{ email: "test@test.com", name: undefined }],
-            subject: "AI Incident Database Notifications",
+            subject: "AI Incident Database: 1 new incident",
             html: templates.Notifications,
             personalization: [
                 {
@@ -1477,7 +1491,7 @@ describe(`Notifications`, () => {
                 name: config.NOTIFICATIONS_SENDER_NAME,
             },
             to: [{ email: "test2@test.com", name: undefined }],
-            subject: "AI Incident Database Notifications",
+            subject: "AI Incident Database: 1 new incident",
             html: templates.Notifications,
             personalization: [
                 {
@@ -1777,11 +1791,13 @@ describe(`Notifications`, () => {
                     incidentTitle: 'Test New Incident',
                     incidentUrl: config.SITE_URL + '/cite/741',
                     incidentDescription: 'A new incident description.',
-                    incidentDate: '2023-10-02',
+                    incidentDate: 'October 2, 2023',
+                    reportImageUrl: config.SITE_URL + '/img/incident-741.jpg',
+                    editorNotes: 'Curated editor note for 741.',
                     developers: `<a href="${config.SITE_URL}/entities/openai">OpenAI</a>`,
                     deployers: `<a href="${config.SITE_URL}/entities/acme">Acme</a>`,
                     entitiesHarmed: `<a href="${config.SITE_URL}/entities/the-public">The Public</a>`,
-                    implicatedSystems: '',
+                    implicatedSystems: `<a href="${config.SITE_URL}/entities/gpt-4">GPT-4</a>`,
                 },
             ],
             entityEvents: [
@@ -1790,7 +1806,8 @@ describe(`Notifications`, () => {
                     incidentTitle: 'Entity Incident',
                     incidentUrl: config.SITE_URL + '/cite/742',
                     incidentDescription: 'An entity-related incident.',
-                    incidentDate: '2023-10-03',
+                    incidentDate: 'October 3, 2023',
+                    reportImageUrl: config.SITE_URL + '/img/incident-742.jpg',
                     developers: '',
                     deployers: '',
                     entitiesHarmed: '',
@@ -1816,18 +1833,31 @@ describe(`Notifications`, () => {
                     incidentTitle: 'Promoted Submission',
                     incidentUrl: config.SITE_URL + '/cite/743',
                     incidentDescription: 'Your submission is now an incident.',
-                    incidentDate: '2023-11-15',
+                    incidentDate: 'November 15, 2023',
+                    reportImageUrl: config.SITE_URL + '/img/incident-743.jpg',
                 },
             ],
         };
 
         const html = nunjucks.renderString(templates.Notifications, digest);
 
-        // All four section headers render when their arrays are populated.
-        expect(html).toContain('New Incidents');
-        expect(html).toContain('Entity Updates');
-        expect(html).toContain('Updates to Incidents You Follow');
-        expect(html).toContain('Your Approved Submissions');
+        // All four section headers render (with item counts) when populated.
+        expect(html).toContain('New Incidents (1)');
+        expect(html).toContain('Entity Updates (1)');
+        expect(html).toContain('Updates to Incidents You Follow (1)');
+        expect(html).toContain('Your Approved Submissions (1)');
+
+        // Hidden preheader (inbox preview) and the unsubscribe footer.
+        expect(html).toContain('The latest incidents and updates from the AI Incident Database');
+        expect(html).toContain('Manage your subscriptions or unsubscribe');
+
+        // Per-incident lead image.
+        expect(html).toContain(`src="${config.SITE_URL}/img/incident-741.jpg"`);
+
+        // Editor notes (New Incidents only) and implicated systems render when present.
+        expect(html).toContain('Editor Notes');
+        expect(html).toContain('Curated editor note for 741.');
+        expect(html).toContain('AI systems implicated');
 
         // Incident links come from literal template markup, so they survive regardless
         // of how the rendering engine escapes data-driven values.
@@ -1875,7 +1905,7 @@ describe(`Notifications`, () => {
 
         const html = nunjucks.renderString(templates.Notifications, digest);
 
-        expect(html).toContain('New Incidents');
+        expect(html).toContain('New Incidents (1)');
         expect(html).not.toContain('Entity Updates');
         expect(html).not.toContain('Updates to Incidents You Follow');
         expect(html).not.toContain('Your Approved Submissions');

--- a/site/gatsby-site/server/tests/notifications.spec.ts
+++ b/site/gatsby-site/server/tests/notifications.spec.ts
@@ -1892,6 +1892,7 @@ describe(`Notifications`, () => {
                     incidentUrl: config.SITE_URL + '/cite/741',
                     incidentDescription: 'desc',
                     incidentDate: '2023-10-02',
+                    reportImageUrl: '', // a report with no image stores image_url: '' (server/fields/reports.ts)
                     developers: '',
                     deployers: '',
                     entitiesHarmed: '',
@@ -1909,5 +1910,10 @@ describe(`Notifications`, () => {
         expect(html).not.toContain('Entity Updates');
         expect(html).not.toContain('Updates to Incidents You Follow');
         expect(html).not.toContain('Your Approved Submissions');
+
+        // An empty (or missing) image_url is falsy, so no incident <img> is emitted — the card
+        // renders without an image rather than a broken icon or placeholder. (The AIID header
+        // logo uses alt="AIID", so it is unaffected by this assertion.)
+        expect(html).not.toContain('alt="Incident image"');
     });
 });

--- a/site/gatsby-site/src/scripts/process-notifications.ts
+++ b/site/gatsby-site/src/scripts/process-notifications.ts
@@ -16,12 +16,32 @@ const buildEntityList = (allEntities: DBEntity[], entityIds: string[] = []) => {
     return `${entityNames.slice(0, - 1).join(', ')}, and ${entityNames[entityNames.length - 1]}`;
 }
 
+const DEFAULT_NOTIFICATION_SUBJECT = 'AI Incident Database Notifications';
+
+const DESCRIPTION_MAX_LENGTH = 500;
+
+// Keep one verbose incident from dominating the digest.
+const truncate = (text?: string | null, max = DESCRIPTION_MAX_LENGTH): string | undefined => {
+    if (!text) return undefined;
+    return text.length > max ? `${text.slice(0, max).trimEnd()}…` : text;
+};
+
+// Render stored dates (e.g. "2024-01-01") as "January 1, 2024".
+const formatIncidentDate = (date?: string | null): string | undefined => {
+    if (!date) return undefined;
+    const parsed = new Date(date);
+    if (isNaN(parsed.getTime())) return date;
+    return parsed.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' });
+};
+
 interface NewIncidentEntry {
     incidentId: string;
     incidentTitle: string;
     incidentUrl: string;
     incidentDescription?: string;
     incidentDate?: string;
+    reportImageUrl?: string;
+    editorNotes?: string;
     developers: string;
     deployers: string;
     entitiesHarmed: string;
@@ -49,6 +69,7 @@ interface SubmissionPromotedEntry {
     incidentUrl: string;
     incidentDescription?: string;
     incidentDate?: string;
+    reportImageUrl?: string;
 }
 
 interface UserDigest {
@@ -65,12 +86,27 @@ const emptyDigest = (): UserDigest => ({
     submissionsPromoted: [],
 });
 
-const incidentToNewIncidentEntry = (incident: DBIncident, allEntities: DBEntity[]): NewIncidentEntry => ({
+const pluralize = (count: number, noun: string): string => `${count} ${noun}${count === 1 ? '' : 's'}`;
+
+// A per-recipient subject summarizing the digest,
+// e.g. "AI Incident Database: 2 new incidents, 1 incident update".
+const buildNotificationSubject = (digest: UserDigest): string => {
+    const parts: string[] = [];
+    if (digest.newIncidents.length) parts.push(pluralize(digest.newIncidents.length, 'new incident'));
+    if (digest.entityEvents.length) parts.push(pluralize(digest.entityEvents.length, 'entity update'));
+    if (digest.incidentUpdates.length) parts.push(pluralize(digest.incidentUpdates.length, 'incident update'));
+    if (digest.submissionsPromoted.length) parts.push(pluralize(digest.submissionsPromoted.length, 'approved submission'));
+    return parts.length > 0 ? `AI Incident Database: ${parts.join(', ')}` : DEFAULT_NOTIFICATION_SUBJECT;
+};
+
+const incidentToNewIncidentEntry = (incident: DBIncident, allEntities: DBEntity[], reportImageUrl?: string): NewIncidentEntry => ({
     incidentId: `${incident.incident_id}`,
     incidentTitle: incident.title,
     incidentUrl: `${config.SITE_URL}/cite/${incident.incident_id}`,
-    incidentDescription: incident.description ?? undefined,
-    incidentDate: incident.date,
+    incidentDescription: truncate(incident.description),
+    incidentDate: formatIncidentDate(incident.date),
+    reportImageUrl,
+    editorNotes: incident.editor_notes ?? undefined,
     developers: buildEntityList(allEntities, incident['Alleged developer of AI system']),
     deployers: buildEntityList(allEntities, incident['Alleged deployer of AI system']),
     entitiesHarmed: buildEntityList(allEntities, incident['Alleged harmed or nearly harmed parties']),
@@ -140,14 +176,29 @@ export const processNotifications = async () => {
             .filter((id): id is number => typeof id === 'number')
     )];
 
-    const [entitySubs, incidentSubs] = await Promise.all([
+    // The lead image for each incident card comes from the incident's first report.
+    const firstReportNumbers = [...new Set(
+        incidents.map(i => i.reports?.[0]).filter((n): n is number => typeof n === 'number')
+    )];
+
+    const [entitySubs, incidentSubs, firstReports] = await Promise.all([
         entityIdsTouched.length > 0
             ? subscriptionsCollection.find({ type: 'entity', entityId: { $in: entityIdsTouched } }).toArray()
             : Promise.resolve([] as DBSubscription[]),
         incidentIdsTouchedForUpdates.length > 0
             ? subscriptionsCollection.find({ type: 'incident', incident_id: { $in: incidentIdsTouchedForUpdates } }).toArray()
             : Promise.resolve([] as DBSubscription[]),
+        firstReportNumbers.length > 0
+            ? reportsCollection.find({ report_number: { $in: firstReportNumbers } }).toArray()
+            : Promise.resolve([] as DBReport[]),
     ]);
+
+    const firstReportByNumber = new Map<number, DBReport>(firstReports.map(r => [r.report_number!, r]));
+    const imageForIncident = (incident: DBIncident): string | undefined => {
+        const firstReportNumber = incident.reports?.[0];
+        if (typeof firstReportNumber !== 'number') return undefined;
+        return (firstReportByNumber.get(firstReportNumber) ?? reportByNumber.get(firstReportNumber))?.image_url ?? undefined;
+    };
 
     // Build the per-user digest by walking each pending notification.
     const digestByUser = new Map<string, UserDigest>();
@@ -186,7 +237,7 @@ export const processNotifications = async () => {
             if (!incident) continue;
             includedNotifications.push(notification);
 
-            const entry = incidentToNewIncidentEntry(incident, allEntities);
+            const entry = incidentToNewIncidentEntry(incident, allEntities, imageForIncident(incident));
             for (const sub of newIncidentsSubs) {
                 if (dedupeAdd(seenNewIncident, sub.userId, incident.incident_id!)) {
                     ensureDigest(sub.userId).newIncidents.push(entry);
@@ -202,7 +253,7 @@ export const processNotifications = async () => {
             includedNotifications.push(notification);
 
             const subs = entitySubs.filter(s => s.entityId === entity.entity_id);
-            const base = incidentToNewIncidentEntry(incident, allEntities);
+            const base = incidentToNewIncidentEntry(incident, allEntities, imageForIncident(incident));
             const entry: EntityEventEntry = {
                 ...base,
                 entityName: entity.name,
@@ -257,8 +308,9 @@ export const processNotifications = async () => {
                 incidentId: `${incident.incident_id}`,
                 incidentTitle: incident.title,
                 incidentUrl: `${config.SITE_URL}/cite/${incident.incident_id}`,
-                incidentDescription: incident.description ?? undefined,
-                incidentDate: incident.date,
+                incidentDescription: truncate(incident.description),
+                incidentDate: formatIncidentDate(incident.date),
+                reportImageUrl: imageForIncident(incident),
             };
             if (dedupeAdd(seenSubmission, userId, incident.incident_id!)) {
                 ensureDigest(userId).submissionsPromoted.push(entry);
@@ -278,11 +330,15 @@ export const processNotifications = async () => {
     const resolvedRecipients = await userCacheManager.getAndCacheRecipients(userIds, context);
     const recipients = resolvedRecipients
         .filter(r => digestByUser.has(r.userId))
-        .map(r => ({
-            email: r.email,
-            userId: r.userId,
-            dynamicData: digestByUser.get(r.userId)!,
-        }));
+        .map(r => {
+            const digest = digestByUser.get(r.userId)!;
+            return {
+                email: r.email,
+                userId: r.userId,
+                subject: buildNotificationSubject(digest),
+                dynamicData: digest,
+            };
+        });
 
     if (recipients.length === 0) {
         await markNotificationsAsProcessed(notificationsCollection, includedNotifications);
@@ -296,7 +352,7 @@ export const processNotifications = async () => {
     try {
         const params: SendBulkEmailParams = {
             recipients,
-            subject: 'AI Incident Database Notifications',
+            subject: DEFAULT_NOTIFICATION_SUBJECT,
             templateId: 'Notifications',
         };
         await sendBulkEmails(params);


### PR DESCRIPTION
Improve the notifications email look and feel. Add images. Add unsubscribe information to the footer.

This requires testing in staging. Edit an incident attached to a subscribed entity. Ingest two new incidents -- one with an image and one without an image.