### PR TITLE
prevent crash when editor name is blank

### DIFF
--- a/site/gatsby-site/src/components/cite/citationTypes/BibTex.js
+++ b/site/gatsby-site/src/components/cite/citationTypes/BibTex.js
@@ -22,9 +22,9 @@ const BibTex = ({ nodes, incidentDate, incident_id, incidentTitle, editors }) =>
   // Only return the earliest submitter
   let submitterCite = getFormattedName(docs[0]['submitters'][0]);
 
-  const [firstEditor] = editors;
+  const [firstEditor] = editors.filter((editor) => editor && editor.first_name && editor.last_name);
 
-  const { first_name, last_name } = firstEditor;
+  const { first_name = '', last_name = '' } = firstEditor ?? {};
 
   const bibTex =
     '@article {' +

--- a/site/gatsby-site/src/components/cite/citationTypes/Citation.js
+++ b/site/gatsby-site/src/components/cite/citationTypes/Citation.js
@@ -41,11 +41,11 @@ const Citation = ({ nodes, incidentDate, incident_id, incidentTitle, editors }) 
     setRetrievalString(text);
   }, []);
 
-  const [firstEditor] = editors;
+  const [firstEditor] = editors.filter((editor) => editor && editor.first_name && editor.last_name);
 
-  const { first_name, last_name: editorLastName } = firstEditor;
+  const { first_name = '', last_name: editorLastName = '' } = firstEditor ?? {};
 
-  const editorFirstNameInitial = first_name[0] + '.';
+  const editorFirstNameInitial = first_name ? first_name[0] + '.' : '';
 
   const text = t(
     '{{submitterCite}}. ({{incidentDate}}) Incident Number {{incidentId}}: {{incidentTitle}}. in {{editorLastName}}, {{editorFirstNameInitial}} (ed.) <i>Artificial Intelligence Incident Database.</i> Responsible AI Collaborative. {{retrievalString}}',


### PR DESCRIPTION
If the editor has not specified their account name, then the app crashes.

The page dies client-side after hydration with TypeError: Cannot read properties of null (reading '0'), thrown from site/gatsby-site/src/components/cite/citationTypes/Citation.js:48:
  
  const [firstEditor] = editors;
  const { first_name, last_name: editorLastName } = firstEditor;
  const editorFirstNameInitial = first_name[0] + '.';   // ← throws

This popped up in staging, but I don't think it is currently a problem in production.