### PR TITLE
Feature embedding pipeline staging

### DIFF
--- a/.github/workflows/embed-incidents.yml
+++ b/.github/workflows/embed-incidents.yml
@@ -1,0 +1,70 @@
+name: Embed Incidents
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: The Github environment to load secrets from
+        type: string
+        required: true
+      limit:
+        description: Process at most this many incidents (blank = all)
+        type: string
+        required: false
+      resume:
+        description: Skip incidents already embedded with the current model
+        type: boolean
+        default: false
+        required: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  embed-incidents:
+    environment: ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    # Generous because a rate-limited endpoint can stretch a full run over several hours.
+    timeout-minutes: 300
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: lts/*
+
+      - name: Install NPM dependencies
+        run: npm ci
+        working-directory: site/gatsby-site
+
+      - name: Embed incidents
+        run: |
+          npm run embed-incidents:ci -- \
+            ${{ inputs.limit && format('--limit {0}', inputs.limit) || '' }} \
+            ${{ inputs.resume == true && '--resume' || '' }}
+        working-directory: site/gatsby-site
+        # The two credentials are secrets only. Everything below reads from a variable
+        # first and a secret second, so either place works, and a value set as a secret
+        # is masked in the log. Unset on both falls back to the code default.
+        env:
+          MONGODB_CONNECTION_STRING: ${{ secrets.MONGODB_CONNECTION_STRING }}
+          EMBEDDING_API_KEY: ${{ secrets.EMBEDDING_API_KEY }}
+          EMBEDDING_API_BASE_URL: ${{ vars.EMBEDDING_API_BASE_URL || secrets.EMBEDDING_API_BASE_URL }}
+          EMBEDDING_MODEL: ${{ vars.EMBEDDING_MODEL || secrets.EMBEDDING_MODEL }}
+          EMBEDDING_CONCURRENCY: ${{ vars.EMBEDDING_CONCURRENCY || secrets.EMBEDDING_CONCURRENCY }}
+          EMBEDDING_TIMEOUT_MS: ${{ vars.EMBEDDING_TIMEOUT_MS || secrets.EMBEDDING_TIMEOUT_MS }}
+          EMBEDDING_MAX_ATTEMPTS: ${{ vars.EMBEDDING_MAX_ATTEMPTS || secrets.EMBEDDING_MAX_ATTEMPTS }}
+          EMBEDDING_MAX_INPUT_CHARS: ${{ vars.EMBEDDING_MAX_INPUT_CHARS || secrets.EMBEDDING_MAX_INPUT_CHARS }}
+
+      # Uploaded even on failure, because that is when the manifest is worth reading.
+      - name: Upload failure manifest
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: embed-failures
+          path: site/gatsby-site/embed-failures.json
+          if-no-files-found: ignore

--- a/site/docs/README.md
+++ b/site/docs/README.md
@@ -56,6 +56,10 @@ Instruction on how to add a new field to an existing collection in the database
 
 Guide for importing OECD incident relationships into the database
 
+16. [Incident Embeddings](../gatsby-site/src/utils/embeddings/README.md)
+
+Batch pipeline that embeds every incident's title and report text into a vector, run on demand via GitHub Actions
+
 ## Getting Help
 
 1. Open issues on [GitHub](https://github.com/responsible-ai-collaborative/aiid/issues)

--- a/site/gatsby-site/.gitignore
+++ b/site/gatsby-site/.gitignore
@@ -15,3 +15,6 @@ node_modules
 
 /netlify/functions/lookupIndex.json
 /static/lookupIndex.json
+
+# Failure manifest from src/scripts/embed-incidents.ts
+embed-failures.json

--- a/site/gatsby-site/package.json
+++ b/site/gatsby-site/package.json
@@ -161,6 +161,8 @@
     "restore-mongodb": "npx tsx --env-file=.env src/scripts/restore-mongodb.ts",
     "import-classifications-csv": "npx tsx --env-file=.env src/scripts/import-classifications-csv.ts",
     "generate-oecd-relationships": "npx tsx --env-file=.env src/scripts/generate-oecd-relationships.ts",
+    "embed-incidents": "npx tsx --env-file=.env src/scripts/embed-incidents.ts",
+    "embed-incidents:ci": "npx tsx src/scripts/embed-incidents.ts",
     "algolia-update": "npx tsx --env-file=.env src/scripts/algolia-update.ts",
     "algolia-update:ci": "npx tsx src/scripts/algolia-update.ts",
     "db:migrator": "npx tsx migrator"

--- a/site/gatsby-site/src/scripts/embed-incidents.ts
+++ b/site/gatsby-site/src/scripts/embed-incidents.ts
@@ -1,0 +1,403 @@
+/**
+ * Generates an embedding for every incident from its title and report bodies.
+ *
+ * @example npm run embed-incidents -- --limit 5
+ * @example npm run embed-incidents -- --incident-id 1 --incident-id 2
+ * @example npm run embed-incidents -- --resume
+ *
+ * Each incident is written the moment it completes, so an interrupted run keeps
+ * everything it had already finished. `--resume` then skips those.
+ */
+
+import { MongoClient, type Collection } from 'mongodb';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import { writeFileSync } from 'fs';
+
+import { createEmbeddingProvider, EmbeddingRequestError } from '../utils/embeddings/provider';
+import { buildIncidentText, chunkText, poolVectors } from '../utils/embeddings/incidentText';
+
+const DB_NAME = 'aiidprod';
+const EMBEDDINGS_COLLECTION = 'incident_embeddings';
+
+/** Diagnostic list of what failed. The GitHub Action uploads this by name. */
+const FAILURES_FILE = 'embed-failures.json';
+
+/** How often to print a progress line during a long run. */
+const PROGRESS_EVERY = 50;
+
+/** How many failures in a row end the run. */
+const MAX_CONSECUTIVE_FAILURES = 10;
+
+/** Chunk size in characters, kept low because the model accepts much less than its advertised context. */
+const DEFAULT_MAX_INPUT_CHARS = 8000;
+
+/** How many times to shrink the char budget when the server reports a token overflow. */
+const MAX_REBUDGET_ATTEMPTS = 3;
+
+/** Floor for the shrinking budget, so a pathological input cannot spiral. */
+const MIN_INPUT_CHARS = 500;
+
+/** Formats a duration in ms as a compact human string: 950ms, 2.4s, 3m12s. */
+const formatDuration = (ms: number): string => {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+
+  const minutes = Math.floor(ms / 60_000);
+  const seconds = Math.round((ms % 60_000) / 1000);
+
+  if (minutes < 60) return `${minutes}m${String(seconds).padStart(2, '0')}s`;
+
+  return `${Math.floor(minutes / 60)}h${String(minutes % 60).padStart(2, '0')}m`;
+};
+
+/**
+ * failure manifest records enough to diagnose an incident without
+ * re-running it, and the file is uploaded as an artifact by the GitHub Action.
+ */
+interface Failure {
+  incident_id: number;
+  attempts: number;
+  status: number | null;
+  error: string;
+}
+
+const argv = yargs(hideBin(process.argv))
+  .usage('Usage: npm run embed-incidents -- [options]')
+  .option('incident-id', {
+    describe: 'Only embed these incident ids (repeatable)',
+    type: 'number',
+    array: true,
+  })
+  .option('limit', { describe: 'Process at most this many incidents', type: 'number' })
+  .option('resume', {
+    describe: 'Skip incidents already embedded with the current model',
+    type: 'boolean',
+    default: false,
+  })
+  .help()
+  .alias('h', 'help')
+  .parseSync();
+
+/**
+ * Runs the whole job: selects the incidents to embed, drives a pool of workers over them,
+ * and reports what happened. Returns the process exit code, which is 0 when everything
+ * succeeded, 1 on any failure or early stop, and 130 when a signal ended the run.
+ */
+const main = async () => {
+  const connectionString = process.env.MONGODB_CONNECTION_STRING;
+
+  if (!connectionString) {
+    throw new Error('MONGODB_CONNECTION_STRING is required.');
+  }
+
+  const provider = createEmbeddingProvider();
+  const maxInputChars = Number(process.env.EMBEDDING_MAX_INPUT_CHARS) || DEFAULT_MAX_INPUT_CHARS;
+  const concurrency = Number(process.env.EMBEDDING_CONCURRENCY) || 2;
+  const client = new MongoClient(connectionString);
+
+  await client.connect();
+
+  const db = client.db(DB_NAME);
+  const incidentsCollection = db.collection('incidents');
+  const reportsCollection = db.collection('reports');
+  const embeddingsCollection: Collection = db.collection(EMBEDDINGS_COLLECTION);
+
+  try {
+    const filter: Record<string, any> = {};
+
+    if (argv['incident-id']?.length) {
+      filter.incident_id = { $in: argv['incident-id'] };
+    }
+
+    // Anything that failed was never stored, so resume retries it as a matter of course.
+    if (argv.resume) {
+      const done = await embeddingsCollection.distinct('incident_id', { model: provider.model });
+
+      if (done.length > 0) {
+        filter.incident_id = filter.incident_id
+          ? { ...filter.incident_id, $nin: done }
+          : { $nin: done };
+
+        console.log(`resume: skipping ${done.length} incident(s) already embedded`);
+      }
+    }
+
+    const incidents = await incidentsCollection
+      .find(filter, { projection: { _id: 0, incident_id: 1, title: 1, reports: 1 } })
+      .sort({ incident_id: 1 })
+      // The driver treats a limit of 0 as no limit at all.
+      .limit(argv.limit ?? 0)
+      .toArray();
+
+    const rule = '-'.repeat(72);
+
+    console.log(rule);
+    console.log(`base url    ${provider.baseUrl}`);
+    console.log(`model       ${provider.model}`);
+    console.log(`writing to  ${DB_NAME}.${EMBEDDINGS_COLLECTION}`);
+    console.log(
+      `limits      max_input_chars=${maxInputChars} timeout=${formatDuration(
+        provider.timeoutMs
+      )} max_attempts=${provider.maxAttempts}`
+    );
+    console.log(`concurrency ${concurrency}`);
+    console.log(`incidents   ${incidents.length}`);
+    console.log(rule);
+
+    if (incidents.length === 0) {
+      console.log('Nothing to do.');
+      return 0;
+    }
+
+    // The unique index is what keeps concurrent workers from writing two rows for one incident.
+    await embeddingsCollection.createIndex({ incident_id: 1 }, { unique: true });
+
+    const startedAt = Date.now();
+    const latencies: number[] = [];
+    const failures: Failure[] = [];
+    let completed = 0;
+    let retried = 0;
+    let chunkedIncidents = 0;
+    let totalChunks = 0;
+    let cursor = 0;
+    let consecutiveFailures = 0;
+
+    /** Set when the run should stop dispatching new work: a signal or the breaker. */
+    let stopReason: string | null = null;
+
+    /**
+     * Writes the failure manifest to disk. It runs after every single failure, so a hard stop
+     * such as Ctrl-C or an Actions timeout still leaves the list behind. Failures are rare and
+     * the file is small, so the repeated writes cost nothing.
+     */
+    const flushFailures = () => {
+      if (failures.length === 0) return;
+
+      try {
+        writeFileSync(FAILURES_FILE, JSON.stringify(failures, null, 2));
+      } catch (e: any) {
+        console.error(`could not write failure manifest: ${e?.message || e}`);
+      }
+    };
+
+    for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+      process.on(signal, () => {
+        // A second signal falls through to the default handler and kills the process.
+        if (stopReason) return;
+        stopReason = `received ${signal}`;
+        console.warn(`${signal} received, finishing in-flight requests then stopping`);
+      });
+    }
+
+    /**
+     * Embeds a single incident and stores the result. It gathers the incident's reports,
+     * builds and chunks the text, calls the provider, pools the chunk vectors into one, and
+     * upserts the document. Throws on failure so the worker can record it and carry on.
+     */
+    const processOne = async (incident: any) => {
+      const incidentStartedAt = Date.now();
+
+      const reports = incident.reports?.length
+        ? await reportsCollection
+            .find(
+              { report_number: { $in: incident.reports } },
+              { projection: { _id: 0, report_number: 1, plain_text: 1, text: 1 } }
+            )
+            .toArray()
+        : [];
+
+      const text = buildIncidentText(incident, reports);
+      let chunks = chunkText(text, maxInputChars);
+
+      if (chunks.length === 0) {
+        throw new EmbeddingRequestError('incident has no title or report text to embed', {
+          status: null,
+          attempts: 0,
+          body: '',
+        });
+      }
+
+      if (chunks.length > 1) chunkedIncidents++;
+
+      totalChunks += chunks.length;
+
+      let budget = maxInputChars;
+      let result: Awaited<ReturnType<typeof provider.embed>> | null = null;
+
+      for (let shrink = 0; shrink <= MAX_REBUDGET_ATTEMPTS; shrink++) {
+        try {
+          // All chunks in one request, so a chunked incident is still a single call.
+          result = await provider.embed(chunks);
+          break;
+        } catch (e: any) {
+          const overflow =
+            e instanceof EmbeddingRequestError && e.status === 422
+              ? /input length (\d+) exceeds model maximum (\d+)/.exec(e.body)
+              : null;
+
+          if (!overflow || shrink === MAX_REBUDGET_ATTEMPTS) throw e;
+
+          const [, reported, maximum] = overflow;
+          const previousChunks = chunks.length;
+
+          // Chars per token range from about 4 for Latin text down to near 1 for CJK.
+          budget = Math.max(
+            MIN_INPUT_CHARS,
+            Math.floor(budget * (Number(maximum) / Number(reported)) * 0.8)
+          );
+
+          chunks = chunkText(text, budget);
+
+          totalChunks += chunks.length - previousChunks;
+
+          console.warn(
+            `incident ${incident.incident_id} exceeded the token limit ` +
+              `(${reported} > ${maximum}), re-chunking at ${budget} chars ` +
+              `into ${chunks.length} chunks`
+          );
+        }
+      }
+
+      // The loop above either assigned a result or threw, so the assertion is safe.
+      const { vectors, attempts, latencyMs } = result!;
+
+      latencies.push(latencyMs);
+
+      if (attempts > 1) retried++;
+
+      const vector = poolVectors(vectors);
+
+      // Upserting on incident_id means a re-run overwrites the row it wrote last time.
+      await embeddingsCollection.updateOne(
+        { incident_id: incident.incident_id },
+        {
+          $set: {
+            incident_id: incident.incident_id,
+            vector,
+            dims: vector.length,
+            model: provider.model,
+            base_url: provider.baseUrl,
+            chunks: chunks.length,
+            source_chars: text.length,
+            generated_at: new Date(),
+          },
+        },
+        { upsert: true }
+      );
+
+      const position = `${completed + failures.length + 1}/${incidents.length}`;
+
+      console.log(
+        `[${position}] incident ${incident.incident_id} ok ` +
+          `chunks=${chunks.length} chars=${text.length} dims=${vector.length} ` +
+          `attempts=${attempts} ${formatDuration(Date.now() - incidentStartedAt)}`
+      );
+    };
+
+    /**
+     * Pulls incidents off the shared cursor until they run out or the run is told to stop.
+     * Several of these run concurrently, and because they all advance the same cursor no two
+     * workers ever take the same incident. A failure is recorded here and the loop carries on,
+     * so one bad incident leaves the rest of the run intact.
+     */
+    const worker = async () => {
+      while (cursor < incidents.length && !stopReason) {
+        const incident = incidents[cursor++];
+
+        try {
+          await processOne(incident);
+          completed++;
+          consecutiveFailures = 0;
+        } catch (e: any) {
+          failures.push({
+            incident_id: incident.incident_id,
+            attempts: e instanceof EmbeddingRequestError ? e.attempts : 0,
+            status: e instanceof EmbeddingRequestError ? e.status : null,
+            error: e?.message || String(e),
+          });
+
+          console.error(`incident ${incident.incident_id} failed: ${e?.message || e}`);
+
+          flushFailures();
+
+          consecutiveFailures++;
+
+          // A quota error will hit every remaining incident, so stop the whole run now.
+          if (e instanceof EmbeddingRequestError && e.quotaExhausted) {
+            stopReason = 'provider reported quota exhaustion';
+          } else if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+            stopReason = `${consecutiveFailures} consecutive failures`;
+          }
+        }
+
+        const processed = completed + failures.length;
+
+        if (processed % PROGRESS_EVERY === 0 && processed < incidents.length) {
+          const elapsed = Date.now() - startedAt;
+          const remaining = Math.round((elapsed / processed) * (incidents.length - processed));
+
+          console.log(
+            `progress ${processed}/${incidents.length} ok=${completed} failed=${failures.length} ` +
+              `retried=${retried} elapsed=${formatDuration(elapsed)} eta=${formatDuration(
+                remaining
+              )}`
+          );
+        }
+      }
+    };
+
+    // Never fewer than one worker and never more workers than there are incidents.
+    await Promise.all(
+      Array.from({ length: Math.max(1, Math.min(concurrency, incidents.length)) }, worker)
+    );
+
+    const elapsed = Date.now() - startedAt;
+
+    const average = latencies.length
+      ? latencies.reduce((sum, value) => sum + value, 0) / latencies.length
+      : 0;
+
+    console.log(rule);
+
+    if (stopReason) {
+      console.error(`STOPPED EARLY  ${stopReason}`);
+      console.error(`not attempted  ${incidents.length - completed - failures.length} incident(s)`);
+    }
+
+    console.log(`succeeded   ${completed}/${incidents.length}`);
+    console.log(`failed      ${failures.length}`);
+    console.log(`retried     ${retried}`);
+    console.log(`chunked     ${chunkedIncidents} incident(s), ${totalChunks} chunk(s) total`);
+    console.log(`wall time   ${formatDuration(elapsed)}`);
+    console.log(`latency     avg=${formatDuration(average)}`);
+
+    if (failures.length > 0) {
+      flushFailures();
+      console.error(`failure manifest written to ${FAILURES_FILE}`);
+    }
+
+    if (stopReason || failures.length > 0) {
+      console.error('resume with: npm run embed-incidents -- --resume');
+    }
+
+    console.log(rule);
+
+    // 130 is the conventional exit code for a process stopped by a signal.
+    if (stopReason) return stopReason.startsWith('received SIG') ? 130 : 1;
+
+    return failures.length > 0 ? 1 : 0;
+  } finally {
+    await client.close();
+  }
+};
+
+if (require.main === module) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((e) => {
+      console.error(e);
+      process.exit(1);
+    });
+}

