### PR TITLE
fix algolia sorting with package update

### DIFF
--- a/site/gatsby-site/playwright/e2e/unit/discover/routing.spec.ts
+++ b/site/gatsby-site/playwright/e2e/unit/discover/routing.spec.ts
@@ -13,13 +13,13 @@ test('Should parse back and forth a discover URL', async () => {
       '?authors=Christopher%20Knaus%7C%7CSam%20Levin&classifications=CSETv0%3AIntent%3AAccident&epoch_date_published_max=1670371200&hideDuplicates=1&is_incident_report=true&page=1&s=tesla&sortBy=published-date-asc&source_domain=theguardian.com',
   };
 
-  const result = parseURL({ location, indexName, queryConfig });
+  const result = parseURL({ location, indexName, queryConfig, locale: 'en' });
 
   const state = result[indexName];
 
   expect(state.query).toBe('tesla');
   expect(state.page).toBe(1);
-  expect(state.sortBy).toBe('published-date-asc');
+  expect(state.sortBy).toBe('instant_search-en_epoch_date_published_asc');
   expect(state.refinementList).toEqual({
     source_domain: ['theguardian.com'],
     authors: ['Christopher Knaus', 'Sam Levin'],

--- a/site/gatsby-site/src/components/discover/Discover.js
+++ b/site/gatsby-site/src/components/discover/Discover.js
@@ -102,7 +102,7 @@ export default function Discover() {
           getLocation: () => {
             return window.location;
           },
-          parseURL: ({ location }) => parseURL({ location, indexName, queryConfig, taxa }),
+          parseURL: ({ location }) => parseURL({ location, indexName, queryConfig, taxa, locale }),
           createURL: ({ routeState }) => {
             return createURL({ indexName, locale, queryConfig, routeState, taxa, display });
           },

--- a/site/gatsby-site/src/components/discover/Sorting.js
+++ b/site/gatsby-site/src/components/discover/Sorting.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useState } from 'react';
+import React, { Fragment, useEffect, useMemo, useState } from 'react';
 import { useSortBy } from 'react-instantsearch';
 import { Dropdown } from 'flowbite-react';
 import { Trans, useTranslation } from 'react-i18next';
@@ -11,10 +11,19 @@ export default function Sorting() {
 
   const { indexUiState } = useInstantSearch();
 
-  const { refine, currentRefinement, options } = useSortBy({ items: SORTING_LIST });
+  // useSortBy validates values against its items' `value` property, which must
+  // match the locale-specific index names used to refine.
+  const items = useMemo(
+    () => SORTING_LIST.map((item) => ({ ...item, value: item[`value_${locale}`] })),
+    [locale]
+  );
+
+  const { refine, currentRefinement } = useSortBy({ items });
 
   const [selectedItem, setSelectedItem] = useState(
-    SORTING_LIST.find((s) => s.name === currentRefinement) || SORTING_LIST.find((s) => s.default)
+    SORTING_LIST.find(
+      (s) => s.name === currentRefinement || s[`value_${locale}`] === currentRefinement
+    ) || SORTING_LIST.find((s) => s.default)
   );
 
   const { t } = useTranslation();
@@ -45,12 +54,15 @@ export default function Sorting() {
           data-cy="discover-sort"
           className="min-w-max"
         >
-          {options.map((item) => (
+          {SORTING_LIST.map((item) => (
             <Fragment key={item.name}>
               <Dropdown.Item
                 key={item[`value_${locale}`]}
                 value={item[`value_${locale}`]}
-                style={{ fontWeight: item.isRefined ? 'bold' : 'normal' }}
+                style={{
+                  fontWeight:
+                    item[`value_${locale}`] === selectedItem[`value_${locale}`] ? 'bold' : 'normal',
+                }}
                 onClick={() => {
                   sortResults(item);
                 }}

--- a/site/gatsby-site/src/components/discover/parseURL.js
+++ b/site/gatsby-site/src/components/discover/parseURL.js
@@ -1,5 +1,6 @@
 import { parse } from 'query-string';
 import { decodeQueryParams } from 'use-query-params';
+import SORTING_LIST from './SORTING_LISTS';
 
 const parseRefinements = ({ query }) => {
   const refinementKeys = [
@@ -57,7 +58,7 @@ const convertStringToRange = (query) => {
   return result;
 };
 
-const generateSearchState = ({ query }) => {
+const generateSearchState = ({ query, locale }) => {
   return {
     page: query.page,
     query: query.s ?? '',
@@ -67,7 +68,9 @@ const generateSearchState = ({ query }) => {
     range: {
       ...convertStringToRange(query),
     },
-    sortBy: query.sortBy,
+    // The URL stores the sorting option's short name, but instantsearch expects
+    // the index name and discards values it can't match against the sortBy items.
+    sortBy: SORTING_LIST.find((s) => s.name === query.sortBy)?.[`value_${locale}`] ?? query.sortBy,
     configure: {
       hitsPerPage: 28,
       distinct: query.hideDuplicates ? true : false,
@@ -75,12 +78,12 @@ const generateSearchState = ({ query }) => {
   };
 };
 
-export default function ({ location, indexName, queryConfig }) {
+export default function ({ location, indexName, queryConfig, locale = 'en' }) {
   const object = parse(location.search);
 
   const query = decodeQueryParams(queryConfig, object);
 
-  const searchState = generateSearchState({ query });
+  const searchState = generateSearchState({ query, locale });
 
   return { [indexName]: searchState };
 }


### PR DESCRIPTION
The Discover search doesn't sort one index — each sort option is a separate, per-language Algolia replica index: instant_search-en_epoch_incident_date_desc,
  instant_search-es_epoch_incident_date_desc, instant_search-fr_..., and so on. That's why SORTING_LIST carries a value_en, value_es, value_fr for every option. The URL, on the other hand,
  deliberately stores a locale-neutral short name (sortBy=incident-date-desc) so links work across languages. So converting a URL's sortBy into something InstantSearch can actually query has
  always been a locale-dependent lookup: short name + locale → index name. createURL.js already took locale for exactly this reason, in the reverse direction (index name → short name).

  What changed with the upgrade is which side of the boundary tolerates the untranslated value:

  - Old connector: whatever string was in uiState.sortBy got passed straight through as the index name, no questions asked. So parseURL could dump the raw short name into UI state, and
  Sorting.js — which has useLocalization() and therefore knows the locale — quietly fixed it up after mount by calling refine(item[value_${locale}]). The locale-dependent translation
  happened, it was just hidden inside the component, riding on the connector's tolerance for garbage values.
  - New connector: uiState.sortBy is validated against the widget's items and silently discarded if it doesn't match a known index name. The short name never survives long enough to reach
  Sorting.js's correction logic — it's dropped at UI-state hydration, before any component renders.

  So the translation now has to happen at parse time, inside parseURL — and since that function previously never did the mapping, it had never needed to know the locale. Passing locale in is
  just relocating information the flow always required to the place that now needs it first.

  The same logic applies to the second locale-related change, in Sorting.js: the new connector's validation table is keyed by each item's value property, and SORTING_LIST built value from the
  English index name only. Under the old permissive connector that mismatch was invisible; under the new one, a Spanish user clicking a sort option would refine to instant_search-es_...,
  which wouldn't be in a lookup table keyed by instant_search-en_... values. Setting value: item[value_${locale}] makes the validation table match what the component actually refines with.

  In short: the dependency update didn't create the locale dependency — it removed the leniency that let the code defer locale-aware translation until after UI-state hydration.