### PR TITLE
GitHub workflow for OECD crosslink

### DIFF
--- a/.github/workflows/update-oecd-relationships.yml
+++ b/.github/workflows/update-oecd-relationships.yml
@@ -1,0 +1,60 @@
+name: Update OECD Relationships
+
+on:
+  schedule:
+    - cron: "0 12 * * 2" # At 12:00 on Tuesday.
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Environment to update (production or staging)"
+        required: true
+        default: "staging"
+        type: choice
+        options:
+          - production
+          - staging
+      dry-run:
+        description: "Dry run (preview inserts without writing)"
+        required: true
+        default: true
+        type: boolean
+      max-new:
+        description: "Maximum number of new relationships allowed per run"
+        required: false
+        default: "50"
+
+jobs:
+  update:
+    name: Update OECD relationships (${{ matrix.environment }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        # Scheduled runs update staging and production; manual runs use the selected environment
+        environment: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.environment)) || fromJSON('["staging","production"]') }}
+    environment: ${{ matrix.environment }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: site/gatsby-site/package-lock.json
+
+      - name: Install dependencies
+        working-directory: site/gatsby-site
+        run: npm ci
+
+      - name: Update OECD relationships
+        working-directory: site/gatsby-site
+        run: npx tsx src/scripts/update-oecd-relationships.ts
+        env:
+          API_MONGODB_CONNECTION_STRING: ${{ secrets.API_MONGODB_CONNECTION_STRING }}
+          OECD_MATCHES_GITHUB_TOKEN: ${{ secrets.OECD_MATCHES_GITHUB_TOKEN }}
+          OECD_UPDATE_MAX_NEW: ${{ inputs.max-new || '50' }}
+          DRY_RUN: ${{ inputs.dry-run || 'false' }}

--- a/site/docs/OECD-IMPORT.md
+++ b/site/docs/OECD-IMPORT.md
@@ -9,11 +9,39 @@ The script converts AIID matches export JSON files into structured relationship 
 - Migration: `migrations/2025.05.20T12.00.00.import-oecd-relationships.ts`
 - Generated data: `migrations/data/oecd_relationships.json`
 
-## Prerequisites
+## Automated Updates
+
+The [Update OECD Relationships](../../.github/workflows/update-oecd-relationships.yml) GitHub Action keeps the `incident_links` collection up to date without requiring a migration. It runs weekly (Tuesdays at 12:00 UTC) against both staging and production, and can also be triggered manually via `workflow_dispatch` for a single environment (with an optional dry run).
+
+Each run:
+
+1. Downloads the latest `matches.json` from the private `oecd-ai-org/AIM-AIID-Matches` repository (via the `OECD_MATCHES_GITHUB_TOKEN` secret)
+2. Converts it to relationships with the same logic as `generate-oecd-relationships.ts`
+3. Inserts only relationships not already present, upserting on the unique key `(incident_id, sameAs, source_namespace)`; nothing is ever deleted
+
+Runtime safety checks abort the run without writing when:
+
+- More than `OECD_UPDATE_MAX_NEW` (default 50) new relationships would be inserted — large jumps should be reviewed by a human and imported via a migration or a manual run with a raised limit
+- The generated relationship count is less than half of the existing count, which indicates a broken or truncated upstream export
+- Any generated relationship fails shape validation
+
+The underlying script can also be run locally:
+
+```bash
+npm run update-oecd-relationships -- --inputFile=matches.json
+```
+
+**Required secrets (per GitHub environment):**
+- `API_MONGODB_CONNECTION_STRING`: the database to update (already configured for deploys)
+- `OECD_MATCHES_GITHUB_TOKEN`: a GitHub token with read access to `oecd-ai-org/AIM-AIID-Matches`
+
+## Manual Import via Migration
+
+For bulk imports (e.g. when the automated update's safety threshold is exceeded), relationships can be imported through a migration as described below.
+
+### Prerequisites
 
 Access to the OECD private repository is required to obtain the `matches.json` file containing the AIID matches export data. This file must be downloaded and placed in the project directory before running the import script.
-
-## Usage
 
 ### Generate Relationships
 
@@ -30,7 +58,7 @@ npm run generate-oecd-relationships -- --inputFile=PATH_TO_JSON_FILE --outputFil
 npm run generate-oecd-relationships -- --inputFile=matches.json --outputFile=migrations/data/oecd_relationships.json
 ```
 
-### Generate New Migration
+### Create the Migration
 
 To create a new migration file:
 

--- a/site/gatsby-site/package.json
+++ b/site/gatsby-site/package.json
@@ -161,6 +161,7 @@
     "restore-mongodb": "npx tsx --env-file=.env src/scripts/restore-mongodb.ts",
     "import-classifications-csv": "npx tsx --env-file=.env src/scripts/import-classifications-csv.ts",
     "generate-oecd-relationships": "npx tsx --env-file=.env src/scripts/generate-oecd-relationships.ts",
+    "update-oecd-relationships": "npx tsx --env-file=.env src/scripts/update-oecd-relationships.ts",
     "algolia-update": "npx tsx --env-file=.env src/scripts/algolia-update.ts",
     "algolia-update:ci": "npx tsx src/scripts/algolia-update.ts",
     "db:migrator": "npx tsx migrator"

--- a/site/gatsby-site/src/scripts/generate-oecd-relationships.ts
+++ b/site/gatsby-site/src/scripts/generate-oecd-relationships.ts
@@ -22,7 +22,7 @@ interface CommandLineArgs {
   outputFile: string;
 }
 
-interface AiidMatchEntry {
+export interface AiidMatchEntry {
   report?: {
     aiid_incident_ids?: number[];
   };
@@ -33,7 +33,7 @@ interface AiidMatchEntry {
   is_related: boolean;
 }
 
-interface IncidentRelationship {
+export interface IncidentRelationship {
   incident_id: number;
   sameAs: string;
   source_namespace: string;
@@ -54,7 +54,7 @@ function parseArgs(): CommandLineArgs {
     .parseSync();
 }
 
-function processMatchesJson(data: AiidMatchEntry[]): IncidentRelationship[] {
+export function processMatchesJson(data: AiidMatchEntry[]): IncidentRelationship[] {
   const relationships: IncidentRelationship[] = [];
 
   for (const entry of data) {
@@ -76,9 +76,12 @@ function processMatchesJson(data: AiidMatchEntry[]): IncidentRelationship[] {
   }
 
   const uniqueRelationships: IncidentRelationship[] = [];
+
   const seen = new Set<string>();
+
   for (const rel of relationships) {
     const key = `${rel.incident_id}|${rel.sameAs}`;
+
     if (!seen.has(key)) {
       seen.add(key);
       uniqueRelationships.push(rel);
@@ -98,6 +101,7 @@ async function writeRelationshipsToFile(relationships: IncidentRelationship[], o
   try {
 
     const directory = path.dirname(outputFilePath);
+
     if (!fs.existsSync(directory)) {
       fs.mkdirSync(directory, { recursive: true });
     }
@@ -122,6 +126,7 @@ async function main(): Promise<void> {
     
     console.log(chalk.blue(`Reading input file: ${args.inputFile}`));
     const jsonData = fs.readFileSync(args.inputFile, 'utf-8');
+
     const matchesData: AiidMatchEntry[] = JSON.parse(jsonData);
 
     console.log(chalk.blue(`Processing ${matchesData.length} entries from the JSON file...`));

--- a/site/gatsby-site/src/scripts/update-oecd-relationships.ts
+++ b/site/gatsby-site/src/scripts/update-oecd-relationships.ts
@@ -1,0 +1,202 @@
+/**
+ * Updates OECD incident relationships in the `incident_links` collection from the
+ * latest matches.json in the private oecd-ai-org/AIM-AIID-Matches repository.
+ *
+ * Usage: npm run update-oecd-relationships [-- --inputFile=PATH_TO_MATCHES_JSON]
+ *
+ * When --inputFile is omitted, matches.json is downloaded from GitHub using
+ * OECD_MATCHES_GITHUB_TOKEN (a token with read access to oecd-ai-org/AIM-AIID-Matches).
+ *
+ * Environment variables:
+ * - API_MONGODB_CONNECTION_STRING: connection string of the database to update (required)
+ * - OECD_MATCHES_GITHUB_TOKEN: GitHub token for downloading matches.json (required unless --inputFile is passed)
+ * - OECD_UPDATE_MAX_NEW: maximum number of new relationships allowed per run (default 50);
+ *   the script aborts without writing when the threshold is exceeded
+ * - DRY_RUN: set to "true" to preview changes without writing
+ *
+ * Relationships never present are inserted; existing relationships are left untouched.
+ * Nothing is ever deleted — relationships that disappear upstream are only reported.
+ */
+
+import fs from 'fs';
+import { MongoClient } from 'mongodb';
+import yargs from 'yargs/yargs';
+import { hideBin } from 'yargs/helpers';
+import {
+  AiidMatchEntry,
+  IncidentRelationship,
+  processMatchesJson,
+} from './generate-oecd-relationships';
+
+const MATCHES_REPO = 'oecd-ai-org/AIM-AIID-Matches';
+
+const MATCHES_FILE_PATH = 'matches.json';
+
+const DB_NAME = 'aiidprod';
+
+const DRY_RUN = process.env.DRY_RUN === 'true';
+
+const MAX_NEW_RELATIONSHIPS = parseInt(process.env.OECD_UPDATE_MAX_NEW || '50', 10);
+
+const relationshipKey = (r: { incident_id: number; sameAs: string; source_namespace: string }) =>
+  `${r.incident_id}|${r.sameAs}|${r.source_namespace}`;
+
+async function downloadMatches(): Promise<AiidMatchEntry[]> {
+  const token = process.env.OECD_MATCHES_GITHUB_TOKEN;
+
+  if (!token) {
+    throw new Error('OECD_MATCHES_GITHUB_TOKEN is required when --inputFile is not provided');
+  }
+
+  const url = `https://api.github.com/repos/${MATCHES_REPO}/contents/${MATCHES_FILE_PATH}`;
+
+  console.log(`Downloading ${MATCHES_FILE_PATH} from ${MATCHES_REPO}...`);
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      // matches.json exceeds the 1MB limit of the default contents response,
+      // so the raw media type is required
+      Accept: 'application/vnd.github.raw',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to download matches.json: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+function validateRelationships(relationships: IncidentRelationship[]): void {
+  if (relationships.length === 0) {
+    throw new Error('No relationships were generated from matches.json - aborting');
+  }
+
+  for (const r of relationships) {
+    const valid =
+      Number.isInteger(r.incident_id) &&
+      r.incident_id > 0 &&
+      typeof r.sameAs === 'string' &&
+      r.sameAs.startsWith('https://oecd.ai/en/incidents/') &&
+      r.source_namespace === 'OECD';
+
+    if (!valid) {
+      throw new Error(`Generated relationship failed validation: ${JSON.stringify(r)}`);
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const args = yargs(hideBin(process.argv))
+    .option('inputFile', {
+      description: 'Optional path to a local matches.json (skips the GitHub download)',
+      type: 'string',
+    })
+    .parseSync();
+
+  const connectionString = process.env.API_MONGODB_CONNECTION_STRING;
+
+  if (!connectionString) {
+    throw new Error('API_MONGODB_CONNECTION_STRING is required');
+  }
+
+  console.log(`Running in ${DRY_RUN ? 'DRY RUN' : 'LIVE'} mode`);
+
+  const matches: AiidMatchEntry[] = args.inputFile
+    ? JSON.parse(fs.readFileSync(args.inputFile, 'utf-8'))
+    : await downloadMatches();
+
+  console.log(`Processing ${matches.length} match entries...`);
+
+  const relationships = processMatchesJson(matches);
+
+  validateRelationships(relationships);
+
+  console.log(`Generated ${relationships.length} relationships`);
+
+  const client = new MongoClient(connectionString);
+
+  try {
+    await client.connect();
+
+    const collection = client.db(DB_NAME).collection('incident_links');
+
+    const existing = await collection.find({ source_namespace: 'OECD' }).toArray();
+
+    const existingKeys = new Set(existing.map((r: any) => relationshipKey(r)));
+
+    console.log(`Found ${existingKeys.size} existing OECD relationships in the database`);
+
+    // Sanity check: a drastically smaller upstream file most likely means the
+    // export is broken or truncated, not that matches were legitimately removed
+    if (relationships.length < existingKeys.size * 0.5) {
+      throw new Error(
+        `Generated relationship count (${relationships.length}) is less than half the existing count (${existingKeys.size}) - upstream data looks wrong, aborting`
+      );
+    }
+
+    const generatedKeys = new Set(relationships.map(relationshipKey));
+
+    const removedUpstream = [...existingKeys].filter((k) => !generatedKeys.has(k));
+
+    if (removedUpstream.length > 0) {
+      console.warn(
+        `Warning: ${removedUpstream.length} existing relationships are no longer present upstream (they will NOT be deleted):`
+      );
+      removedUpstream.forEach((k) => console.warn(`  ${k}`));
+    }
+
+    const newRelationships = relationships.filter((r) => !existingKeys.has(relationshipKey(r)));
+
+    console.log(`${newRelationships.length} new relationships to insert`);
+
+    newRelationships.forEach((r) => console.log(`  incident ${r.incident_id} -> ${r.sameAs}`));
+
+    // Safety check: an unusually large batch of new relationships likely means
+    // something changed upstream and a human should review before importing
+    if (newRelationships.length > MAX_NEW_RELATIONSHIPS) {
+      throw new Error(
+        `Refusing to insert ${newRelationships.length} new relationships (limit: ${MAX_NEW_RELATIONSHIPS}). ` +
+          `Review the changes and re-run with a higher OECD_UPDATE_MAX_NEW if they are expected.`
+      );
+    }
+
+    if (DRY_RUN) {
+      console.log('Dry run - no changes were written');
+      return;
+    }
+
+    let upserted = 0;
+
+    for (const relationship of newRelationships) {
+      // Upsert on the unique key (incident_id, sameAs, source_namespace) so
+      // concurrent or repeated runs cannot create duplicates
+      const result = await collection.updateOne(
+        {
+          incident_id: relationship.incident_id,
+          sameAs: relationship.sameAs,
+          source_namespace: relationship.source_namespace,
+        },
+        { $setOnInsert: relationship },
+        { upsert: true }
+      );
+
+      if (result.upsertedCount > 0) {
+        upserted += 1;
+      }
+    }
+
+    console.log(`OECD relationships update completed: ${upserted} new relationships inserted`);
+  } finally {
+    await client.close();
+  }
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('Error:', error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
New files

  .github/workflows/update-oecd-relationships.yml — runs weekly (Tuesdays 12:00 UTC) against both staging and production, and supports manual workflow_dispatch with an environment choice, a dry-run toggle (defaults to on for manual runs), and an adjustable max-new limit. It follows the repo's existing conventions (environment-scoped secrets, Node 20, npm ci in site/gatsby-site).

  site/gatsby-site/src/scripts/update-oecd-relationships.ts — downloads matches.json from the private OECD repo via the GitHub API, converts it using the same processMatchesJson logic as the existing generate script (now exported rather than duplicated), diffs against what's already in incident_links, and upserts only the missing relationships on the unique key. It never deletes — relationships that disappear upstream are only reported as warnings.

  Runtime safety checks

  - Insert cap: aborts without writing if more than OECD_UPDATE_MAX_NEW (default 50) new relationships would be inserted — large jumps get human review and go through a migration or a manual run with a raised limit.
  - Shrink guard: aborts if the generated set is less than half the existing count, which indicates a truncated or broken upstream export.
  - Shape validation: every record must have a positive integer incident_id, a https://oecd.ai/en/incidents/... URL, and the OECD namespace.

# Setup

Add an OECD_MATCHES_GITHUB_TOKEN secret (a token with read access to oecd-ai-org/AIM-AIID-Matches) to both the staging and production GitHub environments.