--- a/site/gatsby-site/src/utils/embeddings/README.md
+++ b/site/gatsby-site/src/utils/embeddings/README.md
@@ -1,0 +1,306 @@
+# Incident Embeddings
+
+This directory holds the embedding pipeline: a batch job that turns every incident into a
+single vector and stores it in MongoDB, so incidents can be compared by meaning rather
+than by keyword.
+
+An incident document has no article body of its own, only a `title`. The text worth
+embedding lives on its reports, reached through the `incidents.reports` array of
+`report_number` join keys. The pipeline joins the two, embeds the result, and writes one
+document per incident to `aiidprod.incident_embeddings`.
+
+This is separate from the per-report embeddings the site already uses for the
+"Most Semantically Similar Incidents" panel. Those are generated at submission time and
+stored on each report. These are generated in bulk, for the whole corpus, from a model
+that is configured entirely through environment variables.
+
+## What It Does
+
+For each incident:
+
+1. Reads the incident and every report it links to.
+2. Joins the title and the report bodies into one string, with reports sorted by
+   `report_number` so the same incident produces byte-identical input on every run.
+3. Splits that string into chunks at paragraph boundaries if it exceeds the character
+   budget. At the default budget about 44% of incidents fit in a single chunk, and the
+   whole corpus of roughly 1,550 incidents becomes roughly 4,600 chunks.
+4. Sends all chunks in one request. The API accepts an array and returns one embedding
+   per element, so a chunked incident is still a single call.
+5. Averages the chunk vectors component-wise and normalises the result to unit length.
+   This is the same pooling that `server/fields/common.ts:incidentEmbedding` performs
+   when it combines sibling report vectors.
+6. Upserts the vector into `incident_embeddings`, keyed on `incident_id`.
+
+Every incident is written the moment it completes, so an interrupted run keeps everything
+it had already finished.
+
+## Key Files
+
+| File | What it contains |
+|---|---|
+| `src/scripts/embed-incidents.ts` | Entry point and orchestration. Selects the incidents to process, fetches their reports, requests a vector for each, writes the results, and prints the progress and summary output. Also handles early stops from a signal or from repeated failures. |
+| `src/utils/embeddings/provider.ts` | HTTP client for the embedding endpoint. Builds and sends the request, validates the response shape, and retries with growing delays on transient errors. Holds every vendor-specific detail, which is what reduces a model change to a settings change. |
+| `src/utils/embeddings/incidentText.ts` | Text and vector helpers, with no network or database access. `buildIncidentText` joins a title and its report bodies into one string, `chunkText` splits text longer than the model accepts, and `poolVectors` averages chunk vectors into a single vector. |
+| `.github/workflows/embed-incidents.yml` | GitHub Action definition. Declares the dispatch inputs, installs Node and the project dependencies, runs the script with the configured secrets, and uploads the failure manifest. |
+
+## Running It Locally
+
+You need a MongoDB with incident data and an API key for the embedding endpoint. Put both
+in `site/gatsby-site/.env`:
+
+```bash
+MONGODB_CONNECTION_STRING=mongodb://127.0.0.1:4110
+EMBEDDING_API_KEY=your-key-here
+```
+
+Then, from `site/gatsby-site`:
+
+```bash
+npm run embed-incidents -- --limit 5      # small live test
+npm run embed-incidents -- --incident-id 1 --incident-id 2
+npm run embed-incidents                   # the whole corpus
+npm run embed-incidents -- --resume       # skip what is already embedded
+```
+
+There are only three options, because everything else is configuration rather than a
+choice you make per run:
+
+| Option | Effect |
+|---|---|
+| `--limit N` | Process at most the first N incidents. |
+| `--incident-id N` | Only these incidents. Repeatable. |
+| `--resume` | Skip incidents already embedded with the current model. |
+
+A full run of roughly 1,550 incidents takes about three and a half minutes at a
+concurrency of 3.
+
+## Running It From GitHub Actions
+
+The workflow is **Embed Incidents** (`.github/workflows/embed-incidents.yml`). It is
+triggered manually: open the Actions tab, select the workflow, and choose "Run workflow".
+
+| Field | Required | Notes |
+|---|---|---|
+| `environment` | Yes | Which GitHub environment to load secrets and variables from, and therefore **which database gets written to**. It must name an environment that already exists under Settings, Environments. There is no default, so that the target database is always an explicit choice. |
+| `limit` | No | Process at most this many incidents. Blank means all. |
+| `resume` | No | Tick to skip incidents already embedded with the current model. |
+
+The job checks out the repo, installs Node LTS and dependencies, and runs the script. It
+allows up to 300 minutes, because a free-tier endpoint under rate limiting can stretch a
+full run, and every incident is checkpointed so a timeout is always recoverable.
+
+Whether the run passes or fails, the job uploads `embed-failures.json` as an artifact
+named `embed-failures` if the script produced one. If a run fails, download that artifact
+to see which incidents failed and why, then re-run with `resume` ticked.
+
+If you have not run this workflow before, follow
+[Testing The Workflow](#testing-the-workflow) below, which covers the setup that a first
+run needs and how to confirm it worked.
+
+## Testing The Workflow
+
+### Before the first run
+
+1. **The workflow file must be on the default branch.** GitHub only shows a "Run workflow"
+   button for `workflow_dispatch` workflows that exist on the repository default branch,
+   which is `main` here. Once it is there you can still target any branch from the branch
+   selector, but until then the workflow does not appear in the Actions tab at all.
+2. **Create a GitHub environment** under Settings, Environments. The `environment` input
+   has no default, so it must name one that exists. Point the first one at a test database
+   rather than production.
+3. **Add `MONGODB_CONNECTION_STRING`** as a secret on that environment. The user needs the
+   `readWrite` role on `aiidprod`, because the script creates a unique index and upserts
+   documents. A read-only user is enough for some other pipelines in this repo but not for
+   this one.
+4. **Add `EMBEDDING_API_KEY`** as a secret on the same environment.
+5. **Allow the runner through your database firewall.** GitHub-hosted runners have dynamic
+   addresses, so an Atlas cluster needs `0.0.0.0/0` under Network Access or an allowlist
+   built from GitHub's published IP ranges. A run that hangs and then times out while
+   connecting is nearly always this.
+6. Everything else is optional. Every remaining setting has a working default.
+
+### The first run
+
+Run the workflow with `environment` set to your test environment, `limit` set to `5`, and
+`resume` unticked. Five incidents exercises the whole path, including chunking and the
+database write, and spends five requests.
+
+### What a healthy log looks like
+
+```
+------------------------------------------------------------------------
+base url    https://openrouter.ai/api/v1
+model       nvidia/nemotron-3-embed-1b:free
+writing to  aiidprod.incident_embeddings
+limits      max_input_chars=8000 timeout=2m00s max_attempts=6
+concurrency 2
+incidents   5
+------------------------------------------------------------------------
+[1/5] incident 1 ok chunks=10 chars=72787 dims=2048 attempts=1 1.2s
+[2/5] incident 2 ok chunks=7 chars=48196 dims=2048 attempts=1 0.9s
+...
+------------------------------------------------------------------------
+succeeded   5/5
+failed      0
+retried     0
+chunked     5 incident(s), 43 chunk(s) total
+wall time   6.1s
+latency     avg=1.1s
+------------------------------------------------------------------------
+```
+
+Three things are worth reading before anything else. The banner confirms which endpoint,
+model and collection the run actually used, so it catches a misconfigured setting straight
+away. Every incident line should report `dims=2048`, since a different number means the
+model changed. The summary should show `succeeded 5/5` with `failed 0`, and the job exits
+non-zero if anything failed.
+
+### Confirming the vectors landed
+
+Connect to the test database with mongosh or Compass and check the three things the log
+cannot prove:
+
+```js
+use aiidprod
+
+// One document per incident, so five after the first run.
+db.incident_embeddings.countDocuments()
+
+// Stored metadata should match the banner from the log.
+db.incident_embeddings.findOne({}, { vector: 0 })
+
+// Vectors are normalised, so this is 1 give or take floating point error.
+const v = db.incident_embeddings.findOne({}, { vector: 1 }).vector
+Math.sqrt(v.reduce((sum, x) => sum + x * x, 0))
+```
+
+Then run the workflow a second time with the same `limit` of 5. The count should still be
+5, because writes are upserts keyed on `incident_id`, and `generated_at` should have moved
+forward. That confirms a re-run overwrites cleanly and cannot accumulate duplicates.
+
+### When it fails
+
+Read the last few log lines first, because the script prints the reason it stopped and the
+command to resume. Download the `embed-failures` artifact from the run summary for the
+per-incident detail, then re-run with `resume` ticked once the cause is fixed.
+
+| Symptom | Cause |
+|---|---|
+| `MONGODB_CONNECTION_STRING is required` | The secret is not set on the environment you selected |
+| Hangs, then times out while connecting | The database firewall does not allow the runner |
+| `not authorized on aiidprod` | The database user lacks the `readWrite` role |
+| `EMBEDDING_API_KEY is required` | The secret is not set on the environment you selected |
+| `Rate limit exceeded: free-models-per-day` | The free tier daily ceiling, which resets at midnight UTC |
+| `base url ***` or `model ***` in the banner | That setting was stored as a secret, so GitHub masked it |
+
+### Running the whole corpus
+
+The free tier allows 50 requests per day and the corpus needs roughly 1,550, one request
+per incident. A full backfill therefore cannot finish in a single run on the free tier.
+Three ways forward: run with `resume` ticked once a day until it completes, add credits to
+raise the daily ceiling, or switch to a paid model as described in
+[Changing The Model Or Provider](#changing-the-model-or-provider). Every finished incident
+is already stored, so stopping and resuming costs nothing.
+
+## Configuration
+
+Everything is set through the environment. Locally that means `.env`; in CI it means
+secrets and variables on the GitHub environment named by the `environment` input.
+
+| Name | Type | Default | Purpose |
+|---|---|---|---|
+| `MONGODB_CONNECTION_STRING` | secret | none, required | Read and write access to the `aiidprod` database. |
+| `EMBEDDING_API_KEY` | secret | none, required | Bearer token for the embedding endpoint. |
+| `EMBEDDING_API_BASE_URL` | variable or secret | `https://openrouter.ai/api/v1` | Base URL of an OpenAI-compatible embeddings API. |
+| `EMBEDDING_MODEL` | variable or secret | `nvidia/nemotron-3-embed-1b:free` | Model identifier, passed straight through. |
+| `EMBEDDING_MAX_INPUT_CHARS` | variable or secret | `8000` | Chunk size in characters. See the note below. |
+| `EMBEDDING_CONCURRENCY` | variable or secret | `2` | Incidents embedded in parallel. This is the main pacing control against a rate-limited endpoint. |
+| `EMBEDDING_TIMEOUT_MS` | variable or secret | `120000` | Per-request timeout. |
+| `EMBEDDING_MAX_ATTEMPTS` | variable or secret | `6` | Attempts per request before giving up on an incident. |
+
+The defaults are the settings that work against the current model, so a run needs nothing
+but the two secrets.
+
+The two credentials must be secrets. The other six are read from a repository or
+environment variable first and a secret second, so either place works. Setting one as a
+secret means GitHub masks it, and the startup banner then prints `model ***` instead of the
+model name, which costs you the clearest signal that a run picked up the config you meant.
+
+`EMBEDDING_MAX_INPUT_CHARS` is worth understanding before changing it. The real limit is
+in tokens, not characters, and the ratio varies from roughly 4 characters per token for
+Latin prose to close to 1 for Chinese or Japanese. The default of 8,000 is deliberately
+conservative for a 4,096-token model. If the server rejects a request as too long anyway,
+the script reads the token counts out of the error and re-chunks that incident at a
+smaller budget, up to three times, rather than failing it.
+
+## What Gets Stored
+
+One document per incident in `aiidprod.incident_embeddings`, with a unique index on
+`incident_id`:
+
+```js
+{
+  incident_id: 1,
+  vector: [0.0143, -0.0271, ...],            // 2048 floats, unit length
+  dims: 2048,
+  model: 'nvidia/nemotron-3-embed-1b:free',
+  base_url: 'https://openrouter.ai/api/v1',
+  chunks: 10,                                 // chunks pooled into this vector
+  source_chars: 72787,                        // length of the joined text
+  generated_at: ISODate('2026-08-25T16:18:07Z')
+}
+```
+
+Writes are upserts keyed on `incident_id`, so re-running never duplicates a row. `model`
+is what `--resume` compares against, which means changing the model correctly causes a
+resumed run to re-embed everything.
+
+## Failure Handling
+
+The endpoint may be free-tier, rate limited, and slow, so the script assumes failure is
+normal:
+
+- **Retries.** 408, 425, 429, 500, 502, 503 and 504 are retried with exponential backoff
+  and jitter. A `Retry-After` header is honoured up to a 60-second ceiling. Anything else
+  fails immediately with the response body attached, because retrying a request the
+  server has rejected only wastes minutes and buries the real error.
+- **Checkpointing.** Each incident is written as soon as it succeeds. Nothing is batched
+  or held until the end.
+- **Quota exhaustion.** If the server asks for a `Retry-After` longer than the ceiling,
+  the run stops rather than sleeping. Finished work is already stored, so coming back
+  later with `--resume` is cheaper than waiting.
+- **Circuit breaker.** Ten consecutive failures stop the run, so a broken key or a dead
+  endpoint does not work through the whole corpus to rediscover the same error.
+- **Interruption.** `SIGINT` and `SIGTERM` let in-flight requests finish, then stop and
+  print the summary. A second Ctrl-C kills the process outright.
+- **Failure manifest.** Any failure is appended to `embed-failures.json` and the file is
+  rewritten immediately, so even a hard kill leaves the list behind.
+
+Recovery is always the same command, which the script prints for you:
+
+```bash
+npm run embed-incidents -- --resume
+```
+
+Anything that failed was never stored, so a resumed run retries it as a matter of course.
+
+| Exit code | Meaning |
+|---|---|
+| `0` | Every incident succeeded. |
+| `1` | At least one incident failed, or the run stopped early. |
+| `130` | Interrupted by a signal. |
+
+## Changing The Model Or Provider
+
+Set `EMBEDDING_MODEL`. If the new model lives somewhere else, set
+`EMBEDDING_API_BASE_URL` too. No code changes are needed for any endpoint that speaks the
+OpenAI embeddings shape:
+
+```
+POST {baseUrl}/embeddings  {model, input}  ->  {data: [{embedding, index}]}
+```
+
+Check `EMBEDDING_MAX_INPUT_CHARS` against the new model's token limit, and expect the
+next run to re-embed the whole corpus, since `--resume` keys on the model name. Vectors
+of different dimensions are stored side by side without complaint, so compare only
+vectors that share a `model` value.

--- a/site/gatsby-site/src/utils/embeddings/README.md
+++ b/site/gatsby-site/src/utils/embeddings/README.md
@@ -38,9 +38,9 @@ it had already finished.
 
 | File | What it contains |
 |---|---|
-| `src/scripts/embed-incidents.ts` | Entry point and orchestration. Selects the incidents to process, fetches their reports, requests a vector for each, writes the results, and prints the progress and summary output. Also handles early stops from a signal or from repeated failures. |
-| `src/utils/embeddings/provider.ts` | HTTP client for the embedding endpoint. Builds and sends the request, validates the response shape, and retries with growing delays on transient errors. Holds every vendor-specific detail, which is what reduces a model change to a settings change. |
-| `src/utils/embeddings/incidentText.ts` | Text and vector helpers, with no network or database access. `buildIncidentText` joins a title and its report bodies into one string, `chunkText` splits text longer than the model accepts, and `poolVectors` averages chunk vectors into a single vector. |
+| `src/scripts/embed-incidents.ts` | Serves as the entry point and orchestration. Selects the incidents to process, fetches their reports, requests a vector for each, writes the results, and prints the progress and summary output. Also handles early stops from a signal or from repeated failures. |
+| `src/utils/embeddings/provider.ts` | HTTP client for the embedding endpoint. Builds and sends the request, validates the response shape, and retries with growing delays on transient errors. Holds every vendor-specific detail. |
+| `src/utils/embeddings/incidentText.ts` | Text and vector helpers. `buildIncidentText` joins a title and its report bodies into one string, `chunkText` splits text longer than the model accepts, and `poolVectors` averages chunk vectors into a single vector. |
 | `.github/workflows/embed-incidents.yml` | GitHub Action definition. Declares the dispatch inputs, installs Node and the project dependencies, runs the script with the configured secrets, and uploads the failure manifest. |
 
 ## Running It Locally
@@ -192,15 +192,6 @@ per-incident detail, then re-run with `resume` ticked once the cause is fixed.
 | `EMBEDDING_API_KEY is required` | The secret is not set on the environment you selected |
 | `Rate limit exceeded: free-models-per-day` | The free tier daily ceiling, which resets at midnight UTC |
 | `base url ***` or `model ***` in the banner | That setting was stored as a secret, so GitHub masked it |
-
-### Running the whole corpus
-
-The free tier allows 50 requests per day and the corpus needs roughly 1,550, one request
-per incident. A full backfill therefore cannot finish in a single run on the free tier.
-Three ways forward: run with `resume` ticked once a day until it completes, add credits to
-raise the daily ceiling, or switch to a paid model as described in
-[Changing The Model Or Provider](#changing-the-model-or-provider). Every finished incident
-is already stored, so stopping and resuming costs nothing.
 
 ## Configuration
 

--- a/site/gatsby-site/src/utils/embeddings/incidentText.ts
+++ b/site/gatsby-site/src/utils/embeddings/incidentText.ts
@@ -1,0 +1,135 @@
+/**
+ * Builds the text that represents an incident, and pools chunk vectors back into one.
+ *
+ * An incident stores only a title, and the article text lives on its reports. Those are
+ * reached through the `incidents.reports` array of report_number join keys.
+ */
+
+/**
+ * The incident fields
+ */
+export type IncidentTextSource = {
+  title?: string | null;
+  [key: string]: unknown;
+};
+
+/**
+ * The report fields
+ */
+export type ReportTextSource = {
+  report_number?: number | null;
+  plain_text?: string | null;
+  text?: string | null;
+  [key: string]: unknown;
+};
+
+/**
+ * Joins the incident title and every report body into the single string that gets embedded.
+ * Reports are sorted by report_number first, so the same incident always produces identical
+ * text and therefore an identical vector. Empty titles and empty bodies are dropped.
+ */
+export const buildIncidentText = (
+  incident: IncidentTextSource,
+  reports: readonly ReportTextSource[]
+): string => {
+  const title = (incident.title || '').trim();
+
+  // Sorting by report_number keeps the text identical across runs so the vector is stable.
+  const bodies = [...reports]
+    .sort((a, b) => (a.report_number ?? 0) - (b.report_number ?? 0))
+    .map((report) => (report.plain_text || report.text || '').trim())
+    .filter((body) => body.length > 0);
+
+  return [title, ...bodies].filter((part) => part.length > 0).join('\n\n');
+};
+
+/**
+ * Splits text into chunks of at most `maxChars`, preferring paragraph boundaries.
+ *
+ * Returns the text untouched in a single-element array when it already fits. At the
+ * default 8,000-char budget that covers about 44% of the corpus.
+ */
+export const chunkText = (text: string, maxChars: number): string[] => {
+  if (maxChars <= 0) throw new Error('maxChars must be greater than zero');
+
+  if (text.length <= maxChars) return text.length > 0 ? [text] : [];
+
+  const chunks: string[] = [];
+  let current = '';
+
+  // Moves the buffered paragraphs into a finished chunk and starts a new buffer.
+  const flush = () => {
+    if (current.length > 0) {
+      chunks.push(current);
+      current = '';
+    }
+  };
+
+  for (const paragraph of text.split(/\n{2,}/)) {
+    // A single paragraph longer than the budget has to be hard-split.
+    if (paragraph.length > maxChars) {
+      flush();
+
+      for (let i = 0; i < paragraph.length; i += maxChars) {
+        chunks.push(paragraph.slice(i, i + maxChars));
+      }
+
+      continue;
+    }
+
+    // A new chunk starts when adding this paragraph would push the buffer over the budget.
+    const candidate = current.length === 0 ? paragraph : `${current}\n\n${paragraph}`;
+
+    if (candidate.length > maxChars) {
+      flush();
+      current = paragraph;
+    } else {
+      current = candidate;
+    }
+  }
+
+  flush();
+
+  return chunks;
+};
+
+/**
+ * Component-wise mean of the chunk vectors, then L2-normalised.
+ */
+export const poolVectors = (vectors: number[][]): number[] => {
+  if (vectors.length === 0) throw new Error('cannot pool an empty set of vectors');
+
+  const dims = vectors[0].length;
+
+  if (vectors.some((vector) => vector.length !== dims)) {
+    throw new Error('cannot pool vectors of differing dimensions');
+  }
+
+  if (vectors.length === 1) return normalise(vectors[0]);
+
+  const mean = new Array(dims).fill(0);
+
+  for (const vector of vectors) {
+    for (let i = 0; i < dims; i++) {
+      mean[i] += vector[i];
+    }
+  }
+
+  for (let i = 0; i < dims; i++) {
+    mean[i] /= vectors.length;
+  }
+
+  return normalise(mean);
+};
+
+/**
+ * Scales a vector to unit length. Cosine similarity between unit vectors reduces to a dot
+ * product, so normalising here keeps later comparisons cheap and keeps incidents comparable
+ * even when they needed different numbers of chunks.
+ */
+const normalise = (vector: number[]): number[] => {
+  const magnitude = Math.sqrt(vector.reduce((sum, component) => sum + component * component, 0));
+
+  // A zero vector has no direction to preserve, so return it unchanged.
+  return magnitude === 0 ? [...vector] : vector.map((component) => component / magnitude);
+};

--- a/site/gatsby-site/src/utils/embeddings/provider.ts
+++ b/site/gatsby-site/src/utils/embeddings/provider.ts
@@ -1,0 +1,259 @@
+/**
+ * Embedding provider for any OpenAI-compatible endpoint.
+ *
+ * OpenRouter, OpenAI and most other vendors expose the same shape:
+ * POST {baseUrl}/embeddings {model, input} returns {data: [{embedding, index}]}.
+ * Pointing EMBEDDING_API_BASE_URL and EMBEDDING_MODEL elsewhere is the whole vendor swap.
+ */
+
+/**
+ * What a successful embedding call returns. The vectors come back in the same order as the
+ * texts that were sent. The attempt count and latency are recorded so the runner can report
+ * how much retrying a run needed.
+ */
+export interface EmbedResult {
+  vectors: number[][];
+  /** Total attempts spent on this call, including the successful one. */
+  attempts: number;
+  /** Wall time of the successful request in milliseconds. */
+  latencyMs: number;
+}
+
+/**
+ * A configured embedding endpoint that the runner can call. The model and base URL are
+ * exposed so they can be logged and stored alongside every vector. The timeout and attempt
+ * limit are exposed so the startup banner can report them.
+ */
+export interface EmbeddingProvider {
+  model: string;
+  baseUrl: string;
+  timeoutMs: number;
+  maxAttempts: number;
+  embed: (texts: string[]) => Promise<EmbedResult>;
+}
+
+/**
+ * An embedding request that failed in a way the caller needs details about. It carries the
+ * HTTP status, the response body, and how many attempts were spent, so a failure can be
+ * recorded in the manifest without re-parsing the message.
+ */
+export class EmbeddingRequestError extends Error {
+  status: number | null;
+
+  attempts: number;
+
+  body: string;
+
+  /** True when the server asked for a wait longer than the run will honour. */
+  quotaExhausted: boolean;
+
+  constructor(
+    message: string,
+    {
+      status,
+      attempts,
+      body,
+      quotaExhausted = false,
+    }: { status: number | null; attempts: number; body: string; quotaExhausted?: boolean }
+  ) {
+    super(message);
+    this.name = 'EmbeddingRequestError';
+    this.status = status;
+    this.attempts = attempts;
+    this.body = body;
+    this.quotaExhausted = quotaExhausted;
+  }
+}
+
+// Statuses that can succeed on a later attempt, so any other status fails immediately.
+const RETRYABLE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+const BASE_BACKOFF_MS = 2000;
+const MAX_BACKOFF_MS = 60_000;
+
+// The longest Retry-After the run will honour before it gives up and stops.
+const MAX_RETRY_AFTER_MS = MAX_BACKOFF_MS;
+
+// Reads a positive number from an environment value, falling back when it is unset or invalid.
+const number = (value: string | undefined, fallback: number): number => {
+  const parsed = Number(value);
+
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+// Pauses for the given number of milliseconds.
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Formats milliseconds as whole seconds for log messages.
+const seconds = (ms: number) => `${Math.round(ms / 1000)}s`;
+
+/**
+ * How long to wait before the next attempt, doubling with each one up to a ceiling. The
+ * result carries plus or minus twenty percent of jitter, which stops concurrent workers
+ * retrying at the same moment and re-triggering the same rate limit together.
+ */
+const backoffDelay = (attempt: number): number => {
+  const base = Math.min(BASE_BACKOFF_MS * Math.pow(2, attempt - 1), MAX_BACKOFF_MS);
+
+  return Math.round(base * (0.8 + Math.random() * 0.4));
+};
+
+/**
+ * Parses a Retry-After header in either delta-seconds or HTTP-date form. Returns the wait
+ * in milliseconds, or null when the header is absent or unparseable. A date already in the
+ * past clamps to zero.
+ */
+const parseRetryAfter = (value: string | null): number | null => {
+  // An explicit check because "0" is falsy in JavaScript and legally means retry now.
+  if (value === null || value.trim() === '') return null;
+
+  const deltaSeconds = Number(value);
+
+  if (Number.isFinite(deltaSeconds)) return Math.max(0, deltaSeconds * 1000);
+
+  const date = Date.parse(value);
+
+  if (Number.isNaN(date)) return null;
+
+  return Math.max(0, date - Date.now());
+};
+
+/**
+ * Builds a provider from the EMBEDDING_* environment variables. Every setting except the
+ * API key has a default that works against the configured model, so a caller normally only
+ * needs to supply EMBEDDING_API_KEY. Throws immediately when that key is missing.
+ */
+export const createEmbeddingProvider = (): EmbeddingProvider => {
+  // Trailing slashes are stripped so joining "/embeddings" below cannot double up.
+  const baseUrl = (process.env.EMBEDDING_API_BASE_URL || 'https://openrouter.ai/api/v1').replace(
+    /\/+$/,
+    ''
+  );
+
+  const model = process.env.EMBEDDING_MODEL || 'nvidia/nemotron-3-embed-1b:free';
+  const apiKey = process.env.EMBEDDING_API_KEY;
+
+  if (!apiKey) {
+    throw new Error('EMBEDDING_API_KEY is required.');
+  }
+
+  const timeoutMs = number(process.env.EMBEDDING_TIMEOUT_MS, 120_000);
+  const maxAttempts = number(process.env.EMBEDDING_MAX_ATTEMPTS, 6);
+
+  /**
+   * Sends all texts in one request and returns one vector per text. Retryable failures are
+   * attempted again with exponential backoff until maxAttempts is reached, while a status
+   * the server will keep rejecting fails straight away. Throws EmbeddingRequestError when
+   * no attempt succeeds.
+   */
+  const embed = async (texts: string[]): Promise<EmbedResult> => {
+    // Carried across attempts so the final error can report what actually went wrong.
+    let lastStatus: number | null = null;
+    let lastBody = '';
+    let lastMessage = 'unknown error';
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      // An AbortController paired with a timer is how fetch gets a per-request timeout.
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      const startedAt = Date.now();
+
+      try {
+        const response = await fetch(`${baseUrl}/embeddings`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ model, input: texts }),
+          signal: controller.signal,
+        });
+
+        const latencyMs = Date.now() - startedAt;
+
+        if (response.ok) {
+          const json: any = await response.json();
+          const data = json?.data;
+
+          if (!Array.isArray(data) || data.length !== texts.length) {
+            throw new Error(
+              `unexpected response: expected ${texts.length} embeddings, got ${
+                Array.isArray(data) ? data.length : typeof data
+              }`
+            );
+          }
+
+          // Each item carries its own index, so sort by it before mapping to vectors.
+          const vectors = [...data]
+            .sort((a, b) => (a.index ?? 0) - (b.index ?? 0))
+            .map((entry) => entry.embedding as number[]);
+
+          if (vectors.some((vector) => !Array.isArray(vector) || vector.length === 0)) {
+            throw new Error('unexpected response: an embedding was empty or not an array');
+          }
+
+          return { vectors, attempts: attempt, latencyMs };
+        }
+
+        lastStatus = response.status;
+        lastBody = (await response.text().catch(() => '')).slice(0, 500);
+        lastMessage = `HTTP ${response.status}`;
+
+        if (!RETRYABLE_STATUSES.has(response.status)) {
+          throw new EmbeddingRequestError(`non-retryable ${lastMessage}: ${lastBody}`, {
+            status: lastStatus,
+            attempts: attempt,
+            body: lastBody,
+          });
+        }
+
+        const retryAfter = parseRetryAfter(response.headers.get('retry-after'));
+
+        if (retryAfter !== null && retryAfter > MAX_RETRY_AFTER_MS) {
+          throw new EmbeddingRequestError(
+            `quota exhausted: server asked for Retry-After ${seconds(retryAfter)}, ` +
+              `above the ${seconds(MAX_RETRY_AFTER_MS)} ceiling`,
+            { status: lastStatus, attempts: attempt, body: lastBody, quotaExhausted: true }
+          );
+        }
+
+        if (attempt < maxAttempts) {
+          const waitMs = retryAfter ?? backoffDelay(attempt);
+
+          console.warn(
+            `attempt ${attempt}/${maxAttempts} status=${response.status}` +
+              `${retryAfter === null ? '' : ` retry_after=${seconds(retryAfter)}`}` +
+              ` waiting ${seconds(waitMs)}`
+          );
+
+          await sleep(waitMs);
+        }
+      } catch (e: any) {
+        if (e instanceof EmbeddingRequestError) throw e;
+
+        const aborted = e?.name === 'AbortError';
+
+        lastMessage = aborted ? `timeout after ${seconds(timeoutMs)}` : e?.message || String(e);
+
+        if (attempt < maxAttempts) {
+          const waitMs = backoffDelay(attempt);
+
+          console.warn(
+            `attempt ${attempt}/${maxAttempts} ${lastMessage} waiting ${seconds(waitMs)}`
+          );
+
+          await sleep(waitMs);
+        }
+      } finally {
+        clearTimeout(timer);
+      }
+    }
+
+    // Reached only when every attempt failed without throwing a non-retryable error.
+    throw new EmbeddingRequestError(
+      `gave up after ${maxAttempts} attempts: ${lastMessage}${lastBody ? `: ${lastBody}` : ''}`,
+      { status: lastStatus, attempts: maxAttempts, body: lastBody }
+    );
+  };
+
+  return { model, baseUrl, timeoutMs, maxAttempts, embed };
+};


### PR DESCRIPTION
Adds a batch pipeline that turns every incident into a single vector and stores it in a new `incident_embeddings` collection. It joins each incident's title with the text of its reports, sends that to any OpenAI-compatible embeddings endpoint, and writes one document per incident.

## Running it from GitHub Actions

The workflow is **Embed Incidents** (`.github/workflows/embed-incidents.yml`). It is triggered manually: open the Actions tab, select the workflow, and choose "Run workflow".

| Field | Required | Notes |
|---|---|---|
| `environment` | Yes | Which GitHub environment to load secrets from, and therefore which database gets written to. It must name an environment that already exists. There is no default, so the target is always an explicit choice. |
| `limit` | No | Process at most this many incidents. Blank means all. |
| `resume` | No | Tick to skip incidents already embedded with the current model. |


Whether the run passes or fails, the job uploads `embed-failures.json` as an artifact named `embed-failures` if the script produced one. To recover from a partial run, fix the cause and re-run with `resume` ticked. Every finished incident is already stored, so resuming picks up where it stopped.

## Required secrets

Set these on the GitHub environment named by the `environment` input.

| Name | Type | Notes |
|---|---|---|
| `MONGODB_CONNECTION_STRING` | secret | Needs the `readWrite` role on `aiidprod`. The script creates a unique index and upserts documents, so a read-only user will fail partway through. |
| `EMBEDDING_API_KEY` | secret | Bearer token for the embeddings endpoint. |

Nothing else is required. Six further settings are available as either a repository variable or a secret, and every one has a default that works against the configured model:

`EMBEDDING_MODEL`, `EMBEDDING_API_BASE_URL`, `EMBEDDING_MAX_INPUT_CHARS`, `EMBEDDING_CONCURRENCY`, `EMBEDDING_TIMEOUT_MS`, `EMBEDDING_MAX_ATTEMPTS`.

Switching model or vendor is a change to `EMBEDDING_MODEL` and `EMBEDDING_API_BASE_URL`, with no code change, because `provider.ts` holds every vendor-specific detail.


## What it writes

One document per incident in `aiidprod.incident_embeddings`, with a unique index on `incident_id`:

```js
{
  incident_id: 1,
  vector: [ ...2048 floats, unit length... ],
  dims: 2048,
  model: 'nvidia/nemotron-3-embed-1b:free',
  base_url: 'https://openrouter.ai/api/v1',
  chunks: 10,
  source_chars: 72787,
  generated_at: ISODate('2026-08-28T18:17:55Z')
}
```

`incidents` and `reports` are only ever read. Writes are upserts keyed on `incident_id`, so a re-run overwrites the row it wrote last time.

## Testing Performed

Run against a live MongoDB from GitHub Actions with `limit` set to 5:

(https://github.com/jayparmar16/aiid/actions/runs/33198361172)

The run created `incident_embeddings`, which did not exist beforehand, and wrote 5 documents. Verified afterwards against the database:

- 5 documents, one per incident, with the unique index on `incident_id` present
- Every vector 2048 long and unit length
- `model` and `base_url` matching what the run logged
- Cosine similarity between two unrelated incidents at 0.23, confirming the vectors carry real signal